### PR TITLE
Refactor: Unify kernel API with direct functions

### DIFF
--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -29,7 +29,8 @@ from ._pallas_random import LFSR88RNG, LFSR113RNG, LFSR128RNG
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
 from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import defjvp, general_batching_rule
-from ._xla_custom_op_warp import warp_kernel, dtype_to_warp_type, jaxinfo_to_warpinfo
+from ._xla_custom_op_warp import warp_kernel, jaxtype_to_warptype, jaxinfo_to_warpinfo
+from ._xla_custom_op_pallas import pallas_kernel
 
 __all__ = [
     # --- global configuration --- #
@@ -71,10 +72,12 @@ __all__ = [
     'numba_kernel',
 
     # 4. Warp kernel
-    'dtype_to_warp_type',
     'warp_kernel',
+    'jaxtype_to_warptype',
+    'jaxinfo_to_warpinfo',
 
     # 5. Pallas kernel
+    'pallas_kernel',
     'LFSR88RNG',
     'LFSR113RNG',
     'LFSR128RNG',

--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -28,10 +28,9 @@ from ._jitc_normal import JITCNormalR, JITCNormalC
 from ._jitc_uniform import JITCUniformR, JITCUniformC
 from ._pallas_random import LFSR88RNG, LFSR113RNG, LFSR128RNG
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import defjvp, general_batching_rule
-from ._xla_custom_op_warp import WarpKernelGenerator, dtype_to_warp_type, warp_kernel
+from ._xla_custom_op_warp import warp_kernel, dtype_to_warp_type, jaxinfo_to_warpinfo
 
 __all__ = [
     # --- global configuration --- #
@@ -70,18 +69,16 @@ __all__ = [
     'general_batching_rule',
 
     # 3. Numba kernel
-    'NumbaKernelGenerator',
     'set_numba_environ',
     'numba_environ_context',
     'numba_kernel',
 
     # 4. Warp kernel
-    'WarpKernelGenerator',
-    'dtype_to_warp_type',
     'warp_kernel',
+    'dtype_to_warp_type',
+    'jaxinfo_to_warpinfo',
 
     # 5. Pallas kernel
-    'PallasKernelGenerator',
     'LFSR88RNG',
     'LFSR113RNG',
     'LFSR128RNG',

--- a/brainevent/_coo_event_impl.py
+++ b/brainevent/_coo_event_impl.py
@@ -603,7 +603,7 @@ def event_coomv_p_call(
 
 event_coomv_p = XLACustomKernel('event_coomv')
 event_coomv_p.def_cpu_kernel(_event_coomv_numba_kernel_generator)
-event_coomv_p.def_gpu_kernel(_event_coomv_warp_kernel_generator)
+event_coomv_p.def_gpu_kernel(warp=_event_coomv_warp_kernel_generator)
 event_coomv_p.def_jvp_rule2(_event_coomv_jvp_weights, None, None, _event_coomv_jvp_vector)
 event_coomv_p.def_transpose_rule(_event_coomv_transpose_rule)
 event_coomv_p.def_batching_rule(_event_coomv_batching)
@@ -1132,7 +1132,7 @@ def event_coomm_p_call(
 
 event_coomm_p = XLACustomKernel('event_coomm')
 event_coomm_p.def_cpu_kernel(_event_coomm_numba_kernel_generator)
-event_coomm_p.def_gpu_kernel(_event_coomm_warp_kernel_generator)
+event_coomm_p.def_gpu_kernel(warp=_event_coomm_warp_kernel_generator)
 event_coomm_p.def_jvp_rule2(_event_coomm_jvp_left, None, None, _event_coomm_jvp_right)
 event_coomm_p.def_transpose_rule(_event_coomm_transpose_rule)
 event_coomm_p.def_batching_rule(_event_coomm_batching)

--- a/brainevent/_coo_event_impl.py
+++ b/brainevent/_coo_event_impl.py
@@ -26,9 +26,9 @@ from jax.interpreters import ad
 from ._coo_float_impl import coo_matvec, coo_matmat
 from ._typing import Data, Row, Col, MatrixShape
 from ._xla_custom_op import XLACustomKernel
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
+from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 
 def event_coo_matvec(
@@ -204,10 +204,10 @@ def _event_coomv_warp_kernel_generator(
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    row_dtype = dtype_to_warp_type(row_info.dtype)
-    col_dtype = dtype_to_warp_type(col_info.dtype)
-    spike_dtype = dtype_to_warp_type(vector_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    row_dtype = jaxtype_to_warptype(row_info.dtype)
+    col_dtype = jaxtype_to_warptype(col_info.dtype)
+    spike_dtype = jaxtype_to_warptype(vector_info.dtype)
 
     match (transpose, weight_info.size, vector_info.dtype, float_as_event):
 
@@ -602,8 +602,8 @@ def event_coomv_p_call(
 
 
 event_coomv_p = XLACustomKernel('event_coomv')
-event_coomv_p.def_cpu_kernel(NumbaKernelGenerator(_event_coomv_numba_kernel_generator))
-event_coomv_p.def_gpu_kernel(WarpKernelGenerator(_event_coomv_warp_kernel_generator))
+event_coomv_p.def_cpu_kernel(_event_coomv_numba_kernel_generator)
+event_coomv_p.def_gpu_kernel(_event_coomv_warp_kernel_generator)
 event_coomv_p.def_jvp_rule2(_event_coomv_jvp_weights, None, None, _event_coomv_jvp_vector)
 event_coomv_p.def_transpose_rule(_event_coomv_transpose_rule)
 event_coomv_p.def_batching_rule(_event_coomv_batching)
@@ -743,10 +743,10 @@ def _event_coomm_warp_kernel_generator(
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    row_dtype = dtype_to_warp_type(row_info.dtype)
-    col_dtype = dtype_to_warp_type(col_info.dtype)
-    spike_dtype = dtype_to_warp_type(matrix_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    row_dtype = jaxtype_to_warptype(row_info.dtype)
+    col_dtype = jaxtype_to_warptype(col_info.dtype)
+    spike_dtype = jaxtype_to_warptype(matrix_info.dtype)
 
     match (transpose, weight_info.size, matrix_info.dtype, float_as_event):
 
@@ -1131,8 +1131,8 @@ def event_coomm_p_call(
 
 
 event_coomm_p = XLACustomKernel('event_coomm')
-event_coomm_p.def_cpu_kernel(NumbaKernelGenerator(_event_coomm_numba_kernel_generator))
-event_coomm_p.def_gpu_kernel(WarpKernelGenerator(_event_coomm_warp_kernel_generator))
+event_coomm_p.def_cpu_kernel(_event_coomm_numba_kernel_generator)
+event_coomm_p.def_gpu_kernel(_event_coomm_warp_kernel_generator)
 event_coomm_p.def_jvp_rule2(_event_coomm_jvp_left, None, None, _event_coomm_jvp_right)
 event_coomm_p.def_transpose_rule(_event_coomm_transpose_rule)
 event_coomm_p.def_batching_rule(_event_coomm_batching)

--- a/brainevent/_coo_float_impl.py
+++ b/brainevent/_coo_float_impl.py
@@ -349,7 +349,7 @@ def coomv_p_call(
 
 coomv_p = XLACustomKernel('coomv')
 coomv_p.def_cpu_kernel(_coomv_numba_kernel_generator)
-coomv_p.def_gpu_kernel(_coomv_warp_kernel_generator)
+coomv_p.def_gpu_kernel(warp=_coomv_warp_kernel_generator)
 coomv_p.def_jvp_rule2(_coomv_jvp_weights, None, None, _coomv_jvp_vector)
 coomv_p.def_transpose_rule(_coomv_transpose_rule)
 coomv_p.def_batching_rule(_coomv_batching)
@@ -627,7 +627,7 @@ def coomm_p_call(
 
 coomm_p = XLACustomKernel('coomm')
 coomm_p.def_cpu_kernel(_coomm_numba_kernel_generator)
-coomm_p.def_gpu_kernel(_coomm_warp_kernel_generator)
+coomm_p.def_gpu_kernel(warp=_coomm_warp_kernel_generator)
 coomm_p.def_jvp_rule2(_coomm_jvp_left, None, None, _coomm_jvp_right)
 coomm_p.def_transpose_rule(_coomm_transpose_rule)
 coomm_p.def_batching_rule(coomm_batching)

--- a/brainevent/_coo_float_impl.py
+++ b/brainevent/_coo_float_impl.py
@@ -24,9 +24,9 @@ from jax.interpreters import ad
 
 from ._typing import Data, Row, Col, MatrixShape
 from ._xla_custom_op import XLACustomKernel
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
+from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "coo_matvec",
@@ -115,10 +115,10 @@ def _coomv_warp_kernel_generator(
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    row_dtype = dtype_to_warp_type(row_info.dtype)
-    col_dtype = dtype_to_warp_type(col_info.dtype)
-    vector_dtype = dtype_to_warp_type(vector_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    row_dtype = jaxtype_to_warptype(row_info.dtype)
+    col_dtype = jaxtype_to_warptype(col_info.dtype)
+    vector_dtype = jaxtype_to_warptype(vector_info.dtype)
 
     match (transpose, weight_info.size):
         # transpose=True, homogeneous
@@ -348,8 +348,8 @@ def coomv_p_call(
 
 
 coomv_p = XLACustomKernel('coomv')
-coomv_p.def_cpu_kernel(NumbaKernelGenerator(_coomv_numba_kernel_generator))
-coomv_p.def_gpu_kernel(WarpKernelGenerator(_coomv_warp_kernel_generator))
+coomv_p.def_cpu_kernel(_coomv_numba_kernel_generator)
+coomv_p.def_gpu_kernel(_coomv_warp_kernel_generator)
 coomv_p.def_jvp_rule2(_coomv_jvp_weights, None, None, _coomv_jvp_vector)
 coomv_p.def_transpose_rule(_coomv_transpose_rule)
 coomv_p.def_batching_rule(_coomv_batching)
@@ -406,10 +406,10 @@ def _coomm_warp_kernel_generator(
 ):
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    matrix_dtype = dtype_to_warp_type(matrix_info.dtype)
-    row_dtype = dtype_to_warp_type(row_info.dtype)
-    col_dtype = dtype_to_warp_type(col_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    matrix_dtype = jaxtype_to_warptype(matrix_info.dtype)
+    row_dtype = jaxtype_to_warptype(row_info.dtype)
+    col_dtype = jaxtype_to_warptype(col_info.dtype)
 
     match (transpose, weight_info.size):
         # transpose=True, weight.size==1
@@ -626,8 +626,8 @@ def coomm_p_call(
 
 
 coomm_p = XLACustomKernel('coomm')
-coomm_p.def_cpu_kernel(NumbaKernelGenerator(_coomm_numba_kernel_generator))
-coomm_p.def_gpu_kernel(WarpKernelGenerator(_coomm_warp_kernel_generator))
+coomm_p.def_cpu_kernel(_coomm_numba_kernel_generator)
+coomm_p.def_gpu_kernel(_coomm_warp_kernel_generator)
 coomm_p.def_jvp_rule2(_coomm_jvp_left, None, None, _coomm_jvp_right)
 coomm_p.def_transpose_rule(_coomm_transpose_rule)
 coomm_p.def_batching_rule(coomm_batching)

--- a/brainevent/_csr_event_impl.py
+++ b/brainevent/_csr_event_impl.py
@@ -851,11 +851,9 @@ def event_csrmv_p_call(
 event_csrmv_p = XLACustomKernel('event_csrmv')
 event_csrmv_p.def_cpu_kernel(_event_csrmv_numba_kernel_generator)
 event_csrmv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        warp_kernel=_event_csrmv_warp_kernel_generator,
-        pallas_kernel=_event_csrmv_pallas_tiled_kernel_generator,
-    )
+    default='pallas',
+    warp=_event_csrmv_warp_kernel_generator,
+    pallas=_event_csrmv_pallas_tiled_kernel_generator,
 )
 event_csrmv_p.def_tpu_kernel(_event_csrmv_pallas_tiled_kernel_generator)
 event_csrmv_p.def_jvp_rule2(_event_csrmv_jvp_weights, None, None, _event_csrmv_jvp_v)
@@ -1676,11 +1674,9 @@ def event_csrmm_p_call(
 event_csrmm_p = XLACustomKernel('event_csrmm')
 event_csrmm_p.def_cpu_kernel(_event_csrmm_numba_kernel_generator)
 event_csrmm_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        warp_kernel=_event_csrmm_warp_kernel_generator,
-        pallas_kernel=_event_csrmm_pallas_kernel_generator,
-    )
+    default='pallas',
+    warp=_event_csrmm_warp_kernel_generator,
+    pallas=_event_csrmm_pallas_kernel_generator,
 )
 event_csrmm_p.def_tpu_kernel(_event_csrmm_pallas_kernel_generator)
 event_csrmm_p.def_jvp_rule2(_csrmm_jvp_data, None, None, _csrmm_jvp_B)

--- a/brainevent/_csr_float_impl.py
+++ b/brainevent/_csr_float_impl.py
@@ -576,11 +576,9 @@ def csrmv_p_call(
 csrmv_p = XLACustomKernel('csrmv')
 csrmv_p.def_cpu_kernel(_csrmv_numba_kernel_generator)
 csrmv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        warp_kernel=_csrmv_warp_kernel_generator,
-        pallas_kernel=_csrmv_pallas_tiled_kernel_generator,
-    )
+    default='pallas',
+    warp=_csrmv_warp_kernel_generator,
+    pallas=_csrmv_pallas_tiled_kernel_generator,
 )
 csrmv_p.def_tpu_kernel(_csrmv_pallas_tiled_kernel_generator)
 csrmv_p.def_jvp_rule2(_csrmv_jvp_weights, None, None, _csrmv_jvp_v)
@@ -1269,11 +1267,9 @@ def csrmm_p_call(
 csrmm_p = XLACustomKernel('csrmm')
 csrmm_p.def_cpu_kernel(_csrmm_numba_kernel_generator)
 csrmm_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_csrmm_warp_kernel_generator,
-        pallas_kernel=_csrmm_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_csrmm_warp_kernel_generator,
+    pallas=_csrmm_pallas_kernel_generator,
 )
 csrmm_p.def_tpu_kernel(_csrmm_pallas_kernel_generator)
 csrmm_p.def_jvp_rule2(_csrmm_jvp_data, None, None, _csrmm_jvp_B)

--- a/brainevent/_event.py
+++ b/brainevent/_event.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 import operator
-from typing import Union, Optional, Sequence, Any
+from typing import Union, Optional, Sequence
 
 import brainunit as u
 import jax

--- a/brainevent/_event_matrix_impl.py
+++ b/brainevent/_event_matrix_impl.py
@@ -305,12 +305,7 @@ def matrix_event_mm_p_call(weights, spikes, *, float_as_event: bool):
 
 matrix_event_mm_p = XLACustomKernel('matrix_event_mm')
 matrix_event_mm_p.def_cpu_kernel(_matrix_event_mm_cpu_kernel_generator)
-matrix_event_mm_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_matrix_event_mm_gpu_kernel_generator,
-    )
-)
+matrix_event_mm_p.def_gpu_kernel(warp=_matrix_event_mm_gpu_kernel_generator)
 matrix_event_mm_p.def_jvp_rule2(_matrix_event_mm_jvp_weights, _matrix_event_mm_jvp_spikes)
 matrix_event_mm_p.def_transpose_rule(_matrix_event_mm_transpose_rule)
 matrix_event_mm_p.def_batching_rule(_matrix_event_mm_batching)
@@ -539,12 +534,7 @@ def event_matrix_mm_p_call(spikes, weights, *, float_as_event: bool):
 
 event_matrix_mm_p = XLACustomKernel('event_matrix_mm', )
 event_matrix_mm_p.def_cpu_kernel(_event_matrix_mm_cpu_kernel_generator)
-event_matrix_mm_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_event_matrix_mm_gpu_kernel_generator,
-    )
-)
+event_matrix_mm_p.def_gpu_kernel(warp=_event_matrix_mm_gpu_kernel_generator)
 event_matrix_mm_p.def_jvp_rule2(_event_matrix_mm_jvp_spikes, _event_matrix_mm_jvp_weights, )
 event_matrix_mm_p.def_transpose_rule(_event_matrix_mm_transpose_rule)
 event_matrix_mm_p.def_batching_rule(_event_matrix_mm_batching)

--- a/brainevent/_event_matrix_impl.py
+++ b/brainevent/_event_matrix_impl.py
@@ -23,9 +23,9 @@ from jax.interpreters import ad
 
 from ._misc import cdiv
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
+from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import WarpKernelGenerator, dtype_to_warp_type, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 TILE_THREAD = 256
 
@@ -172,6 +172,7 @@ def _matrix_event_mm_gpu_kernel_generator(
     TILE_N: int,
     TILE_K: int,
     TILE_M: int,
+    TILE_SIZE: int,
     block_dim: int,
     **kwargs
 ):
@@ -179,8 +180,8 @@ def _matrix_event_mm_gpu_kernel_generator(
 
     import warp  # pylint: disable=import-outside-toplevel
 
-    spike_dtype = dtype_to_warp_type(spk_info.dtype)
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
+    spike_dtype = jaxtype_to_warptype(spk_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
 
     if spk_info.dtype == jnp.bool_:
         def kernel(
@@ -303,11 +304,11 @@ def matrix_event_mm_p_call(weights, spikes, *, float_as_event: bool):
 
 
 matrix_event_mm_p = XLACustomKernel('matrix_event_mm')
-matrix_event_mm_p.def_cpu_kernel(NumbaKernelGenerator(_matrix_event_mm_cpu_kernel_generator))
+matrix_event_mm_p.def_cpu_kernel(_matrix_event_mm_cpu_kernel_generator)
 matrix_event_mm_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_matrix_event_mm_gpu_kernel_generator)
+        warp_kernel=_matrix_event_mm_gpu_kernel_generator,
     )
 )
 matrix_event_mm_p.def_jvp_rule2(_matrix_event_mm_jvp_weights, _matrix_event_mm_jvp_spikes)
@@ -436,13 +437,14 @@ def _event_matrix_mm_gpu_kernel_generator(
     TILE_N: int,
     TILE_K: int,
     TILE_M: int,
+    TILE_SIZE: int,
     block_dim: int,
     **kwargs
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    spike_dtype = dtype_to_warp_type(spk_info.dtype)
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
+    spike_dtype = jaxtype_to_warptype(spk_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
 
     if spk_info.dtype == jnp.bool_:
         def kernel(
@@ -536,11 +538,11 @@ def event_matrix_mm_p_call(spikes, weights, *, float_as_event: bool):
 
 
 event_matrix_mm_p = XLACustomKernel('event_matrix_mm', )
-event_matrix_mm_p.def_cpu_kernel(NumbaKernelGenerator(_event_matrix_mm_cpu_kernel_generator))
+event_matrix_mm_p.def_cpu_kernel(_event_matrix_mm_cpu_kernel_generator)
 event_matrix_mm_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_event_matrix_mm_gpu_kernel_generator)
+        warp_kernel=_event_matrix_mm_gpu_kernel_generator,
     )
 )
 event_matrix_mm_p.def_jvp_rule2(_event_matrix_mm_jvp_spikes, _event_matrix_mm_jvp_weights, )

--- a/brainevent/_event_vector_impl.py
+++ b/brainevent/_event_vector_impl.py
@@ -24,9 +24,9 @@ from ._compatible_import import pallas as pl
 from ._event_matrix_impl import matrix_event_mm, event_matrix_mm
 from ._misc import cdiv
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
+from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import WarpKernelGenerator, dtype_to_warp_type, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 TILE_THREAD = 256
 
@@ -97,8 +97,8 @@ def _matrix_event_mv_warp_kernel_generator(
     import warp  # pylint: disable=import-outside-toplevel
     assert warp.__version__ >= '1.8.0', "warp version >= 1.8.0 is required"
 
-    spike_dtype = dtype_to_warp_type(spk_info.dtype)
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
+    spike_dtype = jaxtype_to_warptype(spk_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
 
     if spk_info.dtype == jnp.bool_:
         def kernel(
@@ -194,11 +194,11 @@ def matrix_event_mv_p_call(weights, spikes, *, float_as_event: bool):
 
 
 matrix_event_mv_p = XLACustomKernel('matrix_event_mv_op')
-matrix_event_mv_p.def_cpu_kernel(NumbaKernelGenerator(_matrix_event_numba_cpu_kernel_generator))
+matrix_event_mv_p.def_cpu_kernel(_matrix_event_numba_cpu_kernel_generator)
 matrix_event_mv_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_matrix_event_mv_warp_kernel_generator)
+        warp_kernel=_matrix_event_mv_warp_kernel_generator
     )
 )
 matrix_event_mv_p.def_jvp_rule2(_matrix_event_mv_jvp_weights, _matrix_event_mv_jvp_spikes)
@@ -266,8 +266,8 @@ def _event_matrix_mv_warp_kernel_generator(
     TILE_SIZE = spk_info.shape[0]
     block_dim = TILE_THREAD
 
-    spike_dtype = dtype_to_warp_type(spk_info.dtype)
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
+    spike_dtype = jaxtype_to_warptype(spk_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
 
     if spk_info.dtype == jnp.bool_:
         def kernel(
@@ -454,11 +454,11 @@ def event_matrix_mv_p_call(spikes, weights, *, float_as_event: bool):
 
 
 event_matrix_mv_p = XLACustomKernel('event_matrix_mv_op')
-event_matrix_mv_p.def_cpu_kernel(NumbaKernelGenerator(_event_matrix_mv_numba_kernel_generator))
+event_matrix_mv_p.def_cpu_kernel(_event_matrix_mv_numba_kernel_generator)
 event_matrix_mv_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_event_matrix_mv_warp_kernel_generator)
+        warp_kernel=_event_matrix_mv_warp_kernel_generator
     )
 )
 event_matrix_mv_p.def_jvp_rule2(_event_matrix_mv_jvp_spikes, _event_matrix_mv_jvp_weights, )

--- a/brainevent/_event_vector_impl.py
+++ b/brainevent/_event_vector_impl.py
@@ -195,12 +195,7 @@ def matrix_event_mv_p_call(weights, spikes, *, float_as_event: bool):
 
 matrix_event_mv_p = XLACustomKernel('matrix_event_mv_op')
 matrix_event_mv_p.def_cpu_kernel(_matrix_event_numba_cpu_kernel_generator)
-matrix_event_mv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_matrix_event_mv_warp_kernel_generator
-    )
-)
+matrix_event_mv_p.def_gpu_kernel(warp=_matrix_event_mv_warp_kernel_generator)
 matrix_event_mv_p.def_jvp_rule2(_matrix_event_mv_jvp_weights, _matrix_event_mv_jvp_spikes)
 matrix_event_mv_p.def_transpose_rule(_matrix_event_mv_transpose_rule)
 matrix_event_mv_p.def_batching_rule(_matrix_event_batching)
@@ -455,12 +450,7 @@ def event_matrix_mv_p_call(spikes, weights, *, float_as_event: bool):
 
 event_matrix_mv_p = XLACustomKernel('event_matrix_mv_op')
 event_matrix_mv_p.def_cpu_kernel(_event_matrix_mv_numba_kernel_generator)
-event_matrix_mv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_event_matrix_mv_warp_kernel_generator
-    )
-)
+event_matrix_mv_p.def_gpu_kernel(warp=_event_matrix_mv_warp_kernel_generator)
 event_matrix_mv_p.def_jvp_rule2(_event_matrix_mv_jvp_spikes, _event_matrix_mv_jvp_weights, )
 event_matrix_mv_p.def_transpose_rule(_event_matrix_mv_transpose_rule)
 event_matrix_mv_p.def_batching_rule(_event_matrix_batching)

--- a/brainevent/_fixed_conn_num_event_impl.py
+++ b/brainevent/_fixed_conn_num_event_impl.py
@@ -605,13 +605,7 @@ def event_fixed_num_mv_p_call(
 
 event_fixed_num_mv_p = XLACustomKernel('event_fixed_num_mv')
 event_fixed_num_mv_p.def_cpu_kernel(_event_fixed_num_mv_numba_kernel_generator)
-event_fixed_num_mv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        # warp_kernel=WarpKernelGenerator(_event_fixed_num_mv_warp_kernel_generator),
-        pallas_kernel=_event_fixed_num_mv_pallas_kernel_generator
-    )
-)
+event_fixed_num_mv_p.def_gpu_kernel(pallas=_event_fixed_num_mv_pallas_kernel_generator)
 event_fixed_num_mv_p.def_tpu_kernel(_event_fixed_num_mv_pallas_kernel_generator)
 event_fixed_num_mv_p.def_jvp_rule2(_event_fixed_num_mv_jvp_weights, None, _event_fixed_num_mv_jvp_spikes, None)
 event_fixed_num_mv_p.def_transpose_rule(_event_fixed_num_mv_transpose_rule)
@@ -991,7 +985,7 @@ def event_fixed_num_mm_p_call(
 
 event_fixed_num_mm_p = XLACustomKernel('event_fixed_num_mm')
 event_fixed_num_mm_p.def_cpu_kernel(_event_fixed_num_mm_numba_kernel_generator)
-event_fixed_num_mm_p.def_gpu_kernel(_event_fixed_num_mm_pallas_kernel_generator)
+event_fixed_num_mm_p.def_gpu_kernel(pallas=_event_fixed_num_mm_pallas_kernel_generator)
 event_fixed_num_mm_p.def_tpu_kernel(_event_fixed_num_mm_pallas_kernel_generator)
 event_fixed_num_mm_p.def_jvp_rule2(_event_fixed_num_mm_jvp_weights, None, _event_fixed_num_mm_jvp_matrix, None)
 event_fixed_num_mm_p.def_transpose_rule(_event_fixed_num_mm_transpose_rule)

--- a/brainevent/_fixed_conn_num_event_impl.py
+++ b/brainevent/_fixed_conn_num_event_impl.py
@@ -29,10 +29,10 @@ from ._fixed_conn_num_float_impl import fixed_num_mv_p_call, fixed_num_mm_p_call
 from ._misc import generate_block_dim, check_fixed_conn_num_shape
 from ._typing import MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 
 def _event_fixed_num_mv_numba_kernel_generator(
@@ -192,9 +192,9 @@ def _event_fixed_num_mv_warp_kernel_generator(
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    vector_dtype = dtype_to_warp_type(spike_info.dtype)
-    indices_dtype = dtype_to_warp_type(indices_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    vector_dtype = jaxtype_to_warptype(spike_info.dtype)
+    indices_dtype = jaxtype_to_warptype(indices_info.dtype)
     TILE_THREADS = generate_block_dim(indices_info.shape[1], maximum=128)
 
     if transpose:
@@ -442,16 +442,12 @@ def _event_fixed_num_mv_pallas_kernel_generator(
                 i_row_sum = i_row_sum * weight_ref[0]
             out_ref[i_row] = i_row_sum
 
-    def kernel(weight, indices, vector, out):
-        fn = pl.pallas_call(
-            _raw_kernel,
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-            grid=(n_pre,),
-            input_output_aliases={3: 0},
-        )
-        return [fn(weight, indices, vector, out)]
-
-    return kernel
+    return pallas_kernel(
+        _raw_kernel,
+        outs=kwargs['outs'],
+        tile=(n_pre,),
+        input_output_aliases={3: 0},
+    )
 
 
 def _event_fixed_num_mv_jvp_spikes(
@@ -608,15 +604,15 @@ def event_fixed_num_mv_p_call(
 
 
 event_fixed_num_mv_p = XLACustomKernel('event_fixed_num_mv')
-event_fixed_num_mv_p.def_cpu_kernel(NumbaKernelGenerator(_event_fixed_num_mv_numba_kernel_generator))
+event_fixed_num_mv_p.def_cpu_kernel(_event_fixed_num_mv_numba_kernel_generator)
 event_fixed_num_mv_p.def_gpu_kernel(
     GPUKernelChoice(
         default='pallas',
         # warp_kernel=WarpKernelGenerator(_event_fixed_num_mv_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_event_fixed_num_mv_pallas_kernel_generator)
+        pallas_kernel=_event_fixed_num_mv_pallas_kernel_generator
     )
 )
-event_fixed_num_mv_p.def_tpu_kernel(PallasKernelGenerator(_event_fixed_num_mv_pallas_kernel_generator))
+event_fixed_num_mv_p.def_tpu_kernel(_event_fixed_num_mv_pallas_kernel_generator)
 event_fixed_num_mv_p.def_jvp_rule2(_event_fixed_num_mv_jvp_weights, None, _event_fixed_num_mv_jvp_spikes, None)
 event_fixed_num_mv_p.def_transpose_rule(_event_fixed_num_mv_transpose_rule)
 event_fixed_num_mv_p.def_batching_rule(_event_fixed_num_mv_batching)
@@ -753,14 +749,6 @@ def _event_fixed_num_mm_pallas_kernel_generator(
 
             jax.lax.fori_loop(0, pl.cdiv(n_conn, block_k), loop_fn, None)
 
-        def kernel(weight, indices, vector, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
-                input_output_aliases={3: 0},
-            )
-            return [fn(weight, indices, vector, out)]
 
     else:
 
@@ -775,6 +763,7 @@ def _event_fixed_num_mm_pallas_kernel_generator(
             weight_ref,  # [1] or [n_pre, n_conn]
             index_ref,  # [n_pre, n_conn]
             matrix_ref,  # [k, n]
+            _,
             out_ref,  # [n_pre, n]
         ):
             i_m = pl.program_id(0)
@@ -806,15 +795,12 @@ def _event_fixed_num_mm_pallas_kernel_generator(
                 final_out = final_out * weight_ref[0]
             pl.store(out_ref, (i_m, pl.dslice(i_n_start, block_n)), final_out, mask=i_n_mask)
 
-        def kernel(weight, indices, vector, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
-            )
-            return [fn(weight, indices, vector)]
-
-    return kernel
+    return pallas_kernel(
+        _raw_kernel,
+        outs=kwargs['outs'],
+        tile=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
+        input_output_aliases={3: 0},
+    )
 
 
 def _event_fixed_num_mm_jvp_matrix(
@@ -1004,9 +990,9 @@ def event_fixed_num_mm_p_call(
 
 
 event_fixed_num_mm_p = XLACustomKernel('event_fixed_num_mm')
-event_fixed_num_mm_p.def_cpu_kernel(NumbaKernelGenerator(_event_fixed_num_mm_numba_kernel_generator))
-event_fixed_num_mm_p.def_gpu_kernel(PallasKernelGenerator(_event_fixed_num_mm_pallas_kernel_generator))
-event_fixed_num_mm_p.def_tpu_kernel(PallasKernelGenerator(_event_fixed_num_mm_pallas_kernel_generator))
+event_fixed_num_mm_p.def_cpu_kernel(_event_fixed_num_mm_numba_kernel_generator)
+event_fixed_num_mm_p.def_gpu_kernel(_event_fixed_num_mm_pallas_kernel_generator)
+event_fixed_num_mm_p.def_tpu_kernel(_event_fixed_num_mm_pallas_kernel_generator)
 event_fixed_num_mm_p.def_jvp_rule2(_event_fixed_num_mm_jvp_weights, None, _event_fixed_num_mm_jvp_matrix, None)
 event_fixed_num_mm_p.def_transpose_rule(_event_fixed_num_mm_transpose_rule)
 event_fixed_num_mm_p.def_batching_rule(_event_fixed_num_mm_batching)

--- a/brainevent/_fixed_conn_num_float_impl.py
+++ b/brainevent/_fixed_conn_num_float_impl.py
@@ -473,13 +473,7 @@ def fixed_num_mv_p_call(
 
 fixed_num_mv_p = XLACustomKernel('fixed_num_mv')
 fixed_num_mv_p.def_cpu_kernel(_fixed_num_mv_numba_kernel_generator)
-fixed_num_mv_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        # warp_kernel=WarpKernelGenerator(_fixed_num_mv_warp_kernel_generator),  # not optimized
-        pallas_kernel=_fixed_num_mv_pallas_kernel_generator,
-    )
-)
+fixed_num_mv_p.def_gpu_kernel(pallas=_fixed_num_mv_pallas_kernel_generator)
 fixed_num_mv_p.def_tpu_kernel(_fixed_num_mv_pallas_kernel_generator)
 fixed_num_mv_p.def_jvp_rule2(_fixed_num_mv_jvp_weights, None, _fixed_num_mv_jvp_vector, None)
 fixed_num_mv_p.def_transpose_rule(_fixed_num_mv_transpose_rule)
@@ -840,13 +834,7 @@ def fixed_num_mm_p_call(
 
 fixed_num_mm_p = XLACustomKernel('fixed_num_mm')
 fixed_num_mm_p.def_cpu_kernel(_fixed_num_mm_numba_kernel_generator)
-fixed_num_mm_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='pallas',
-        # warp_kernel=WarpKernelGenerator(_fixed_num_mv_warp_kernel_generator),
-        pallas_kernel=_fixed_num_mm_pallas_kernel_generator,
-    )
-)
+fixed_num_mm_p.def_gpu_kernel(pallas=_fixed_num_mm_pallas_kernel_generator)
 fixed_num_mm_p.def_tpu_kernel(_fixed_num_mm_pallas_kernel_generator)
 fixed_num_mm_p.def_jvp_rule2(_fixed_num_mm_jvp_weights, None, _fixed_num_mm_jvp_matrix, None)
 fixed_num_mm_p.def_transpose_rule(_fixed_num_mm_transpose_rule)

--- a/brainevent/_fixed_conn_num_float_impl.py
+++ b/brainevent/_fixed_conn_num_float_impl.py
@@ -26,10 +26,10 @@ from jax.interpreters import ad
 from ._compatible_import import pallas as pl
 from ._misc import generate_block_dim, check_fixed_conn_num_shape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 
 def _fixed_num_mv_numba_kernel_generator(
@@ -84,9 +84,9 @@ def _fixed_num_mv_warp_kernel_generator(
 ):
     import warp  # pylint: disable=import-outside-toplevel
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    vector_dtype = dtype_to_warp_type(vector_info.dtype)
-    indices_dtype = dtype_to_warp_type(indices_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    vector_dtype = jaxtype_to_warptype(vector_info.dtype)
+    indices_dtype = jaxtype_to_warptype(indices_info.dtype)
 
     WARP_TILE_SIZE: int = 32
 
@@ -251,16 +251,12 @@ def _fixed_num_mv_pallas_kernel_generator(
                 i_row_sum = i_row_sum * weight_ref[0]
             out_ref[i_row] = i_row_sum
 
-    def kernel(weight, indices, vector, out):
-        fn = pl.pallas_call(
-            _raw_kernel,
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-            grid=(n_pre,),
-            input_output_aliases={3: 0},
-        )
-        return [fn(weight, indices, vector, out)]
-
-    return kernel
+    return pallas_kernel(
+        _raw_kernel,
+        outs=kwargs['outs'],
+        tile=(n_pre,),
+        input_output_aliases={3: 0},
+    )
 
 
 def _fixed_num_mv_jvp_vector(
@@ -434,7 +430,7 @@ def fixed_num_mv_p_call(
     *,
     shape: Tuple[int, int],
     transpose: bool,
-) -> Tuple[Union[jax.Array, u.Quantity]]:
+):
     """Perform a sparse matrix-vector multiplication with fixed connection number.
 
     This function multiplies a sparse weight matrix against a dense vector, where the
@@ -476,15 +472,15 @@ def fixed_num_mv_p_call(
 
 
 fixed_num_mv_p = XLACustomKernel('fixed_num_mv')
-fixed_num_mv_p.def_cpu_kernel(NumbaKernelGenerator(_fixed_num_mv_numba_kernel_generator))
+fixed_num_mv_p.def_cpu_kernel(_fixed_num_mv_numba_kernel_generator)
 fixed_num_mv_p.def_gpu_kernel(
     GPUKernelChoice(
         default='pallas',
         # warp_kernel=WarpKernelGenerator(_fixed_num_mv_warp_kernel_generator),  # not optimized
-        pallas_kernel=PallasKernelGenerator(_fixed_num_mv_pallas_kernel_generator),
+        pallas_kernel=_fixed_num_mv_pallas_kernel_generator,
     )
 )
-fixed_num_mv_p.def_tpu_kernel(PallasKernelGenerator(_fixed_num_mv_pallas_kernel_generator))
+fixed_num_mv_p.def_tpu_kernel(_fixed_num_mv_pallas_kernel_generator)
 fixed_num_mv_p.def_jvp_rule2(_fixed_num_mv_jvp_weights, None, _fixed_num_mv_jvp_vector, None)
 fixed_num_mv_p.def_transpose_rule(_fixed_num_mv_transpose_rule)
 fixed_num_mv_p.def_batching_rule(_fixed_num_mv_batching)
@@ -550,9 +546,9 @@ def _fixed_num_mm_warp_kernel_generator(
     indices_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    matrix_dtype = dtype_to_warp_type(matrix_info.dtype)
-    indices_dtype = dtype_to_warp_type(indices_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    matrix_dtype = jaxtype_to_warptype(matrix_info.dtype)
+    indices_dtype = jaxtype_to_warptype(indices_info.dtype)
 
     raise NotImplementedError
 
@@ -610,14 +606,12 @@ def _fixed_num_mm_pallas_kernel_generator(
 
             jax.lax.fori_loop(0, pl.cdiv(n_conn, block_k), loop_fn, None)
 
-        def kernel(weight, indices, vector, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
-                input_output_aliases={3: 0},
-            )
-            return [fn(weight, indices, vector, out)]
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
+            input_output_aliases={3: 0},
+        )
 
     else:
 
@@ -632,6 +626,7 @@ def _fixed_num_mm_pallas_kernel_generator(
             weight_ref,  # [1] or [n_pre, n_conn]
             index_ref,  # [n_pre, n_conn]
             matrix_ref,  # [k, n]
+            _,
             out_ref,  # [n_pre, n]
         ):
             i_m = pl.program_id(0)
@@ -662,15 +657,12 @@ def _fixed_num_mm_pallas_kernel_generator(
                 final_out = final_out * weight_ref[0]
             pl.store(out_ref, (i_m, pl.dslice(i_n_start, block_n)), final_out, mask=i_n_mask)
 
-        def kernel(weight, indices, vector, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
-            )
-            return [fn(weight, indices, vector)]
-
-    return kernel
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(n_pre, pl.cdiv(matrix_info.shape[1], block_n)),
+            input_output_aliases={3: 0},
+        )
 
 
 def _fixed_num_mm_jvp_matrix(
@@ -847,15 +839,15 @@ def fixed_num_mm_p_call(
 
 
 fixed_num_mm_p = XLACustomKernel('fixed_num_mm')
-fixed_num_mm_p.def_cpu_kernel(NumbaKernelGenerator(_fixed_num_mm_numba_kernel_generator))
+fixed_num_mm_p.def_cpu_kernel(_fixed_num_mm_numba_kernel_generator)
 fixed_num_mm_p.def_gpu_kernel(
     GPUKernelChoice(
         default='pallas',
         # warp_kernel=WarpKernelGenerator(_fixed_num_mv_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_fixed_num_mm_pallas_kernel_generator)
+        pallas_kernel=_fixed_num_mm_pallas_kernel_generator,
     )
 )
-fixed_num_mm_p.def_tpu_kernel(PallasKernelGenerator(_fixed_num_mm_pallas_kernel_generator))
+fixed_num_mm_p.def_tpu_kernel(_fixed_num_mm_pallas_kernel_generator)
 fixed_num_mm_p.def_jvp_rule2(_fixed_num_mm_jvp_weights, None, _fixed_num_mm_jvp_matrix, None)
 fixed_num_mm_p.def_transpose_rule(_fixed_num_mm_transpose_rule)
 fixed_num_mm_p.def_batching_rule(_fixed_num_mm_batching)

--- a/brainevent/_fixed_conn_num_float_impl_test.py
+++ b/brainevent/_fixed_conn_num_float_impl_test.py
@@ -31,6 +31,7 @@ from brainevent._test_util import (
     allclose,
     ones_like,
 )
+
 brainevent.config.numba_environ_set(parallel_if_possible=False)
 
 if brainstate.environ.get_platform() == 'cpu':

--- a/brainevent/_jitc_event_homo_impl.py
+++ b/brainevent/_jitc_event_homo_impl.py
@@ -702,7 +702,7 @@ def event_jitc_mv_homo_p_call(
 event_jitc_mv_homo_p = XLACustomKernel('event_jitc_mv_homo')
 event_jitc_mv_homo_p.def_cpu_kernel(_jitc_mv_homo_numba_kernel_generator)
 event_jitc_mv_homo_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_homo_warp_kernel_generator,
     pallas=_jitc_mv_homo_pallas_kernel_generator,
 )
@@ -1322,7 +1322,7 @@ def event_jitc_mm_homo_p_call(
 event_jitc_mm_homo_p = XLACustomKernel('event_jitc_mm_homo')
 event_jitc_mm_homo_p.def_cpu_kernel(_jitc_mm_homo_numba_kernel_generator)
 event_jitc_mm_homo_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mm_homo_warp_kernel_generator,
     pallas=_jitc_mm_homo_pallas_kernel_generator,
 )

--- a/brainevent/_jitc_event_homo_impl.py
+++ b/brainevent/_jitc_event_homo_impl.py
@@ -29,10 +29,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "event_jitc_homo_matvec",
@@ -266,10 +266,10 @@ def _jitc_mv_homo_warp_kernel_generator(
 ):
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if vector_info.dtype == jnp.bool_:
@@ -405,14 +405,12 @@ def _jitc_mv_homo_pallas_kernel_generator(
                 )[-1]
                 pl.store(post_ref, i_cols, out, mask=i_col_mask)
 
-            def final_kernel(w, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(pl.cdiv(dim, block_size),),
-                    input_output_aliases={4: 0},
-                )
-                return [fn(w, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(pl.cdiv(dim, block_size),),
+                input_output_aliases={4: 0},
+            )
 
         else:
             def kernel(weight_ref, clen_ref, vector_ref, seed_ref, _, post_ref):
@@ -439,14 +437,12 @@ def _jitc_mv_homo_pallas_kernel_generator(
                 )
                 post_ref[i_col] = r
 
-            def final_kernel(weight, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(dim,),
-                    input_output_aliases={4: 0},
-                )
-                return [fn(weight, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(dim,),
+                input_output_aliases={4: 0},
+            )
 
 
     else:
@@ -473,16 +469,12 @@ def _jitc_mv_homo_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-        def final_kernel(weight, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={4: 0},
-            )
-            return [fn(weight, clen, vector, seed, out)]
-
-    return final_kernel
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={4: 0},
+        )
 
 
 def _jitc_mv_homo_jvp_v(
@@ -711,15 +703,15 @@ def event_jitc_mv_homo_p_call(
 
 
 event_jitc_mv_homo_p = XLACustomKernel('event_jitc_mv_homo')
-event_jitc_mv_homo_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_homo_numba_kernel_generator))
+event_jitc_mv_homo_p.def_cpu_kernel(_jitc_mv_homo_numba_kernel_generator)
 event_jitc_mv_homo_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_homo_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_homo_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_homo_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_homo_pallas_kernel_generator,
     )
 )
-event_jitc_mv_homo_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_homo_pallas_kernel_generator))
+event_jitc_mv_homo_p.def_tpu_kernel(_jitc_mv_homo_pallas_kernel_generator)
 event_jitc_mv_homo_p.def_jvp_rule2(_jitc_mv_homo_jvp_weights, None, _jitc_mv_homo_jvp_v, None, None)
 event_jitc_mv_homo_p.def_transpose_rule(_jitc_mv_homo_transpose_rules)
 event_jitc_mv_homo_p.def_batching_rule(_jitc_mv_homo_batching)
@@ -949,10 +941,10 @@ def _jitc_mm_homo_warp_kernel_generator(
 ):
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     @warp.func
     def where(s: bool):
@@ -1139,17 +1131,14 @@ def _jitc_mm_homo_pallas_kernel_generator(
             )
 
     tile = (out_info.shape[0] if corder else B_info.shape[0])
+    grid = (tile, pl.cdiv(B_info.shape[1], block_dim))
 
-    def final_kernel(weight, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={4: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(weight, clen, B, seed, out)]
-
-    return final_kernel
+    return pallas_kernel(
+        kernel,
+        tile=grid,
+        input_output_aliases={4: 0},
+        outs=kwargs['outs'],
+    )
 
 
 def _jitc_mm_homo_jvp_w(
@@ -1336,15 +1325,15 @@ def event_jitc_mm_homo_p_call(
 
 
 event_jitc_mm_homo_p = XLACustomKernel('event_jitc_mm_homo')
-event_jitc_mm_homo_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_homo_numba_kernel_generator))
+event_jitc_mm_homo_p.def_cpu_kernel(_jitc_mm_homo_numba_kernel_generator)
 event_jitc_mm_homo_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_homo_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_homo_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_homo_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_homo_pallas_kernel_generator,
     )
 )
-event_jitc_mm_homo_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mm_homo_pallas_kernel_generator))
+event_jitc_mm_homo_p.def_tpu_kernel(_jitc_mm_homo_pallas_kernel_generator)
 event_jitc_mm_homo_p.def_jvp_rule2(_jitc_mm_homo_jvp_w, None, _jitc_mm_homo_jvp_B, None, None)
 event_jitc_mm_homo_p.def_transpose_rule(_jitc_mm_homo_transpose_rules)
 event_jitc_mm_homo_p.def_batching_rule(_jitc_mm_homo_batching)

--- a/brainevent/_jitc_event_homo_impl_test.py
+++ b/brainevent/_jitc_event_homo_impl_test.py
@@ -24,7 +24,6 @@ import brainevent
 from brainevent._test_util import allclose, gen_events, ones_like
 
 
-
 class Test_JITC_RC_Conversion:
 
     @pytest.mark.parametrize('shape', [(20, 30), (100, 50)])

--- a/brainevent/_jitc_event_normal_impl.py
+++ b/brainevent/_jitc_event_normal_impl.py
@@ -852,11 +852,9 @@ def event_jitc_mv_normal_p_call(
 event_jitc_mv_normal_p = XLACustomKernel('event_jitc_mv_normal')
 event_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 event_jitc_mv_normal_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mv_normal_warp_kernel_generator,
-        pallas_kernel=_jitc_mv_normal_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mv_normal_warp_kernel_generator,
+    pallas=_jitc_mv_normal_pallas_kernel_generator,
 )
 event_jitc_mv_normal_p.def_tpu_kernel(_jitc_mv_normal_pallas_kernel_generator)
 event_jitc_mv_normal_p.def_jvp_rule2(
@@ -1517,11 +1515,9 @@ def event_jitc_mm_normal_p_call(
 event_jitc_mm_normal_p = XLACustomKernel('event_jitc_mm_normal')
 event_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 event_jitc_mm_normal_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mm_normal_warp_kernel_generator,
-        pallas_kernel=_jitc_mm_normal_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mm_normal_warp_kernel_generator,
+    pallas=_jitc_mm_normal_pallas_kernel_generator,
 )
 event_jitc_mm_normal_p.def_tpu_kernel(_jitc_mm_normal_pallas_kernel_generator)
 event_jitc_mm_normal_p.def_jvp_rule2(_jitc_mm_normal_jvp_wloc, _jitc_mm_normal_jvp_wscale,

--- a/brainevent/_jitc_event_normal_impl.py
+++ b/brainevent/_jitc_event_normal_impl.py
@@ -29,10 +29,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "event_jitc_normal_matvec",
@@ -333,11 +333,11 @@ def _jitc_mv_normal_warp_kernel_generator(
     """
     import warp
 
-    w_loc_dtype = dtype_to_warp_type(w_loc_info.dtype)
-    w_scale_dtype = dtype_to_warp_type(w_scale_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_loc_dtype = jaxtype_to_warptype(w_loc_info.dtype)
+    w_scale_dtype = jaxtype_to_warptype(w_scale_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if vector_info.dtype == jnp.bool_:
@@ -568,14 +568,12 @@ def _jitc_mv_normal_pallas_kernel_generator(
                 )[-1]
                 pl.store(post_ref, i_cols, out, mask=i_col_mask)
 
-            def final_kernel(w_loc, w_scale, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(pl.cdiv(dim, block_size),),
-                    input_output_aliases={5: 0},
-                )
-                return [fn(w_loc, w_scale, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(pl.cdiv(dim, block_size),),
+                input_output_aliases={5: 0},
+            )
 
         else:
             def kernel(w_loc_ref, w_scale_ref, clen_ref, vector_ref, seed_ref, _, post_ref):
@@ -604,14 +602,12 @@ def _jitc_mv_normal_pallas_kernel_generator(
                 )
                 post_ref[i_col] = r
 
-            def final_kernel(w_loc, w_scale, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(dim,),
-                    input_output_aliases={5: 0},
-                )
-                return [fn(w_loc, w_scale, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(dim,),
+                input_output_aliases={5: 0},
+            )
 
 
     else:
@@ -639,16 +635,12 @@ def _jitc_mv_normal_pallas_kernel_generator(
                     (rng.random_integers(0, clen), rng)
                 )
 
-        def final_kernel(w_loc, w_scale, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_loc, w_scale, clen, vector, seed, out)]
-
-    return final_kernel
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={5: 0},
+        )
 
 
 def _jitc_mv_normal_jvp_v(
@@ -858,15 +850,15 @@ def event_jitc_mv_normal_p_call(
 
 
 event_jitc_mv_normal_p = XLACustomKernel('event_jitc_mv_normal')
-event_jitc_mv_normal_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_normal_numba_kernel_generator))
+event_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 event_jitc_mv_normal_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_normal_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_normal_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_normal_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_normal_pallas_kernel_generator,
     )
 )
-event_jitc_mv_normal_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_normal_pallas_kernel_generator))
+event_jitc_mv_normal_p.def_tpu_kernel(_jitc_mv_normal_pallas_kernel_generator)
 event_jitc_mv_normal_p.def_jvp_rule2(
     _jitc_mv_normal_jvp_wloc,
     _jitc_mv_normal_jvp_wscale,
@@ -1096,11 +1088,11 @@ def _jitc_mm_normal_warp_kernel_generator(
 ):
     import warp
 
-    w_loc_dtype = dtype_to_warp_type(w_loc_info.dtype)
-    w_scale_dtype = dtype_to_warp_type(w_scale_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_loc_dtype = jaxtype_to_warptype(w_loc_info.dtype)
+    w_scale_dtype = jaxtype_to_warptype(w_scale_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if B_info.dtype == jnp.bool_:
@@ -1301,17 +1293,14 @@ def _jitc_mm_normal_pallas_kernel_generator(
             )
 
     tile = (out_info.shape[0] if corder else B_info.shape[0])
+    grid = (tile, pl.cdiv(B_info.shape[1], block_dim))
 
-    def final_kernel(w_loc, w_scale, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={5: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(w_loc, w_scale, clen, B, seed, out)]
-
-    return final_kernel
+    return pallas_kernel(
+        kernel,
+        tile=grid,
+        input_output_aliases={5: 0},
+        outs=kwargs['outs']
+    )
 
 
 def _jitc_mm_normal_jvp_wloc(
@@ -1526,15 +1515,15 @@ def event_jitc_mm_normal_p_call(
 
 
 event_jitc_mm_normal_p = XLACustomKernel('event_jitc_mm_normal')
-event_jitc_mm_normal_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_normal_numba_kernel_generator))
+event_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 event_jitc_mm_normal_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_normal_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_normal_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_normal_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_normal_pallas_kernel_generator,
     )
 )
-event_jitc_mm_normal_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mm_normal_pallas_kernel_generator))
+event_jitc_mm_normal_p.def_tpu_kernel(_jitc_mm_normal_pallas_kernel_generator)
 event_jitc_mm_normal_p.def_jvp_rule2(_jitc_mm_normal_jvp_wloc, _jitc_mm_normal_jvp_wscale,
                                      None, _jitc_mm_normal_jvp_B, None, None)
 event_jitc_mm_normal_p.def_transpose_rule(_jitc_mm_normal_transpose_rules)

--- a/brainevent/_jitc_event_normal_impl.py
+++ b/brainevent/_jitc_event_normal_impl.py
@@ -852,7 +852,7 @@ def event_jitc_mv_normal_p_call(
 event_jitc_mv_normal_p = XLACustomKernel('event_jitc_mv_normal')
 event_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 event_jitc_mv_normal_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_normal_warp_kernel_generator,
     pallas=_jitc_mv_normal_pallas_kernel_generator,
 )
@@ -1515,7 +1515,7 @@ def event_jitc_mm_normal_p_call(
 event_jitc_mm_normal_p = XLACustomKernel('event_jitc_mm_normal')
 event_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 event_jitc_mm_normal_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mm_normal_warp_kernel_generator,
     pallas=_jitc_mm_normal_pallas_kernel_generator,
 )

--- a/brainevent/_jitc_event_normal_impl_test.py
+++ b/brainevent/_jitc_event_normal_impl_test.py
@@ -19,12 +19,10 @@ from typing import Tuple
 import brainstate
 import brainunit as u
 import jax
-import jax.numpy as jnp
 import pytest
 
 import brainevent
 from brainevent._test_util import allclose, gen_events, ones_like
-
 
 
 class Test_JITCNormalR:

--- a/brainevent/_jitc_event_uniform_impl.py
+++ b/brainevent/_jitc_event_uniform_impl.py
@@ -715,7 +715,7 @@ def event_jitc_mv_uniform_p_call(
 event_jitc_mv_uniform_p = XLACustomKernel('event_jitc_mv_uniform')
 event_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 event_jitc_mv_uniform_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_uniform_warp_kernel_generator,
     pallas=_jitc_mv_uniform_pallas_kernel_generator,
 )
@@ -1434,7 +1434,7 @@ def event_jitc_mm_uniform_p_call(
 event_jitc_mm_uniform_p = XLACustomKernel('event_jitc_mm_uniform')
 event_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 event_jitc_mm_uniform_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mm_uniform_warp_kernel_generator,
     pallas=_jitc_mm_uniform_pallas_kernel_generator,
 )

--- a/brainevent/_jitc_event_uniform_impl.py
+++ b/brainevent/_jitc_event_uniform_impl.py
@@ -29,10 +29,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "event_jitc_uniform_matvec",
@@ -273,11 +273,11 @@ def _jitc_mv_uniform_warp_kernel_generator(
 ):
     import warp
 
-    w_low_dtype = dtype_to_warp_type(w_low_info.dtype)
-    w_high_dtype = dtype_to_warp_type(w_high_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_low_dtype = jaxtype_to_warptype(w_low_info.dtype)
+    w_high_dtype = jaxtype_to_warptype(w_high_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if vector_info.dtype == jnp.bool_:
@@ -432,14 +432,12 @@ def _jitc_mv_uniform_pallas_kernel_generator(
                 )[-1]
                 pl.store(post_ref, i_cols, out, mask=i_col_mask)
 
-            def final_kernel(w_low, w_high, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(pl.cdiv(dim, block_size),),
-                    input_output_aliases={5: 0},
-                )
-                return [fn(w_low, w_high, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(pl.cdiv(dim, block_size),),
+                input_output_aliases={5: 0},
+            )
 
         else:
             def kernel(w_low_ref, w_high_ref, clen_ref, vector_ref, seed_ref, _, post_ref):
@@ -468,14 +466,12 @@ def _jitc_mv_uniform_pallas_kernel_generator(
                 )
                 post_ref[i_col] = r
 
-            def final_kernel(w_low, w_high, clen, vector, seed, out):
-                fn = pl.pallas_call(
-                    kernel,
-                    out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                    grid=(dim,),
-                    input_output_aliases={5: 0},
-                )
-                return [fn(w_low, w_high, clen, vector, seed, out)]
+            return pallas_kernel(
+                kernel,
+                outs=kwargs['outs'],
+                tile=(dim,),
+                input_output_aliases={5: 0},
+            )
 
 
     else:
@@ -503,16 +499,12 @@ def _jitc_mv_uniform_pallas_kernel_generator(
                     (rng.random_integers(0, clen), rng)
                 )
 
-        def final_kernel(w_low, w_high, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_low, w_high, clen, vector, seed, out)]
-
-    return final_kernel
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={5: 0},
+        )
 
 
 def _jitc_mv_uniform_jvp_v(
@@ -721,15 +713,15 @@ def event_jitc_mv_uniform_p_call(
 
 
 event_jitc_mv_uniform_p = XLACustomKernel('event_jitc_mv_uniform')
-event_jitc_mv_uniform_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_uniform_numba_kernel_generator))
+event_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 event_jitc_mv_uniform_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_uniform_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_uniform_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_uniform_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_uniform_pallas_kernel_generator,
     )
 )
-event_jitc_mv_uniform_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_uniform_pallas_kernel_generator))
+event_jitc_mv_uniform_p.def_tpu_kernel(_jitc_mv_uniform_pallas_kernel_generator)
 event_jitc_mv_uniform_p.def_jvp_rule2(
     _jitc_mv_uniform_jvp_wloc,
     _jitc_mv_uniform_jvp_wscale,
@@ -940,11 +932,11 @@ def _jitc_mm_uniform_warp_kernel_generator(
     import warp
 
     TITLE_SIZE = B_info.shape[1]  # Assuming B is [k, n], we want to process n columns at once
-    w_low_dtype = dtype_to_warp_type(w_low_info.dtype)
-    w_high_dtype = dtype_to_warp_type(w_high_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_low_dtype = jaxtype_to_warptype(w_low_info.dtype)
+    w_high_dtype = jaxtype_to_warptype(w_high_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if B_info.dtype == jnp.bool_:
@@ -1221,17 +1213,14 @@ def _jitc_mm_uniform_pallas_kernel_generator(
                 )
 
     tile = (out_info.shape[0] if corder else B_info.shape[0])
+    grid = (tile, pl.cdiv(B_info.shape[1], block_dim))
 
-    def final_kernel(w_low, w_high, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={5: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(w_low, w_high, clen, B, seed, out)]
-
-    return final_kernel
+    return pallas_kernel(
+        kernel,
+        tile=grid,
+        input_output_aliases={5: 0},
+        outs=kwargs['outs']
+    )
 
 
 def _jitc_mm_uniform_jvp_wloc(
@@ -1445,15 +1434,15 @@ def event_jitc_mm_uniform_p_call(
 
 
 event_jitc_mm_uniform_p = XLACustomKernel('event_jitc_mm_uniform')
-event_jitc_mm_uniform_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_uniform_numba_kernel_generator))
+event_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 event_jitc_mm_uniform_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_uniform_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_uniform_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_uniform_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_uniform_pallas_kernel_generator,
     )
 )
-event_jitc_mm_uniform_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mm_uniform_pallas_kernel_generator))
+event_jitc_mm_uniform_p.def_tpu_kernel(_jitc_mm_uniform_pallas_kernel_generator)
 event_jitc_mm_uniform_p.def_jvp_rule2(
     _jitc_mm_uniform_jvp_wloc,
     _jitc_mm_uniform_jvp_wscale,

--- a/brainevent/_jitc_event_uniform_impl.py
+++ b/brainevent/_jitc_event_uniform_impl.py
@@ -715,11 +715,9 @@ def event_jitc_mv_uniform_p_call(
 event_jitc_mv_uniform_p = XLACustomKernel('event_jitc_mv_uniform')
 event_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 event_jitc_mv_uniform_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mv_uniform_warp_kernel_generator,
-        pallas_kernel=_jitc_mv_uniform_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mv_uniform_warp_kernel_generator,
+    pallas=_jitc_mv_uniform_pallas_kernel_generator,
 )
 event_jitc_mv_uniform_p.def_tpu_kernel(_jitc_mv_uniform_pallas_kernel_generator)
 event_jitc_mv_uniform_p.def_jvp_rule2(
@@ -1436,11 +1434,9 @@ def event_jitc_mm_uniform_p_call(
 event_jitc_mm_uniform_p = XLACustomKernel('event_jitc_mm_uniform')
 event_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 event_jitc_mm_uniform_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mm_uniform_warp_kernel_generator,
-        pallas_kernel=_jitc_mm_uniform_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mm_uniform_warp_kernel_generator,
+    pallas=_jitc_mm_uniform_pallas_kernel_generator,
 )
 event_jitc_mm_uniform_p.def_tpu_kernel(_jitc_mm_uniform_pallas_kernel_generator)
 event_jitc_mm_uniform_p.def_jvp_rule2(

--- a/brainevent/_jitc_event_uniform_impl_test.py
+++ b/brainevent/_jitc_event_uniform_impl_test.py
@@ -19,13 +19,10 @@ from typing import Tuple
 import brainstate
 import brainunit as u
 import jax
-import jax.numpy as jnp
 import pytest
 
 import brainevent
 from brainevent._test_util import allclose, gen_events, ones_like
-
-
 
 
 class Test_JITCUniformR:

--- a/brainevent/_jitc_float_homo_impl.py
+++ b/brainevent/_jitc_float_homo_impl.py
@@ -819,11 +819,9 @@ def float_jitc_homo_matrix_p_call(
 float_jitc_homo_matrix_p = XLACustomKernel('float_jitc_homo_matrix')
 float_jitc_homo_matrix_p.def_cpu_kernel(_jitc_homo_matrix_numba_kernel_generator)
 float_jitc_homo_matrix_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_homo_matrix_warp_kernel_generator,
-        pallas_kernel=_jitc_homo_matrix_pallas_kernel_generator
-    )
+    default='warp',
+    warp=_jitc_homo_matrix_warp_kernel_generator,
+    pallas=_jitc_homo_matrix_pallas_kernel_generator
 )
 float_jitc_homo_matrix_p.def_tpu_kernel(_jitc_homo_matrix_pallas_kernel_generator)
 float_jitc_homo_matrix_p.def_jvp_rule2(_jitc_homo_matrix_jvp_weight, None, None)
@@ -1579,11 +1577,9 @@ def float_jitc_mv_homo_p_call(
 float_jitc_mv_homo_p = XLACustomKernel('float_jitc_mv_homo')
 float_jitc_mv_homo_p.def_cpu_kernel(_jitc_mv_homo_numba_kernel_generator)
 float_jitc_mv_homo_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mv_homo_warp_kernel_generator,
-        pallas_kernel=_jitc_mv_homo_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mv_homo_warp_kernel_generator,
+    pallas=_jitc_mv_homo_pallas_kernel_generator,
 )
 float_jitc_mv_homo_p.def_tpu_kernel(_jitc_mv_homo_pallas_kernel_generator)
 float_jitc_mv_homo_p.def_jvp_rule2(
@@ -2196,11 +2192,9 @@ def float_jitc_mm_homo_p_call(
 float_jitc_mm_homo_p = XLACustomKernel('float_jitc_mm_homo')
 float_jitc_mm_homo_p.def_cpu_kernel(_jitc_mm_homo_numba_kernel_generator)
 float_jitc_mm_homo_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mm_homo_warp_kernel_generator,
-        pallas_kernel=_jitc_mm_homo_pallas_kernel_generator,
-    )
+    warp=_jitc_mm_homo_warp_kernel_generator,
+    pallas=_jitc_mm_homo_pallas_kernel_generator,
+    default='warp',
 )
 float_jitc_mm_homo_p.def_tpu_kernel(_jitc_mm_homo_pallas_kernel_generator)
 float_jitc_mm_homo_p.def_jvp_rule2(

--- a/brainevent/_jitc_float_homo_impl.py
+++ b/brainevent/_jitc_float_homo_impl.py
@@ -819,7 +819,7 @@ def float_jitc_homo_matrix_p_call(
 float_jitc_homo_matrix_p = XLACustomKernel('float_jitc_homo_matrix')
 float_jitc_homo_matrix_p.def_cpu_kernel(_jitc_homo_matrix_numba_kernel_generator)
 float_jitc_homo_matrix_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_homo_matrix_warp_kernel_generator,
     pallas=_jitc_homo_matrix_pallas_kernel_generator
 )
@@ -1577,7 +1577,7 @@ def float_jitc_mv_homo_p_call(
 float_jitc_mv_homo_p = XLACustomKernel('float_jitc_mv_homo')
 float_jitc_mv_homo_p.def_cpu_kernel(_jitc_mv_homo_numba_kernel_generator)
 float_jitc_mv_homo_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_homo_warp_kernel_generator,
     pallas=_jitc_mv_homo_pallas_kernel_generator,
 )
@@ -2194,7 +2194,7 @@ float_jitc_mm_homo_p.def_cpu_kernel(_jitc_mm_homo_numba_kernel_generator)
 float_jitc_mm_homo_p.def_gpu_kernel(
     warp=_jitc_mm_homo_warp_kernel_generator,
     pallas=_jitc_mm_homo_pallas_kernel_generator,
-    default='warp',
+    default='pallas',
 )
 float_jitc_mm_homo_p.def_tpu_kernel(_jitc_mm_homo_pallas_kernel_generator)
 float_jitc_mm_homo_p.def_jvp_rule2(

--- a/brainevent/_jitc_float_homo_impl.py
+++ b/brainevent/_jitc_float_homo_impl.py
@@ -28,10 +28,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "float_jitc_homo_matrix",
@@ -419,9 +419,9 @@ def _jitc_homo_matrix_warp_kernel_generator(
     """
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
 
@@ -666,14 +666,12 @@ def _jitc_homo_matrix_pallas_kernel_generator(
                     (i_rows, i_row_mask, rng)
                 )
 
-        def kernel(weight, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={3: 0},
-            )
-            return [fn(weight, clen, seed, out)]
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={3: 0}
+        )
 
     else:
         if corder:
@@ -730,16 +728,12 @@ def _jitc_homo_matrix_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-        def kernel(weight, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={3: 0},
-            )
-            return [fn(weight, clen, seed, out)]
-
-    return kernel
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={3: 0}
+        )
 
 
 def _jitc_homo_matrix_jvp_weight(
@@ -823,15 +817,15 @@ def float_jitc_homo_matrix_p_call(
 
 
 float_jitc_homo_matrix_p = XLACustomKernel('float_jitc_homo_matrix')
-float_jitc_homo_matrix_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_homo_matrix_numba_kernel_generator))
+float_jitc_homo_matrix_p.def_cpu_kernel(_jitc_homo_matrix_numba_kernel_generator)
 float_jitc_homo_matrix_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_homo_matrix_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_homo_matrix_pallas_kernel_generator)
+        warp_kernel=_jitc_homo_matrix_warp_kernel_generator,
+        pallas_kernel=_jitc_homo_matrix_pallas_kernel_generator
     )
 )
-float_jitc_homo_matrix_p.def_tpu_kernel(PallasKernelGenerator(_jitc_homo_matrix_pallas_kernel_generator))
+float_jitc_homo_matrix_p.def_tpu_kernel(_jitc_homo_matrix_pallas_kernel_generator)
 float_jitc_homo_matrix_p.def_jvp_rule2(_jitc_homo_matrix_jvp_weight, None, None)
 float_jitc_homo_matrix_p.def_transpose_rule(_jitc_homo_matrix_transpose)
 float_jitc_homo_matrix_p.def_batching_rule(_jitc_homo_matrix_batching)
@@ -1040,10 +1034,10 @@ def _jitc_mv_homo_warp_kernel_generator(
     """
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
 
@@ -1290,14 +1284,12 @@ def _jitc_mv_homo_pallas_kernel_generator(
                     (i_cols, i_col_mask, rng)
                 )
 
-        def final_kernel(weight, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={4: 0},
-            )
-            return [fn(weight, clen, vector, seed, out)]
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={4: 0},
+        )
 
 
     else:
@@ -1345,14 +1337,12 @@ def _jitc_mv_homo_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-        def final_kernel(weight, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={4: 0},
-            )
-            return [fn(weight, clen, vector, seed, out)]
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={4: 0},
+        )
 
     return final_kernel
 
@@ -1587,15 +1577,15 @@ def float_jitc_mv_homo_p_call(
 
 
 float_jitc_mv_homo_p = XLACustomKernel('float_jitc_mv_homo')
-float_jitc_mv_homo_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_homo_numba_kernel_generator))
+float_jitc_mv_homo_p.def_cpu_kernel(_jitc_mv_homo_numba_kernel_generator)
 float_jitc_mv_homo_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_homo_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_homo_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_homo_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_homo_pallas_kernel_generator,
     )
 )
-float_jitc_mv_homo_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_homo_pallas_kernel_generator))
+float_jitc_mv_homo_p.def_tpu_kernel(_jitc_mv_homo_pallas_kernel_generator)
 float_jitc_mv_homo_p.def_jvp_rule2(
     _jitc_mv_homo_jvp_weights,
     None,
@@ -1769,10 +1759,10 @@ def _jitc_mm_homo_warp_kernel_generator(
 ):
     import warp
 
-    weight_dtype = dtype_to_warp_type(weight_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    weight_dtype = jaxtype_to_warptype(weight_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if transpose:
@@ -2010,17 +2000,14 @@ def _jitc_mm_homo_pallas_kernel_generator(
                 )
 
     tile = (out_info.shape[0] if corder else B_info.shape[0])
+    grid = (tile, pl.cdiv(B_info.shape[1], block_dim))
 
-    def final_kernel(weight, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={4: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(weight, clen, B, seed, out)]
-
-    return final_kernel
+    return pallas_kernel(
+        kernel,
+        tile=grid,
+        input_output_aliases={4: 0},
+        outs=kwargs['outs']
+    )
 
 
 def _jitc_mm_homo_jvp_w(
@@ -2146,7 +2133,7 @@ def _jitc_mm_homo_batching(args, axes, **kwargs):
         return _batching_axis1(args, **kwargs)
 
     elif tuple(axes) == (None, None, 1, None, None):
-        return _batching_axis1(args,  **kwargs)
+        return _batching_axis1(args, **kwargs)
 
     elif tuple(axes) == (None, None, 2, None, None):
         return _batching_axis1(args, axis=2, **kwargs)
@@ -2207,15 +2194,15 @@ def float_jitc_mm_homo_p_call(
 
 
 float_jitc_mm_homo_p = XLACustomKernel('float_jitc_mm_homo')
-float_jitc_mm_homo_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_homo_numba_kernel_generator))
+float_jitc_mm_homo_p.def_cpu_kernel(_jitc_mm_homo_numba_kernel_generator)
 float_jitc_mm_homo_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_homo_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_homo_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_homo_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_homo_pallas_kernel_generator,
     )
 )
-float_jitc_mm_homo_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mm_homo_pallas_kernel_generator))
+float_jitc_mm_homo_p.def_tpu_kernel(_jitc_mm_homo_pallas_kernel_generator)
 float_jitc_mm_homo_p.def_jvp_rule2(
     _jitc_mm_homo_jvp_w,
     None,

--- a/brainevent/_jitc_float_normal_impl.py
+++ b/brainevent/_jitc_float_normal_impl.py
@@ -692,11 +692,9 @@ def float_jitc_normal_matrix_p_call(
 float_jitc_normal_matrix_p = XLACustomKernel('float_jitc_normal_matrix')
 float_jitc_normal_matrix_p.def_cpu_kernel(_jitc_normal_matrix_numba_kernel_generator)
 float_jitc_normal_matrix_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_normal_matrix_warp_kernel_generator,
-        pallas_kernel=_jitc_normal_matrix_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_normal_matrix_warp_kernel_generator,
+    pallas=_jitc_normal_matrix_pallas_kernel_generator,
 )
 float_jitc_normal_matrix_p.def_tpu_kernel(_jitc_normal_matrix_pallas_kernel_generator)
 float_jitc_normal_matrix_p.def_jvp_rule2(
@@ -1440,11 +1438,9 @@ def float_jitc_mv_normal_p_call(
 float_jitc_mv_normal_p = XLACustomKernel('float_jitc_mv_normal')
 float_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 float_jitc_mv_normal_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mv_normal_warp_kernel_generator,
-        pallas_kernel=_jitc_mv_normal_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mv_normal_warp_kernel_generator,
+    pallas=_jitc_mv_normal_pallas_kernel_generator,
 )
 float_jitc_mv_normal_p.def_tpu_kernel(_jitc_mv_normal_pallas_kernel_generator)
 float_jitc_mv_normal_p.def_jvp_rule2(
@@ -2111,11 +2107,9 @@ def float_jitc_mm_normal_p_call(
 float_jitc_mm_normal_p = XLACustomKernel('float_jitc_mm_normal')
 float_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 float_jitc_mm_normal_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mm_normal_warp_kernel_generator,
-        pallas_kernel=_jitc_mm_normal_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mm_normal_warp_kernel_generator,
+    pallas=_jitc_mm_normal_pallas_kernel_generator,
 )
 float_jitc_mm_normal_p.def_tpu_kernel(_jitc_mm_normal_pallas_kernel_generator)
 float_jitc_mm_normal_p.def_jvp_rule2(

--- a/brainevent/_jitc_float_normal_impl.py
+++ b/brainevent/_jitc_float_normal_impl.py
@@ -692,7 +692,7 @@ def float_jitc_normal_matrix_p_call(
 float_jitc_normal_matrix_p = XLACustomKernel('float_jitc_normal_matrix')
 float_jitc_normal_matrix_p.def_cpu_kernel(_jitc_normal_matrix_numba_kernel_generator)
 float_jitc_normal_matrix_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_normal_matrix_warp_kernel_generator,
     pallas=_jitc_normal_matrix_pallas_kernel_generator,
 )
@@ -1438,7 +1438,7 @@ def float_jitc_mv_normal_p_call(
 float_jitc_mv_normal_p = XLACustomKernel('float_jitc_mv_normal')
 float_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 float_jitc_mv_normal_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_normal_warp_kernel_generator,
     pallas=_jitc_mv_normal_pallas_kernel_generator,
 )
@@ -2107,7 +2107,7 @@ def float_jitc_mm_normal_p_call(
 float_jitc_mm_normal_p = XLACustomKernel('float_jitc_mm_normal')
 float_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 float_jitc_mm_normal_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mm_normal_warp_kernel_generator,
     pallas=_jitc_mm_normal_pallas_kernel_generator,
 )

--- a/brainevent/_jitc_float_normal_impl.py
+++ b/brainevent/_jitc_float_normal_impl.py
@@ -28,10 +28,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "float_jitc_normal_matrix",
@@ -281,10 +281,10 @@ def _jitc_normal_matrix_warp_kernel_generator(
 ):
     import warp
 
-    w_loc_dtype = dtype_to_warp_type(w_loc_info.dtype)
-    w_scale_dtype = dtype_to_warp_type(w_scale_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_loc_dtype = jaxtype_to_warptype(w_loc_info.dtype)
+    w_scale_dtype = jaxtype_to_warptype(w_scale_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if transpose:
@@ -539,14 +539,12 @@ def _jitc_normal_matrix_pallas_kernel_generator(
                     (i_rows, i_row_mask, rng)
                 )
 
-        def kernel(w_loc, w_scale, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={4: 0},
-            )
-            return [fn(w_loc, w_scale, clen, seed, out)]
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={4: 0},
+        )
 
     else:
         if corder:
@@ -606,17 +604,12 @@ def _jitc_normal_matrix_pallas_kernel_generator(
                     body,
                     (rng.random_integers(0, clen0), rng)
                 )
-
-        def kernel(w_loc, w_scale, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={4: 0},
-            )
-            return [fn(w_loc, w_scale, clen, seed, out)]
-
-    return kernel
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={4: 0},
+        )
 
 
 def _jitc_normal_matrix_jvp_wlow(
@@ -697,15 +690,15 @@ def float_jitc_normal_matrix_p_call(
 
 
 float_jitc_normal_matrix_p = XLACustomKernel('float_jitc_normal_matrix')
-float_jitc_normal_matrix_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_normal_matrix_numba_kernel_generator))
+float_jitc_normal_matrix_p.def_cpu_kernel(_jitc_normal_matrix_numba_kernel_generator)
 float_jitc_normal_matrix_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_normal_matrix_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_normal_matrix_pallas_kernel_generator),
+        warp_kernel=_jitc_normal_matrix_warp_kernel_generator,
+        pallas_kernel=_jitc_normal_matrix_pallas_kernel_generator,
     )
 )
-float_jitc_normal_matrix_p.def_tpu_kernel(PallasKernelGenerator(_jitc_normal_matrix_pallas_kernel_generator))
+float_jitc_normal_matrix_p.def_tpu_kernel(_jitc_normal_matrix_pallas_kernel_generator)
 float_jitc_normal_matrix_p.def_jvp_rule2(
     _jitc_normal_matrix_jvp_wlow,
     _jitc_normal_matrix_jvp_whigh,
@@ -913,11 +906,11 @@ def _jitc_mv_normal_warp_kernel_generator(
     """
     import warp
 
-    w_loc_dtype = dtype_to_warp_type(w_loc_info.dtype)
-    w_scale_dtype = dtype_to_warp_type(w_scale_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_loc_dtype = jaxtype_to_warptype(w_loc_info.dtype)
+    w_scale_dtype = jaxtype_to_warptype(w_scale_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
 
@@ -1170,14 +1163,12 @@ def _jitc_mv_normal_pallas_kernel_generator(
                     (i_cols, i_col_mask, rng)
                 )
 
-        def final_kernel(w_loc, w_scale, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_loc, w_scale, clen, vector, seed, out)]
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={5: 0},
+        )
 
     else:
         if corder:
@@ -1226,14 +1217,12 @@ def _jitc_mv_normal_pallas_kernel_generator(
                     (rng.random_integers(0, clen), rng)
                 )
 
-        def final_kernel(w_loc, w_scale, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_loc, w_scale, clen, vector, seed, out)]
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={5: 0},
+        )
 
     return final_kernel
 
@@ -1449,15 +1438,15 @@ def float_jitc_mv_normal_p_call(
 
 
 float_jitc_mv_normal_p = XLACustomKernel('float_jitc_mv_normal')
-float_jitc_mv_normal_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_normal_numba_kernel_generator))
+float_jitc_mv_normal_p.def_cpu_kernel(_jitc_mv_normal_numba_kernel_generator)
 float_jitc_mv_normal_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_normal_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_normal_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_normal_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_normal_pallas_kernel_generator,
     )
 )
-float_jitc_mv_normal_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_normal_pallas_kernel_generator))
+float_jitc_mv_normal_p.def_tpu_kernel(_jitc_mv_normal_pallas_kernel_generator)
 float_jitc_mv_normal_p.def_jvp_rule2(
     _jitc_mv_normal_jvp_wloc,
     _jitc_mv_normal_jvp_wscale,
@@ -1637,11 +1626,11 @@ def _jitc_mm_normal_warp_kernel_generator(
 ):
     import warp
 
-    w_loc_dtype = dtype_to_warp_type(w_loc_info.dtype)
-    w_scale_dtype = dtype_to_warp_type(w_scale_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_loc_dtype = jaxtype_to_warptype(w_loc_info.dtype)
+    w_scale_dtype = jaxtype_to_warptype(w_scale_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if transpose:
@@ -1896,18 +1885,16 @@ def _jitc_mm_normal_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-    tile = (out_info.shape[0] if corder else B_info.shape[0])
-
-    def final_kernel(w_loc, w_scale, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={5: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(w_loc, w_scale, clen, B, seed, out)]
-
-    return final_kernel
+    grid = (
+        out_info.shape[0] if corder else B_info.shape[0],
+        pl.cdiv(B_info.shape[1], block_dim)
+    )
+    return pallas_kernel(
+        kernel,
+        tile=grid,
+        input_output_aliases={5: 0},
+        outs=kwargs['outs']
+    )
 
 
 def _jitc_mm_normal_jvp_wloc(
@@ -2122,15 +2109,15 @@ def float_jitc_mm_normal_p_call(
 
 
 float_jitc_mm_normal_p = XLACustomKernel('float_jitc_mm_normal')
-float_jitc_mm_normal_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_normal_numba_kernel_generator))
+float_jitc_mm_normal_p.def_cpu_kernel(_jitc_mm_normal_numba_kernel_generator)
 float_jitc_mm_normal_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_normal_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_normal_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_normal_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_normal_pallas_kernel_generator,
     )
 )
-float_jitc_mm_normal_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mm_normal_pallas_kernel_generator))
+float_jitc_mm_normal_p.def_tpu_kernel(_jitc_mm_normal_pallas_kernel_generator)
 float_jitc_mm_normal_p.def_jvp_rule2(
     _jitc_mm_normal_jvp_wloc,
     _jitc_mm_normal_jvp_wscale,

--- a/brainevent/_jitc_float_normal_impl_test.py
+++ b/brainevent/_jitc_float_normal_impl_test.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 
 
+from typing import Tuple
+
 import brainstate
 import brainunit as u
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from typing import Tuple
 
 import brainevent
 

--- a/brainevent/_jitc_float_uniform_impl.py
+++ b/brainevent/_jitc_float_uniform_impl.py
@@ -735,7 +735,7 @@ def float_jitc_uniform_matrix_p_call(
 float_jitc_uniform_matrix_p = XLACustomKernel('float_jitc_uniform_matrix')
 float_jitc_uniform_matrix_p.def_cpu_kernel(_jitc_uniform_matrix_numba_kernel_generator)
 float_jitc_uniform_matrix_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_uniform_matrix_warp_kernel_generator,
     pallas=_jitc_uniform_matrix_pallas_kernel_generator,
 )
@@ -1484,7 +1484,7 @@ def float_jitc_mv_uniform_p_call(
 float_jitc_mv_uniform_p = XLACustomKernel('float_jitc_mv_uniform')
 float_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 float_jitc_mv_uniform_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mv_uniform_warp_kernel_generator,
     pallas=_jitc_mv_uniform_pallas_kernel_generator,
 )
@@ -2156,7 +2156,7 @@ def float_jitc_mm_uniform_p_call(
 float_jitc_mm_uniform_p = XLACustomKernel('float_jitc_mm_uniform')
 float_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 float_jitc_mm_uniform_p.def_gpu_kernel(
-    default='warp',
+    default='pallas',
     warp=_jitc_mm_uniform_warp_kernel_generator,
     pallas=_jitc_mm_uniform_pallas_kernel_generator,
 )

--- a/brainevent/_jitc_float_uniform_impl.py
+++ b/brainevent/_jitc_float_uniform_impl.py
@@ -735,11 +735,9 @@ def float_jitc_uniform_matrix_p_call(
 float_jitc_uniform_matrix_p = XLACustomKernel('float_jitc_uniform_matrix')
 float_jitc_uniform_matrix_p.def_cpu_kernel(_jitc_uniform_matrix_numba_kernel_generator)
 float_jitc_uniform_matrix_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_uniform_matrix_warp_kernel_generator,
-        pallas_kernel=_jitc_uniform_matrix_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_uniform_matrix_warp_kernel_generator,
+    pallas=_jitc_uniform_matrix_pallas_kernel_generator,
 )
 float_jitc_uniform_matrix_p.def_tpu_kernel(_jitc_uniform_matrix_pallas_kernel_generator)
 float_jitc_uniform_matrix_p.def_jvp_rule2(
@@ -1486,11 +1484,9 @@ def float_jitc_mv_uniform_p_call(
 float_jitc_mv_uniform_p = XLACustomKernel('float_jitc_mv_uniform')
 float_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 float_jitc_mv_uniform_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mv_uniform_warp_kernel_generator,
-        pallas_kernel=_jitc_mv_uniform_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mv_uniform_warp_kernel_generator,
+    pallas=_jitc_mv_uniform_pallas_kernel_generator,
 )
 float_jitc_mv_uniform_p.def_tpu_kernel(_jitc_mv_uniform_pallas_kernel_generator)
 float_jitc_mv_uniform_p.def_jvp_rule2(
@@ -2160,13 +2156,10 @@ def float_jitc_mm_uniform_p_call(
 float_jitc_mm_uniform_p = XLACustomKernel('float_jitc_mm_uniform')
 float_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 float_jitc_mm_uniform_p.def_gpu_kernel(
-    GPUKernelChoice(
-        default='warp',
-        warp_kernel=_jitc_mm_uniform_warp_kernel_generator,
-        pallas_kernel=_jitc_mm_uniform_pallas_kernel_generator,
-    )
+    default='warp',
+    warp=_jitc_mm_uniform_warp_kernel_generator,
+    pallas=_jitc_mm_uniform_pallas_kernel_generator,
 )
-float_jitc_mm_uniform_p.def_gpu_kernel(_jitc_mm_uniform_pallas_kernel_generator)
 float_jitc_mm_uniform_p.def_jvp_rule2(
     _jitc_mm_uniform_jvp_wlow,
     _jitc_mm_uniform_jvp_whigh,

--- a/brainevent/_jitc_float_uniform_impl.py
+++ b/brainevent/_jitc_float_uniform_impl.py
@@ -2160,6 +2160,7 @@ float_jitc_mm_uniform_p.def_gpu_kernel(
     warp=_jitc_mm_uniform_warp_kernel_generator,
     pallas=_jitc_mm_uniform_pallas_kernel_generator,
 )
+float_jitc_mm_uniform_p.def_tpu_kernel(_jitc_mm_uniform_pallas_kernel_generator)
 float_jitc_mm_uniform_p.def_jvp_rule2(
     _jitc_mm_uniform_jvp_wlow,
     _jitc_mm_uniform_jvp_whigh,

--- a/brainevent/_jitc_float_uniform_impl.py
+++ b/brainevent/_jitc_float_uniform_impl.py
@@ -28,10 +28,10 @@ from ._misc import generate_block_dim
 from ._pallas_random import LFSR88RNG
 from ._typing import Data, MatrixShape
 from ._xla_custom_op import XLACustomKernel, GPUKernelChoice
-from ._xla_custom_op_numba import NumbaKernelGenerator, numba_kernel
-from ._xla_custom_op_pallas import PallasKernelGenerator
+from ._xla_custom_op_numba import numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import dtype_to_warp_type, WarpKernelGenerator, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
 
 __all__ = [
     "float_jitc_uniform_matrix",
@@ -281,10 +281,10 @@ def _jitc_uniform_matrix_warp_kernel_generator(
 ):
     import warp
 
-    w_low_dtype = dtype_to_warp_type(w_low_info.dtype)
-    w_high_dtype = dtype_to_warp_type(w_high_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_low_dtype = jaxtype_to_warptype(w_low_info.dtype)
+    w_high_dtype = jaxtype_to_warptype(w_high_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if transpose:
@@ -469,7 +469,6 @@ def _jitc_uniform_matrix_warp_kernel_generator(
 
 def _jitc_uniform_matrix_pallas_kernel_generator(
     out_info: jax.ShapeDtypeStruct,
-    transpose: bool = False,
     corder: bool = True,
     **kwargs
 ):
@@ -547,14 +546,12 @@ def _jitc_uniform_matrix_pallas_kernel_generator(
                     (i_rows, i_row_mask, rng)
                 )
 
-        def kernel(w_low, w_high, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={4: 0},
-            )
-            return [fn(w_low, w_high, clen, seed, out)]
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={4: 0},
+        )
 
     else:
         if corder:
@@ -616,15 +613,12 @@ def _jitc_uniform_matrix_pallas_kernel_generator(
                     (rng.random_integers(0, clen), rng)
                 )
 
-        def kernel(w_low, w_high, clen, seed, out):
-            fn = pl.pallas_call(
-                _raw_kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,), input_output_aliases={4: 0},
-            )
-            return [fn(w_low, w_high, clen, seed, out)]
-
-    return kernel
+        return pallas_kernel(
+            _raw_kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={4: 0},
+        )
 
 
 def _jitc_uniform_matrix_jvp_wlow(
@@ -739,15 +733,15 @@ def float_jitc_uniform_matrix_p_call(
 
 
 float_jitc_uniform_matrix_p = XLACustomKernel('float_jitc_uniform_matrix')
-float_jitc_uniform_matrix_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_uniform_matrix_numba_kernel_generator))
+float_jitc_uniform_matrix_p.def_cpu_kernel(_jitc_uniform_matrix_numba_kernel_generator)
 float_jitc_uniform_matrix_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_uniform_matrix_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_uniform_matrix_pallas_kernel_generator),
+        warp_kernel=_jitc_uniform_matrix_warp_kernel_generator,
+        pallas_kernel=_jitc_uniform_matrix_pallas_kernel_generator,
     )
 )
-float_jitc_uniform_matrix_p.def_tpu_kernel(PallasKernelGenerator(_jitc_uniform_matrix_pallas_kernel_generator))
+float_jitc_uniform_matrix_p.def_tpu_kernel(_jitc_uniform_matrix_pallas_kernel_generator)
 float_jitc_uniform_matrix_p.def_jvp_rule2(
     _jitc_uniform_matrix_jvp_wlow,
     _jitc_uniform_matrix_jvp_whigh,
@@ -954,11 +948,11 @@ def _jitc_mv_uniform_warp_kernel_generator(
 ):
     import warp
 
-    w_low_dtype = dtype_to_warp_type(w_low_info.dtype)
-    w_high_dtype = dtype_to_warp_type(w_high_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    v_dtype = dtype_to_warp_type(vector_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_low_dtype = jaxtype_to_warptype(w_low_info.dtype)
+    w_high_dtype = jaxtype_to_warptype(w_high_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    v_dtype = jaxtype_to_warptype(vector_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
 
@@ -1215,14 +1209,12 @@ def _jitc_mv_uniform_pallas_kernel_generator(
                     (i_cols, i_col_mask, rng)
                 )
 
-        def final_kernel(w_low, w_high, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(pl.cdiv(dim, block_size),),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_low, w_high, clen, vector, seed, out)]
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(pl.cdiv(dim, block_size),),
+            input_output_aliases={5: 0},
+        )
 
     else:
         if corder:
@@ -1272,16 +1264,12 @@ def _jitc_mv_uniform_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-        def final_kernel(w_low, w_high, clen, vector, seed, out):
-            fn = pl.pallas_call(
-                kernel,
-                out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-                grid=(dim,),
-                input_output_aliases={5: 0},
-            )
-            return [fn(w_low, w_high, clen, vector, seed, out)]
-
-    return final_kernel
+        return pallas_kernel(
+            kernel,
+            outs=kwargs['outs'],
+            tile=(dim,),
+            input_output_aliases={5: 0},
+        )
 
 
 def _jitc_mv_uniform_jvp_v(
@@ -1496,16 +1484,15 @@ def float_jitc_mv_uniform_p_call(
 
 
 float_jitc_mv_uniform_p = XLACustomKernel('float_jitc_mv_uniform')
-float_jitc_mv_uniform_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mv_uniform_numba_kernel_generator))
+float_jitc_mv_uniform_p.def_cpu_kernel(_jitc_mv_uniform_numba_kernel_generator)
 float_jitc_mv_uniform_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mv_uniform_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mv_uniform_pallas_kernel_generator),
+        warp_kernel=_jitc_mv_uniform_warp_kernel_generator,
+        pallas_kernel=_jitc_mv_uniform_pallas_kernel_generator,
     )
 )
-float_jitc_mv_uniform_p.def_gpu_kernel(WarpKernelGenerator(_jitc_mv_uniform_warp_kernel_generator))
-float_jitc_mv_uniform_p.def_tpu_kernel(PallasKernelGenerator(_jitc_mv_uniform_pallas_kernel_generator))
+float_jitc_mv_uniform_p.def_tpu_kernel(_jitc_mv_uniform_pallas_kernel_generator)
 float_jitc_mv_uniform_p.def_jvp_rule2(
     _jitc_mv_uniform_jvp_wlow,
     _jitc_mv_uniform_jvp_whigh,
@@ -1685,11 +1672,11 @@ def _jitc_mm_uniform_warp_kernel_generator(
 ):
     import warp
 
-    w_low_dtype = dtype_to_warp_type(w_low_info.dtype)
-    w_high_dtype = dtype_to_warp_type(w_high_info.dtype)
-    clen_dtype = dtype_to_warp_type(clen_info.dtype)
-    B_dtype = dtype_to_warp_type(B_info.dtype)
-    seed_dtype = dtype_to_warp_type(seed_info.dtype)
+    w_low_dtype = jaxtype_to_warptype(w_low_info.dtype)
+    w_high_dtype = jaxtype_to_warptype(w_high_info.dtype)
+    clen_dtype = jaxtype_to_warptype(clen_info.dtype)
+    B_dtype = jaxtype_to_warptype(B_info.dtype)
+    seed_dtype = jaxtype_to_warptype(seed_info.dtype)
 
     if corder:
         if transpose:
@@ -1948,18 +1935,16 @@ def _jitc_mm_uniform_pallas_kernel_generator(
                     (rng.random_integers(0, clen0), rng)
                 )
 
-    tile = (out_info.shape[0] if corder else B_info.shape[0])
-
-    def final_kernel(w_low, w_high, clen, B, seed, out):
-        fn = pl.pallas_call(
-            kernel,
-            grid=(tile, pl.cdiv(B_info.shape[1], block_dim)),
-            input_output_aliases={5: 0},
-            out_shape=jax.ShapeDtypeStruct(out.shape, out.dtype),
-        )
-        return [fn(w_low, w_high, clen, B, seed, out)]
-
-    return final_kernel
+    tile = (
+        out_info.shape[0] if corder else B_info.shape[0],
+        pl.cdiv(B_info.shape[1], block_dim)
+    )
+    return pallas_kernel(
+        kernel,
+        tile=tile,
+        outs=kwargs['outs'],
+        input_output_aliases={5: 0}
+    )
 
 
 def _jitc_mm_uniform_jvp_wlow(
@@ -2173,15 +2158,15 @@ def float_jitc_mm_uniform_p_call(
 
 
 float_jitc_mm_uniform_p = XLACustomKernel('float_jitc_mm_uniform')
-float_jitc_mm_uniform_p.def_cpu_kernel(NumbaKernelGenerator(_jitc_mm_uniform_numba_kernel_generator))
+float_jitc_mm_uniform_p.def_cpu_kernel(_jitc_mm_uniform_numba_kernel_generator)
 float_jitc_mm_uniform_p.def_gpu_kernel(
     GPUKernelChoice(
         default='warp',
-        warp_kernel=WarpKernelGenerator(_jitc_mm_uniform_warp_kernel_generator),
-        pallas_kernel=PallasKernelGenerator(_jitc_mm_uniform_pallas_kernel_generator),
+        warp_kernel=_jitc_mm_uniform_warp_kernel_generator,
+        pallas_kernel=_jitc_mm_uniform_pallas_kernel_generator,
     )
 )
-float_jitc_mm_uniform_p.def_gpu_kernel(PallasKernelGenerator(_jitc_mm_uniform_pallas_kernel_generator))
+float_jitc_mm_uniform_p.def_gpu_kernel(_jitc_mm_uniform_pallas_kernel_generator)
 float_jitc_mm_uniform_p.def_jvp_rule2(
     _jitc_mm_uniform_jvp_wlow,
     _jitc_mm_uniform_jvp_whigh,

--- a/brainevent/_typing.py
+++ b/brainevent/_typing.py
@@ -55,6 +55,9 @@ Indptr = Index
 # A callable type, representing a function or method.
 Kernel = Callable
 
+# kernel function generator
+KernelGenerator = Callable[..., Kernel]
+
 # Represents a scalar weight value, which can be a number, NumPy array, JAX array, or BrainUnit quantity.
 WeightScalar = Union[numbers.Number, np.ndarray, jax.Array, u.Quantity]
 

--- a/brainevent/_xla_custom_op.py
+++ b/brainevent/_xla_custom_op.py
@@ -406,6 +406,12 @@ class XLACustomKernel:
             TypeError: If `kernel_generator` is not an instance of
                        `KernelGenerator` or `KernelGenerator`.
         """
+        if default is not None:
+            assert isinstance(default, str), (
+                f'The `default` should be a string, but got '
+                f'{type(default)}'
+            )
+
         if len(kernel_generator) == 0:
             raise TypeError('The `kernel_generator` should provide at least one GPU kernel generator, '
                             'such as "warp" or "pallas".')
@@ -416,15 +422,19 @@ class XLACustomKernel:
                 register_pallas_gpu_translation(self.primitive, kernel_generator['pallas'])
             else:
                 raise TypeError('The `kernel_generator` should provide only one GPU kernel generator, '
-                            'such as "warp" or "pallas".')
+                                'such as "warp" or "pallas".')
         else:
             self.def_multiple_gpu_kernels(default=default, **kernel_generator)
 
     def def_multiple_gpu_kernels(self, default: str = None, **kernel_generator):
-        assert default is not None, ('The `default` should be provided when '
-                                     'multiple `kernel_generator` is provided.')
-        assert default in kernel_generator, ('The `default` should be one of '
-                                             f'{list(kernel_generator.keys())}.')
+        assert default is not None, (
+            'The `default` should be provided when '
+            'multiple `kernel_generator` is provided.'
+        )
+        assert default in kernel_generator, (
+            'The `default` should be one of '
+            f'{list(kernel_generator.keys())}.'
+        )
         self._gpu_kernel_choice = GPUKernelChoice(
             default=default,
             warp_kernel=kernel_generator.get('warp'),

--- a/brainevent/_xla_custom_op.py
+++ b/brainevent/_xla_custom_op.py
@@ -16,7 +16,7 @@
 # -*- coding: utf-8 -*-
 
 import functools
-from typing import Callable, Sequence, Tuple, Protocol, Union, Optional
+from typing import Callable, Sequence, Tuple, Protocol, Union, Optional, Dict
 
 import jax
 import numpy as np
@@ -24,23 +24,14 @@ from jax.interpreters import xla, mlir, batching, ad
 
 from ._compatible_import import Primitive
 from ._config import config
-from ._xla_custom_op_numba import (
-    NumbaKernelGenerator,
-    register_numba_cpu_translation
-)
+from ._xla_custom_op_numba import register_numba_cpu_translation
 from ._xla_custom_op_pallas import (
-    PallasKernelGenerator,
     register_pallas_gpu_translation,
     register_pallas_tpu_translation
 )
-from ._xla_custom_op_util import (
-    general_batching_rule,
-    defjvp,
-)
-from ._xla_custom_op_warp import (
-    WarpKernelGenerator,
-    register_warp_gpu_translation
-)
+from ._xla_custom_op_util import general_batching_rule, defjvp
+from ._xla_custom_op_warp import register_warp_gpu_translation
+from ._typing import KernelGenerator
 
 __all__ = [
     'XLACustomKernel',
@@ -106,25 +97,25 @@ class GPUKernelChoice:
 
     Attributes:
         default (str): The default kernel backend to use ('warp' or 'pallas').
-        warp_kernel (Optional[WarpKernelGenerator]): The Warp kernel implementation.
-        pallas_kernel (Optional[PallasKernelGenerator]): The Pallas kernel implementation.
+        warp_kernel (Optional[KernelGenerator]): The Warp kernel implementation.
+        pallas_kernel (Optional[KernelGenerator]): The Pallas kernel implementation.
         _all_kernels (dict): Dictionary mapping backend names to kernel implementations.
     """
 
     def __init__(
         self,
         default: str,
-        warp_kernel: Optional[WarpKernelGenerator] = None,
-        pallas_kernel: Optional[PallasKernelGenerator] = None,
+        warp_kernel: Optional[KernelGenerator] = None,
+        pallas_kernel: Optional[KernelGenerator] = None,
     ):
         """Initialize a GPU kernel choice with Warp and/or Pallas implementations.
 
         Args:
             default (str): The default kernel type to use. Must be either 'warp' or 'pallas',
                 and the corresponding kernel must be provided.
-            warp_kernel (Optional[WarpKernelGenerator]): The Warp kernel implementation.
+            warp_kernel (Optional[KernelGenerator]): The Warp kernel implementation.
                 Defaults to None.
-            pallas_kernel (Optional[PallasKernelGenerator]): The Pallas kernel implementation.
+            pallas_kernel (Optional[KernelGenerator]): The Pallas kernel implementation.
                 Defaults to None.
 
         Raises:
@@ -151,7 +142,7 @@ class GPUKernelChoice:
             f"default must be one of {list(self._all_kernels.keys())}."
         )
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Dict:
         """Select and return the appropriate kernel implementation based on configuration.
 
         This method allows the GPUKernelChoice instance to be called like a function.
@@ -161,9 +152,6 @@ class GPUKernelChoice:
         Args:
             *args: Variable positional arguments passed to the kernel implementation.
             **kwargs: Variable keyword arguments passed to the kernel implementation.
-
-        Returns:
-            Union[WarpKernelGenerator, PallasKernelGenerator]: The selected kernel implementation.
         """
         if config.gpu_kernel_backend == 'default':
             backend = self.default
@@ -171,7 +159,7 @@ class GPUKernelChoice:
             backend = config.gpu_kernel_backend
         else:
             backend = self.default
-        return self._all_kernels[backend]
+        return {backend: self._all_kernels[backend]}
 
 
 class XLACustomKernel:
@@ -185,8 +173,8 @@ class XLACustomKernel:
     rules like batching, JVP (forward-mode AD), and transpose (reverse-mode AD).
 
     The core idea is to define the computation logic once for each relevant
-    backend using specialized kernel generators (:class:`NumbaKernelGenerator`,
-    :class:`PallasKernelGenerator`, :class:`WarpKernelGenerator`) and then use this class
+    backend using specialized kernel generators (:class:`KernelGenerator`,
+    :class:`KernelGenerator`, :class:`KernelGenerator`) and then use this class
     to bind everything together into a callable JAX operation.
 
     Attributes:
@@ -195,14 +183,14 @@ class XLACustomKernel:
 
     Args:
         name (str): The unique name for the custom JAX primitive.
-        cpu_kernel (Optional[NumbaKernelGenerator]): An instance of
-            `NumbaKernelGenerator` defining the computation for the CPU backend.
+        cpu_kernel (Optional[KernelGenerator]): An instance of
+            `KernelGenerator` defining the computation for the CPU backend.
             Defaults to None.
-        gpu_kernel (Optional[Union[PallasKernelGenerator, WarpKernelGenerator]]):
-            An instance of `PallasKernelGenerator` or `WarpKernelGenerator`
+        gpu_kernel (Optional[Union[KernelGenerator, KernelGenerator]]):
+            An instance of `KernelGenerator` or `KernelGenerator`
             defining the computation for the GPU backend. Defaults to None.
-        tpu_kernel (Optional[PallasKernelGenerator]): An instance of
-            `PallasKernelGenerator` defining the computation for the TPU backend.
+        tpu_kernel (Optional[KernelGenerator]): An instance of
+            `KernelGenerator` defining the computation for the TPU backend.
             Defaults to None.
         batching_translation (Optional[Callable]): A function defining a custom
             batching rule for the primitive. If None, a general batching rule
@@ -217,63 +205,6 @@ class XLACustomKernel:
             `jax.linear_transpose`). See `jax.interpreters.ad.primitive_transposes`.
             Defaults to None.
 
-    Examples:
-
-    .. code-block:: python
-
-        >>> import jax
-        >>> import jax.numpy as jnp
-        >>> import numpy as np
-        >>> import brainevent
-        >>>
-        >>> # --- Define Kernel Generators (Conceptual) ---
-        >>> class MyAddCPUImpl(brainevent.NumbaKernelGenerator):
-        ...     # ... (Implementation details for Numba kernel) ...
-        ...     def generate_kernel(self, ctx, *args, **kwargs):
-        ...         def _kernel(a, b, out):
-        ...             # Simplified Numba kernel logic
-        ...             for i in range(a.shape[0]): out[i] = a[i] + b[i]
-        ...         return _kernel
-        ...     # ... (get_layouts, get_grid_size etc.) ...
-        >>>
-        >>> class MyAddGPUImpl(brainevent.PallasKernelGenerator):
-        ...     # ... (Implementation details for Pallas kernel) ...
-        ...     def generate_kernel(self, ctx, *args, **kwargs):
-        ...         import jax.experimental.pallas as pl
-        ...         def _kernel(a_ref, b_ref, out_ref):
-        ...             # Simplified Pallas kernel logic
-        ...             idx = pl.program_id(axis=0)
-        ...             out_ref[idx] = a_ref[idx] + b_ref[idx]
-        ...         return _kernel
-        ...     # ... (get_grid_spec, get_input_output_aliases etc.) ...
-        >>>
-        >>> # --- Create the XLACustomKernel ---
-        >>> my_add_op = brainevent.XLACustomKernel(
-        ...     name='my_custom_add',
-        ...     cpu_kernel=MyAddCPUImpl(),
-        ...     gpu_kernel=MyAddGPUImpl()
-        ... )
-        >>>
-        >>> # --- Define Output Specification ---
-        >>> # Helper class or object with shape and dtype attributes
-        >>> class OutputSpec:
-        ...     def __init__(self, shape, dtype):
-        ...         self.shape = shape
-        ...         self.dtype = dtype
-        >>>
-        >>> # --- Call the Custom Operation ---
-        >>> @jax.jit
-        ... def use_custom_op(x, y):
-        ...     # Specify the expected output shape and dtype
-        ...     out_spec = OutputSpec(shape=x.shape, dtype=x.dtype)
-        ...     # Call the kernel like a function
-        ...     return my_add_op(x, y, outs=out_spec)
-        >>>
-        >>> a = jnp.array([1.0, 2.0, 3.0])
-        >>> b = jnp.array([4.0, 5.0, 6.0])
-        >>> result = use_custom_op(a, b)
-        >>> print(result)
-        [5. 7. 9.] # Output depends on backend and kernel implementation
     """
 
     __module__ = 'brainevent'
@@ -281,9 +212,6 @@ class XLACustomKernel:
     def __init__(
         self,
         name: str,
-        cpu_kernel: Optional[NumbaKernelGenerator] = None,
-        gpu_kernel: Optional[Union[PallasKernelGenerator, WarpKernelGenerator, GPUKernelChoice]] = None,
-        tpu_kernel: Optional[PallasKernelGenerator] = None,
         batching_translation: Callable = None,
         jvp_translation: Callable = None,
         transpose_translation: Callable = None,
@@ -295,19 +223,6 @@ class XLACustomKernel:
         # abstract evaluation
         self.primitive.def_impl(functools.partial(xla.apply_primitive, self.primitive))
         self.primitive.def_abstract_eval(self._abstract_eval)
-
-        # cpu kernel
-        if cpu_kernel is not None:
-            self.def_cpu_kernel(cpu_kernel)
-
-        # gpu kernel
-        self._gpu_kernel_choice = None
-        if gpu_kernel is not None:
-            self.def_gpu_kernel(gpu_kernel)
-
-        # tpu kernel
-        if tpu_kernel is not None:
-            self.def_tpu_kernel(tpu_kernel)
 
         # batching rule
         if batching_translation is not None:
@@ -323,6 +238,9 @@ class XLACustomKernel:
 
         # batching rule
         self.register_general_batching()
+
+        # multiple gpu kernels
+        self._gpu_kernel_choice = None
 
     def _abstract_eval(
         self,
@@ -448,12 +366,9 @@ class XLACustomKernel:
 
     def ready_to_call(self):
         if self._gpu_kernel_choice is not None:
-            self.def_gpu_kernel(self._gpu_kernel_choice())
+            self.def_gpu_kernel(**self._gpu_kernel_choice())
 
-    def def_cpu_kernel(
-        self,
-        kernel_generator: NumbaKernelGenerator
-    ):
+    def def_cpu_kernel(self, kernel_generator: Callable):
         """
         Defines and registers the CPU kernel implementation using Numba.
 
@@ -462,21 +377,19 @@ class XLACustomKernel:
         generator.
 
         Args:
-            kernel_generator: An instance of `NumbaKernelGenerator` responsible
+            kernel_generator: An instance of `KernelGenerator` responsible
                               for generating the Numba jitted kernel function.
 
         Raises:
             TypeError: If `kernel_generator` is not an instance of
-                       `NumbaKernelGenerator`.
+                       `KernelGenerator`.
         """
-        if not isinstance(kernel_generator, NumbaKernelGenerator):
-            raise TypeError('The `kernel_generator` should be an instance of `NumbaKernel`.')
+        if not callable(kernel_generator):
+            raise TypeError('The `kernel_generator` should be an instance of callable functions to '
+                            'generate the Numba jitted kernel function.')
         register_numba_cpu_translation(self.primitive, kernel_generator)
 
-    def def_gpu_kernel(
-        self,
-        kernel_generator: Union[PallasKernelGenerator, WarpKernelGenerator, GPUKernelChoice]
-    ):
+    def def_gpu_kernel(self, default: str = None, **kernel_generator):
         """
         Defines and registers the GPU kernel implementation using JAX Pallas or Warp.
 
@@ -485,30 +398,40 @@ class XLACustomKernel:
         the appropriate registration function.
 
         Args:
-            kernel_generator: An instance of `PallasKernelGenerator` or
-                              `WarpKernelGenerator` responsible for generating the
+            kernel_generator: An instance of `KernelGenerator` or
+                              `KernelGenerator` responsible for generating the
                               GPU kernel function.
 
         Raises:
             TypeError: If `kernel_generator` is not an instance of
-                       `PallasKernelGenerator` or `WarpKernelGenerator`.
+                       `KernelGenerator` or `KernelGenerator`.
         """
-        if isinstance(kernel_generator, PallasKernelGenerator):
-            register_pallas_gpu_translation(self.primitive, kernel_generator)
-
-        elif isinstance(kernel_generator, WarpKernelGenerator):
-            register_warp_gpu_translation(self.primitive, kernel_generator)
-
-        elif isinstance(kernel_generator, GPUKernelChoice):
-            self._gpu_kernel_choice = kernel_generator
-
+        if len(kernel_generator) == 0:
+            raise TypeError('The `kernel_generator` should provide at least one GPU kernel generator, '
+                            'such as "warp" or "pallas".')
+        elif len(kernel_generator) == 1:
+            if 'warp' in kernel_generator:
+                register_warp_gpu_translation(self.primitive, kernel_generator['warp'])
+            elif 'pallas' in kernel_generator:
+                register_pallas_gpu_translation(self.primitive, kernel_generator['pallas'])
+            else:
+                raise TypeError('The `kernel_generator` should provide only one GPU kernel generator, '
+                            'such as "warp" or "pallas".')
         else:
-            raise TypeError('The `kernel_generator` should be an instance of `PallasKernel` or `WarpKernel`.')
+            self.def_multiple_gpu_kernels(default=default, **kernel_generator)
 
-    def def_tpu_kernel(
-        self,
-        kernel_generator: PallasKernelGenerator
-    ):
+    def def_multiple_gpu_kernels(self, default: str = None, **kernel_generator):
+        assert default is not None, ('The `default` should be provided when '
+                                     'multiple `kernel_generator` is provided.')
+        assert default in kernel_generator, ('The `default` should be one of '
+                                             f'{list(kernel_generator.keys())}.')
+        self._gpu_kernel_choice = GPUKernelChoice(
+            default=default,
+            warp_kernel=kernel_generator.get('warp'),
+            pallas_kernel=kernel_generator.get('pallas'),
+        )
+
+    def def_tpu_kernel(self, kernel_generator: Callable):
         """
         Defines and registers the TPU kernel implementation using JAX Pallas.
 
@@ -516,7 +439,7 @@ class XLACustomKernel:
         for execution on TPU backends.
 
         Args:
-            kernel_generator: An instance of `PallasKernelGenerator` responsible
+            kernel_generator: An instance of `KernelGenerator` responsible
                               for generating the TPU kernel function.
         """
         register_pallas_tpu_translation(self.primitive, kernel_generator)

--- a/brainevent/_xla_custom_op_numba.py
+++ b/brainevent/_xla_custom_op_numba.py
@@ -16,7 +16,6 @@
 # -*- coding: utf-8 -*-
 
 import ctypes
-import dataclasses
 import functools
 import importlib.util
 from typing import Callable, Dict, Optional, NamedTuple, Union
@@ -24,8 +23,8 @@ from typing import Callable, Dict, Optional, NamedTuple, Union
 from jax.interpreters import mlir
 
 from ._compatible_import import register_custom_call, Primitive, custom_call
-from ._typing import KernelGenerator
 from ._config import config
+from ._typing import KernelGenerator
 
 __all__ = [
     'numba_kernel',

--- a/brainevent/_xla_custom_op_numba_test.py
+++ b/brainevent/_xla_custom_op_numba_test.py
@@ -33,10 +33,6 @@ if numba_installed:
 @pytest.mark.skipif(not numba_installed, reason="Numba not installed")
 class TestNumbaCPU(unittest.TestCase):
     def test1(self):
-        def add_vectors_kernel(x_ref, y_ref, o_ref):
-            x, y = x_ref[...], y_ref[...]
-            o_ref[...] = x + y
-
         def cpu_kernel(**kwargs):
             @brainevent.numba_kernel
             def add_kernel_numba(x, y, out):
@@ -45,22 +41,20 @@ class TestNumbaCPU(unittest.TestCase):
             return add_kernel_numba
 
         def gpu_kernel(x_info, **kwargs):
-            return pl.pallas_call(
+            def add_vectors_kernel(x_ref, y_ref, o_ref):
+                x, y = x_ref[...], y_ref[...]
+                o_ref[...] = x + y
+
+            return brainevent.pallas_kernel(
                 add_vectors_kernel,
-                out_shape=[jax.ShapeDtypeStruct(x_info.shape, x_info.dtype)],
-                interpret=jax.default_backend() == 'cpu',
+                outs=kwargs['outs'],
             )
 
-        prim = brainevent.XLACustomKernel(
-            'add',
-            cpu_kernel=brainevent.NumbaKernelGenerator(cpu_kernel),
-            gpu_kernel=brainevent.PallasKernelGenerator(gpu_kernel),
-        )
+        prim = brainevent.XLACustomKernel( 'add')
+        prim.def_cpu_kernel(cpu_kernel)
+        prim.def_gpu_kernel(pallas=gpu_kernel)
 
         a = bst.random.rand(64)
         b = bst.random.rand(64)
         x_info = jax.ShapeDtypeStruct(a.shape, a.dtype)
         r1 = prim(a, b, outs=[jax.ShapeDtypeStruct((64,), jax.numpy.float32)], x_info=x_info)
-        r2 = gpu_kernel(x_info)(a, b)
-
-        assert jnp.allclose(r1[0], r2[0])

--- a/brainevent/_xla_custom_op_warp.py
+++ b/brainevent/_xla_custom_op_warp.py
@@ -16,7 +16,6 @@
 # -*- coding: utf-8 -*-
 
 import ctypes
-import dataclasses
 import functools
 import importlib.util
 from typing import Callable, Sequence, Dict, Union, NamedTuple
@@ -30,7 +29,7 @@ from ._compatible_import import Primitive, register_custom_call, custom_call
 from ._typing import KernelGenerator
 
 __all__ = [
-    'dtype_to_warp_type',
+    'jaxtype_to_warptype',
     'jaxinfo_to_warpinfo',
     'warp_kernel',
 ]
@@ -183,7 +182,7 @@ def warp_kernel(
     )
 
 
-def dtype_to_warp_type(dtype):
+def jaxtype_to_warptype(dtype):
     """
     Convert the JAX dtype to the Warp type.
 
@@ -258,7 +257,7 @@ def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct):
     --------
     dtype_to_warp_type : Function to convert numpy/JAX dtypes to Warp types.
     """
-    dtype = dtype_to_warp_type(jax_info.dtype)
+    dtype = jaxtype_to_warptype(jax_info.dtype)
     shape = jax_info.shape
     return warp.array(dtype=dtype, ndim=len(shape))
 

--- a/brainevent/_xla_custom_op_warp_test.py
+++ b/brainevent/_xla_custom_op_warp_test.py
@@ -59,7 +59,7 @@ class TestWarpGPU(unittest.TestCase):
     def test_warp_change_with_dtype(self):
         def generate(**kwargs):
             outs = kwargs["outs"][0]
-            dtype = brainevent.dtype_to_warp_type(outs.dtype)
+            dtype = brainevent.jaxtype_to_warptype(outs.dtype)
 
             # generic kernel definition using Any as a placeholder for concrete types
             @wp.kernel

--- a/docs/apis/operator.rst
+++ b/docs/apis/operator.rst
@@ -27,11 +27,7 @@ CPU kernel definition using Numba.
    :toctree: generated/
    :template: classtemplate.rst
 
-    NumbaKernelGenerator
     numba_kernel
-    set_numba_environ
-    numba_environ_context
-
 
 
 GPU kernel definition using Warp.
@@ -40,9 +36,9 @@ GPU kernel definition using Warp.
    :toctree: generated/
    :template: classtemplate.rst
 
-    WarpKernelGenerator
     warp_kernel
-    dtype_to_warp_type
+    jaxtype_to_warptype
+    jaxinfo_to_warpinfo
 
 
 
@@ -52,7 +48,7 @@ GPU/TPU kernel definition using JAX Pallas.
    :toctree: generated/
    :template: classtemplate.rst
 
-    PallasKernelGenerator
+    pallas_kernel
     LFSR88RNG
     LFSR113RNG
     LFSR128RNG


### PR DESCRIPTION
## Summary by Sourcery

Unify and simplify kernel generation APIs across CPU, GPU (Warp, Pallas) backends by removing generator wrapper classes and consolidating on direct use of numba_kernel, warp_kernel, and a new pallas_kernel function.

New Features:
- Introduce a unified pallas_kernel function for defining Pallas kernels.
- Define a KernelGenerator alias in typing for stronger API typing.

Enhancements:
- Remove PallasKernelGenerator, NumbaKernelGenerator, and WarpKernelGenerator classes in favor of direct kernel functions.
- Rename dtype_to_warp_type to jaxtype_to_warptype and update warp_kernel signature to streamline Warp kernel creation.
- Simplify custom operation registrations to use generator callables directly in def_cpu_kernel/def_gpu_kernel/def_tpu_kernel.
- Bulk update codebase to use the new kernel API and remove obsolete abstractions.

Documentation:
- Adjust operator documentation to reflect the new kernel API names.

Tests:
- Update existing tests to reference jaxtype_to_warptype instead of the old dtype_to_warp_type.

Chores:
- Perform a repository-wide refactoring to replace legacy generator patterns and clean up exports in __init__.