### PR TITLE
Feat: Add CSR/CSC diagonal updates and sparse solve

### DIFF
--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from ._array_base import BaseArray
 from ._array_binary import BinaryArray, EventArray

--- a/brainevent/_csr.py
+++ b/brainevent/_csr.py
@@ -29,6 +29,7 @@ from ._csr_impl_binary import binary_csr_matvec, binary_csr_matmat
 from ._csr_impl_diag_add import csr_diag_position_v2, csr_diag_add_v2
 from ._csr_impl_float import csr_matvec, csr_matmat
 from ._csr_impl_masked_float import masked_float_csr_matvec, masked_float_csr_matmat
+from ._csr_impl_spsolve import csr_solve
 from ._misc import _csr_to_coo, _csr_todense
 from ._typing import Data, Indptr, Index, MatrixShape
 
@@ -226,6 +227,25 @@ class BaseCLS(u.sparse.SparseMatrix):
         return self.with_data(
             csr_diag_add_v2(self.data, self.diag_positions, other)
         )
+
+    def solve(self, b: Union[jax.Array, u.Quantity]) -> Union[jax.Array, u.Quantity]:
+        """
+        Solve the linear system Ax = b where A is the sparse matrix.
+
+        This method uses JAX's sparse solver to solve the equation Ax = b,
+        where A is the current sparse matrix and b is the right-hand side vector.
+
+        Parameters
+        ----------
+        b : array_like
+            The right-hand side vector of the linear system.
+
+        Returns
+        -------
+        x : jax.Array or u.Quantity
+            The solution vector x that satisfies Ax = b.
+        """
+        raise NotImplementedError
 
 
 @jax.tree_util.register_pytree_node_class
@@ -560,6 +580,29 @@ class CSR(BaseCLS):
                 return r.T
             else:
                 raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+    def solve(self, b: Union[jax.Array, u.Quantity], tol=1e-6, reorder=1) -> Union[jax.Array, u.Quantity]:
+        """
+        Solve the linear system Ax = b where A is the sparse matrix.
+
+        This method uses JAX's sparse solver to solve the equation Ax = b,
+        where A is the current sparse matrix and b is the right-hand side vector.
+
+        Parameters
+        ----------
+        b : array_like
+            The right-hand side vector of the linear system.
+        tol : Tolerance to decide if singular or not. Defaults to 1e-6.
+        reorder : The reordering scheme to use to reduce fill-in. No reordering if
+            ``reorder=0``. Otherwise, symrcm, symamd, or csrmetisnd (``reorder=1,2,3``),
+            respectively. Defaults to symrcm.
+
+        Returns
+        -------
+        x : jax.Array or u.Quantity
+            The solution vector x that satisfies Ax = b.
+        """
+        return csr_solve(self.data, self.indices, self.indptr, b)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -896,3 +939,26 @@ class CSC(BaseCLS):
                 return r.T
             else:
                 raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+    def solve(self, b: Union[jax.Array, u.Quantity], tol=1e-6, reorder=1) -> Union[jax.Array, u.Quantity]:
+        """
+        Solve the linear system Ax = b where A is the sparse matrix.
+
+        This method uses JAX's sparse solver to solve the equation Ax = b,
+        where A is the current sparse matrix and b is the right-hand side vector.
+
+        Parameters
+        ----------
+        b : array_like
+            The right-hand side vector of the linear system.
+        tol : Tolerance to decide if singular or not. Defaults to 1e-6.
+        reorder : The reordering scheme to use to reduce fill-in. No reordering if
+            ``reorder=0``. Otherwise, symrcm, symamd, or csrmetisnd (``reorder=1,2,3``),
+            respectively. Defaults to symrcm.
+
+        Returns
+        -------
+        x : jax.Array or u.Quantity
+            The solution vector x that satisfies Ax = b.
+        """
+        return self.T.solve(b, tol=tol, reorder=reorder)

--- a/brainevent/_csr.py
+++ b/brainevent/_csr.py
@@ -602,6 +602,8 @@ class CSR(BaseCLS):
         x : jax.Array or u.Quantity
             The solution vector x that satisfies Ax = b.
         """
+        assert self.shape[0] == b.shape[0], ("The number of rows in the matrix must match "
+                                             "the size of the right-hand side vector b.")
         return csr_solve(self.data, self.indices, self.indptr, b)
 
 
@@ -961,4 +963,6 @@ class CSC(BaseCLS):
         x : jax.Array or u.Quantity
             The solution vector x that satisfies Ax = b.
         """
+        assert self.shape[0] == b.shape[0], ("The number of rows in the matrix must match "
+                                             "the size of the right-hand side vector b.")
         return self.T.solve(b, tol=tol, reorder=reorder)

--- a/brainevent/_csr_impl_diag_add.py
+++ b/brainevent/_csr_impl_diag_add.py
@@ -1,0 +1,247 @@
+# Copyright 2025 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+
+import brainstate
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.interpreters import ad
+from jax.interpreters.partial_eval import DynamicJaxprTracer
+
+from ._compatible_import import pallas as pl
+from ._misc import generate_block_dim
+from ._xla_custom_op import XLACustomKernel
+from ._xla_custom_op_numba import numba_jit_fn, numba_kernel
+from ._xla_custom_op_pallas import pallas_kernel
+from ._xla_custom_op_warp import warp_kernel, jaxinfo_to_warpinfo
+
+
+def _is_tracer(x):
+    return isinstance(x, (jax.ShapeDtypeStruct, jax.core.ShapedArray, DynamicJaxprTracer, jax.core.Tracer))
+
+
+def csr_diag_position_v2(indptr, indices, shape: brainstate.typing.Size):
+    assert isinstance(shape, (tuple, list)), "shape must be a tuple or list"
+    assert indptr.ndim == 1, "indptr must be a 1D array"
+    assert indices.ndim == 1, "indices must be a 1D array"
+    assert len(shape) == 2, "shape must be a tuple or list of length 2"
+    assert all(isinstance(s, int) and s > 0 for s in shape), "shape must be a tuple or list of non-negative integers"
+    if _is_tracer(indptr):
+        raise ValueError('Cannot trace indptr when finding diagonal position')
+    if _is_tracer(indices):
+        raise ValueError('Cannot trace indices when finding diagonal position')
+    n_size = min(shape)
+
+    @numba_jit_fn
+    def _find_diag_position(indptr_, indices_):
+        csr_positions = []
+        diag_positions = []
+        for i in range(n_size):
+            start = indptr_[i]
+            end = indptr_[i + 1]
+            for j in range(start, end):
+                if indices_[j] == i:
+                    csr_positions.append(j)
+                    diag_positions.append(i)
+                    break
+        return np.asarray(csr_positions, dtype=np.int32), np.asarray(diag_positions, dtype=np.int32)
+
+    csr_pos, diag_pos = _find_diag_position(np.asarray(indptr), np.asarray(indices))
+
+    return (csr_pos, diag_pos) if len(csr_pos) == len(diag_pos) else (csr_pos, None)
+
+
+def csr_diag_add_v2(csr_value, positions, diag_value):
+    assert u.fail_for_dimension_mismatch(csr_value, diag_value)
+    assert csr_value.ndim == 1, "csr_value must be a 1D array"
+    assert diag_value.ndim == 1, "diag_value must be a 1D array"
+    assert csr_value.dtype == diag_value.dtype, "csr_value and diag_value must have the same dtype"
+    csr_pos, diag_pos = positions
+    assert csr_pos.ndim == 1, "csr_pos must be a 1D array"
+    assert jnp.issubdtype(csr_pos.dtype, jnp.integer), "diag_position must be an integer array"
+    if diag_pos is not None:
+        assert diag_pos.ndim == 1, "diag_pos must be a 1D array"
+        assert jnp.issubdtype(diag_pos.dtype, jnp.integer), "diag_position must be an integer array"
+
+    diag_value = u.Quantity(diag_value).to(u.get_unit(csr_value)).mantissa
+    csr_value, csr_unit = u.split_mantissa_unit(csr_value)
+    if diag_pos is None:
+        csr_value = csr_value.at[csr_pos].add(diag_value)
+    else:
+        csr_value = csr_value.at[csr_pos].add(diag_value[diag_pos])
+    return u.maybe_decimal(csr_value * csr_unit)
+
+
+def csr_diag_position(indptr, indices, shape: brainstate.typing.Size):
+    """
+    Find the diagonal position in a sparse matrix represented by indptr and indices.
+
+    Parameters:
+        indptr (array-like): The index pointer array.
+        indices (array-like): The column indices of the non-zero elements.
+        shape (brainstate.typing.Size): The shape of the sparse matrix, typically a tuple (n_rows, n_cols).
+
+    Returns:
+        ndarray: The diagonal position in the sparse matrix.
+    """
+    assert isinstance(shape, (tuple, list)), "shape must be a tuple or list"
+    assert len(shape) == 2, "shape must be a tuple or list of length 2"
+    assert all(isinstance(s, int) and s > 0 for s in shape), "shape must be a tuple or list of non-negative integers"
+    n_size = min(shape)
+
+    if _is_tracer(indptr):
+        raise ValueError('Cannot trace indptr when finding diagonal position')
+    if _is_tracer(indices):
+        raise ValueError('Cannot trace indices when finding diagonal position')
+
+    @numba_jit_fn
+    def _find_diag_position(indptr_, indices_):
+        results = []
+        for i in range(n_size):
+            start = indptr_[i]
+            end = indptr_[i + 1]
+            for j in range(start, end):
+                if indices_[j] == i:
+                    results.append(j)
+                    break
+            else:
+                results.append(-1)
+        return np.asarray(results, dtype=np.int32)
+
+    return jnp.asarray(
+        _find_diag_position(np.asarray(indptr), np.asarray(indices))
+    )
+
+
+def csr_diag_add(csr_value, diag_position, diag_value):
+    """
+    Add a diagonal value to a sparse matrix represented in CSR format.
+
+    Parameters:
+        csr_value (array-like): The values of the non-zero elements in the sparse matrix.
+        diag_position (array-like): The diagonal position in the sparse matrix.
+        diag_value (array-like): The diagonal value to be added.
+
+    Returns:
+        ndarray: The result of adding the diagonal value to the sparse matrix.
+    """
+    assert u.fail_for_dimension_mismatch(csr_value, diag_value)
+
+    diag_value = u.Quantity(diag_value).to(u.get_unit(csr_value)).mantissa
+    csr_value, csr_unit = u.split_mantissa_unit(csr_value)
+    return u.maybe_decimal(
+        csr_diag_add_call(csr_value, diag_position, diag_value)[0]
+        * csr_unit
+    )
+
+
+def _csr_diag_add_numba_kernel_generator(
+    **kwargs
+):
+    def kernel(csr_value, diag_position, diag_value, out):
+        for i in range(diag_position.size):
+            pos = diag_position[i]
+            if pos >= 0:
+                out[pos] += diag_value[i]
+
+    return numba_kernel(kernel, input_output_aliases={0: 0})
+
+
+def _csr_diag_add_warp_kernel_generator(
+    csr_value_info: jax.ShapeDtypeStruct,
+    diag_pos_info: jax.ShapeDtypeStruct,
+    diag_value_info: jax.ShapeDtypeStruct,
+    **kwargs
+):
+    import warp  # pylint: disable=import-outside-toplevel
+
+    csr_value_type = jaxinfo_to_warpinfo(csr_value_info)
+    diag_pos_type = jaxinfo_to_warpinfo(diag_pos_info)
+    diag_value_type = jaxinfo_to_warpinfo(diag_value_info)
+
+    def kernel(
+        csr_value: csr_value_type,
+        diag_position: diag_pos_type,
+        diag_value: diag_value_type,
+        out: csr_value_type
+    ):
+        i_diag = warp.tid()
+        pos = diag_position[i_diag]
+        if pos >= 0:
+            out[pos] += diag_value[i_diag]
+
+    dim = diag_pos_info.shape[0]
+    return warp_kernel(kernel, dim=dim, input_output_aliases={0: 0})
+
+
+def _csr_diag_add_pallas_kernel_generator(
+    diag_pos_info: jax.ShapeDtypeStruct,
+    **kwargs
+):
+    total = diag_pos_info.shape[0]
+    block_dim = generate_block_dim(total, 512)
+
+    def kernel(csr_value, diag_position, diag_value, out):
+        i_tile = pl.program_id(0)
+        i_title_start = i_tile * block_dim
+        mask = (i_title_start + jnp.arange(block_dim)) < total
+        positions = pl.load(diag_position, pl.dslice(i_title_start, block_dim), mask=mask)
+        values = pl.load(diag_value, pl.dslice(i_title_start, block_dim), mask=mask)
+        pl.atomic_add(out, pl.dslice(i_title_start, block_dim), values, mask=mask & (positions >= 0))
+
+    return pallas_kernel(kernel, outs=kwargs['outs'], tile=(pl.cdiv(total, block_dim),))
+
+
+def _csr_diag_add_jvp_csr_value(dot, csr_value, diag_position, diag_value, **kwargs):
+    return csr_diag_add_call(dot, diag_position, diag_value)
+
+
+def _csr_diag_add_jvp_diag_value(dot, csr_value, diag_position, diag_value, **kwargs):
+    return csr_diag_add_call(csr_value, diag_position, dot)
+
+
+def _csr_diag_add_transpose_value(ct, csr_value, diag_position, diag_value, **kwargs):
+    assert not ad.is_undefined_primal(diag_position)
+    ct = ct[0]
+    raise NotImplementedError
+
+
+def csr_diag_add_call(csr_value, diag_position, diag_value):
+    assert csr_value.ndim == 1, "csr_value must be a 1D array"
+    assert diag_position.ndim == 1, "diag_position must be a 1D array"
+    assert diag_value.ndim == 1, "diag_value must be a 1D array"
+    assert diag_position.shape == diag_value.shape, "diag_position must have the same shape as csr_value"
+    assert jnp.issubdtype(diag_position.dtype, jnp.integer), "diag_position must be an integer array"
+    assert csr_value.dtype == diag_value.dtype, "csr_value and diag_value must have the same dtype"
+
+    return csr_diag_add_p(
+        csr_value, diag_position, diag_value,
+        outs=[jax.ShapeDtypeStruct(csr_value.shape, csr_value.dtype)]
+    )
+
+
+csr_diag_add_p = XLACustomKernel('csr_diag_add')
+csr_diag_add_p.def_cpu_kernel(_csr_diag_add_numba_kernel_generator)
+csr_diag_add_p.def_gpu_kernel(
+    warp=_csr_diag_add_warp_kernel_generator,
+    pallas=_csr_diag_add_pallas_kernel_generator,
+    default='warp',
+)
+csr_diag_add_p.def_tpu_kernel(_csr_diag_add_pallas_kernel_generator)
+csr_diag_add_p.def_jvp_rule2(_csr_diag_add_jvp_csr_value, None, _csr_diag_add_jvp_diag_value)

--- a/brainevent/_csr_impl_spsolve.py
+++ b/brainevent/_csr_impl_spsolve.py
@@ -1,0 +1,60 @@
+# Copyright 2025 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+import brainunit as u
+from jax.experimental.sparse.linalg import spsolve as raw_spsolve
+
+__all__ = [
+    'csr_solve'
+]
+
+
+def csr_solve(data, indices, indptr, b, tol=1e-6, reorder=1):
+    """
+    A sparse direct solver using QR factorization.
+
+    Compute
+
+    $$
+    M x = b
+    $$
+
+    where $M$ is the CSR sparse matrix, and b is the vector.
+
+    Accepts a sparse matrix in CSR format `data, indices, indptr` arrays.
+    Currently only the CUDA GPU backend is implemented, the CPU backend will fall
+    back to `scipy.sparse.linalg.spsolve`. Neither the CPU nor the GPU
+    implementation support batching with `vmap`.
+
+    Args:
+      data : An array containing the non-zero entries of the CSR matrix.
+      indices : The column indices of the CSR matrix.
+      indptr : The row pointer array of the CSR matrix.
+      b : The right hand side of the linear system.
+      tol : Tolerance to decide if singular or not. Defaults to 1e-6.
+      reorder : The reordering scheme to use to reduce fill-in. No reordering if
+        ``reorder=0``. Otherwise, symrcm, symamd, or csrmetisnd (``reorder=1,2,3``),
+        respectively. Defaults to symrcm.
+
+    Returns:
+      An array with the same dtype and size as b representing the solution to
+      the sparse linear system.
+    """
+    data, data_unit = u.split_mantissa_unit(data)
+    b, b_unit = u.split_mantissa_unit(b)
+    res = raw_spsolve(data, indices, indptr, b, tol=tol, reorder=reorder)
+    return u.maybe_decimal(res * b_unit / data_unit)

--- a/brainevent/_csr_test.py
+++ b/brainevent/_csr_test.py
@@ -751,7 +751,7 @@ class Test_diag_add:
         new_csr = csr.diag_add(diag)
 
         new_dense = new_csr.todense()
-        dense = dense.at[*jnp.diag_indices(min(shape))].add(diag)
+        dense = dense.at[jnp.diag_indices(min(shape))].add(diag)
         dense = jnp.where(mask, dense, 0.)
 
         print(new_dense)
@@ -769,7 +769,7 @@ class Test_diag_add:
         new_csr = csc.diag_add(diag)
 
         new_dense = new_csr.todense()
-        dense = dense.at[*jnp.diag_indices(min(shape))].add(diag)
+        dense = dense.at[jnp.diag_indices(min(shape))].add(diag)
         dense = jnp.where(mask, dense, 0.)
 
         print(new_dense)
@@ -788,7 +788,7 @@ class Test_diag_add:
         new_csr = csc.diag_add(diag)
 
         new_dense = new_csr.todense().T
-        dense = dense.at[*jnp.diag_indices(min(shape))].add(diag)
+        dense = dense.at[jnp.diag_indices(min(shape))].add(diag)
         dense = jnp.where(mask, dense, 0.)
 
         print(new_dense)

--- a/brainevent/_csr_test.py
+++ b/brainevent/_csr_test.py
@@ -795,3 +795,34 @@ class Test_diag_add:
         print(dense)
 
         assert jnp.allclose(new_dense, dense)
+
+
+class Test_solve:
+    @pytest.mark.parametrize('shape', [(200, 200), (400, 400)])
+    def test_csr(self, shape: brainstate.typing.Shape):
+        dense = brainstate.random.rand(*shape)
+        mask = dense < 0.1
+        dense = jnp.where(mask, dense, 0.)
+        csr = brainevent.CSR.fromdense(dense)
+        b = brainstate.random.randn(shape[0])
+
+        x = csr.solve(b)
+        assert jnp.allclose(csr @ x, b, atol=1e-2, rtol=1e-2)
+
+        x2 = jnp.linalg.solve(dense, b)
+        assert jnp.allclose(x, x2, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize('shape', [(200, 200), (400, 400)])
+    def test_csc(self, shape: brainstate.typing.Shape):
+        dense = brainstate.random.rand(*shape)
+        mask = dense < 0.1
+        dense = jnp.where(mask, dense, 0.)
+        csc = brainevent.CSR.fromdense(dense)
+        b = brainstate.random.randn(shape[0])
+
+        x = csc.solve(b)
+        assert jnp.allclose(csc @ x, b, atol=1e-2, rtol=1e-2)
+
+        x2 = jnp.linalg.solve(dense, b)
+        assert jnp.allclose(x, x2, atol=1e-2, rtol=1e-2)
+

--- a/brainevent/_dense_impl_masked_float.py
+++ b/brainevent/_dense_impl_masked_float.py
@@ -81,7 +81,6 @@ def dense_mat_dot_masked_float_vec(weights, spikes):
 
 
 def _dense_mat_dot_masked_float_vec_numba_cpu_kernel_generator(
-    spk_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
     def _kernel(weights, spikes, posts):
@@ -132,7 +131,6 @@ def _dense_mat_dot_masked_float_vec_warp_kernel_generator(
 
 def _dense_mat_dot_masked_float_vec_pallas_kernel_generator(
     weight_info: jax.ShapeDtypeStruct,
-    spk_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
     mat_block_dim = generate_block_dim(weight_info.shape[0], maximum=1024)
@@ -267,7 +265,6 @@ def masked_float_vec_dot_dense_mat(spikes, weights):
 
 
 def _masked_float_vec_dot_dense_mat_numba_kernel_generator(
-    spk_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
     def _kernel(spikes, weights, posts):
@@ -463,7 +460,6 @@ def dense_mat_dot_masked_float_mat(weights, spikes):
 
 
 def _dense_mat_dot_masked_float_mat_numba_kernel_generator(
-    spk_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
     # weights: [m, k]
@@ -698,7 +694,6 @@ def masked_float_mat_dot_dense_mat(spikes, weights):
 
 
 def _masked_float_mat_dot_dense_mat_numba_kernel_generator(
-    spk_info: jax.ShapeDtypeStruct,
     **kwargs
 ):
     # spikes: [m, k]
@@ -716,26 +711,6 @@ def _masked_float_mat_dot_dense_mat_numba_kernel_generator(
             posts[i_m] = out
 
     return numba_kernel(_kernel, parallel=True)
-
-    # if spk_info.dtype == jnp.bool_:
-    #     def _kernel(spikes, weights, posts):
-    #         posts[:] = 0.
-    #         for i_k in range(weights.shape[0]):
-    #             row = weights[i_k]
-    #             for i_m in range(spikes.shape[0]):
-    #                 if spikes[i_m, i_k]:
-    #                     posts[i_m] += row
-    #
-    # else:
-    #     def _kernel(spikes, weights, posts):
-    #         posts[:] = 0.
-    #         for i_k in range(weights.shape[0]):
-    #             row = weights[i_k]
-    #             for i_m in range(spikes.shape[0]):
-    #                 if spikes[i_m, i_k] != 0.:
-    #                     posts[i_m] += row
-    #
-    # return numba_kernel(_kernel)
 
 
 def _masked_float_mat_dot_dense_mat_warp_kernel_generator(

--- a/brainevent/_fixed_conn_num_impl_float.py
+++ b/brainevent/_fixed_conn_num_impl_float.py
@@ -535,7 +535,6 @@ def _fixed_num_mm_numba_kernel_generator(
 
 
 def _fixed_num_mm_warp_kernel_generator(
-    transpose: bool,
     weight_info: jax.ShapeDtypeStruct,
     matrix_info: jax.ShapeDtypeStruct,
     indices_info: jax.ShapeDtypeStruct,

--- a/setup.py
+++ b/setup.py
@@ -18,21 +18,14 @@
 import io
 import os
 import re
-import sys
-import time
 
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 # version
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'brainevent/', '__init__.py'), 'r') as f:
     init_py = f.read()
 version = re.search('__version__ = "(.*)"', init_py).groups()[0]
-if len(sys.argv) > 2 and sys.argv[2] == '--python-tag=py3':
-    version = version
-else:
-    version += '.post{}'.format(time.strftime("%Y%m%d", time.localtime()))
 
 # obtain long description from README
 with io.open(os.path.join(here, 'README.md'), 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary by Sourcery

This PR aims to solve the requirements in the sparse solver needed in [BrainCell](https://github.com/chaobrain/braincell).


Introduce support for diagonal updates and direct sparse solving on CSR/CSC matrices by adding high-level methods, implementing custom XLA kernels, and cleaning up unused kernel parameters.

New Features:
- Add diag_add method to CSR and CSC classes for efficient diagonal updates.
- Add solve method to CSR and CSC classes to solve sparse linear systems.

Enhancements:
- Remove unused spk_info parameters from masked float dense kernel generators.

Tests:
- Add unit tests for diag_add and solve methods on CSR and CSC for various matrix shapes.

## Summary by Sourcery

Add diagonal update and sparse solve support to CSR/CSC matrices, implement custom XLA kernels, remove unused kernel parameters, and expand test coverage.

New Features:
- Add diag_add method to CSR and CSC classes for efficient diagonal updates
- Add solve method to CSR and CSC classes for direct sparse linear system solving

Enhancements:
- Remove unused spk_info parameters from masked float dense kernel generators
- Clean up version computation logic in setup.py

Tests:
- Add unit tests for diag_add method on CSR and CSC matrices of various shapes
- Add unit tests for solve method on CSR and CSC matrices to verify sparse solves match dense results