### PR TITLE
Feat: Add csrmv_yw2y weighted sparse mat-vec to CSR/CSC

### DIFF
--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 from ._array_base import BaseArray
 from ._array_binary import BinaryArray, EventArray

--- a/brainevent/_csr_impl_float.py
+++ b/brainevent/_csr_impl_float.py
@@ -29,7 +29,7 @@ from ._xla_custom_op import XLACustomKernel
 from ._xla_custom_op_numba import numba_kernel
 from ._xla_custom_op_pallas import pallas_kernel
 from ._xla_custom_op_util import general_batching_rule
-from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel
+from ._xla_custom_op_warp import jaxtype_to_warptype, warp_kernel, jaxinfo_to_warpinfo
 
 
 def csr_matvec(
@@ -45,62 +45,23 @@ def csr_matvec(
     Product of CSR sparse matrix and a dense vector.
 
     Args:
-      data : array of shape ``(nse,)``.
-      indices : array of shape ``(nse,)``
-      indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
-      v : array of shape ``(shape[0] if transpose else shape[1],)``
-        and dtype ``data.dtype``
-      shape : length-2 tuple representing the matrix shape
-      transpose : boolean specifying whether to transpose the sparse matrix
-        before computing.
+        data : array of shape ``(nse,)``.
+        indices : array of shape ``(nse,)``
+        indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
+        v : array of shape ``(shape[0] if transpose else shape[1],)``
+            and dtype ``data.dtype``
+        shape : length-2 tuple representing the matrix shape
+        transpose : boolean specifying whether to transpose the sparse matrix
+                    before computing.
 
     Returns:
       y : array of shape ``(shape[1] if transpose else shape[0],)`` representing
-        the matrix vector product.
+          the matrix vector product.
     """
     data, unitd = u.split_mantissa_unit(data)
     v, unitv = u.split_mantissa_unit(v)
     res = csrmv_p_call(data, indices, indptr, v, shape=shape, transpose=transpose)[0]
     return u.maybe_decimal(res * unitd * unitv)
-
-
-def csr_matmat(
-    data: Data,
-    indices: Index,
-    indptr: Indptr,
-    B: Data,
-    *,
-    shape: MatrixShape,
-    transpose: bool = False,
-) -> Data:
-    """
-    Product of CSR sparse matrix and a dense matrix.
-
-    Args:
-      data : array of shape ``(nse,)``.
-      indices : array of shape ``(nse,)``
-      indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
-      B : array of shape ``(shape[0] if transpose else shape[1], cols)`` and
-        dtype ``data.dtype``
-      shape : length-2 tuple representing the matrix shape
-      transpose : boolean specifying whether to transpose the sparse matrix
-        before computing.
-
-    Returns:
-      C : array of shape ``(shape[1] if transpose else shape[0], cols)``
-        representing the matrix-matrix product.
-    """
-    data, unitd = u.split_mantissa_unit(data)
-    B, unitb = u.split_mantissa_unit(B)
-    res = csrmm_p_call(
-        data,
-        indices,
-        indptr,
-        B,
-        shape=shape,
-        transpose=transpose,
-    )[0]
-    return u.maybe_decimal(res * (unitd * unitb))
 
 
 def _csrmv_numba_kernel_generator(
@@ -585,6 +546,45 @@ csrmv_p.def_tpu_kernel(_csrmv_pallas_tiled_kernel_generator)
 csrmv_p.def_jvp_rule2(_csrmv_jvp_weights, None, None, _csrmv_jvp_v)
 csrmv_p.def_transpose_rule(_csrmv_transpose_rule)
 csrmv_p.def_batching_rule(_csrmv_batching)
+
+
+def csr_matmat(
+    data: Data,
+    indices: Index,
+    indptr: Indptr,
+    B: Data,
+    *,
+    shape: MatrixShape,
+    transpose: bool = False,
+) -> Data:
+    """
+    Product of CSR sparse matrix and a dense matrix.
+
+    Args:
+        data : array of shape ``(nse,)``.
+        indices : array of shape ``(nse,)``
+        indptr : array of shape ``(shape[0] + 1,)`` and dtype ``indices.dtype``
+        B : array of shape ``(shape[0] if transpose else shape[1], cols)`` and
+        dtype ``data.dtype``
+        shape : length-2 tuple representing the matrix shape
+        transpose : boolean specifying whether to transpose the sparse matrix
+            before computing.
+
+    Returns:
+        C : array of shape ``(shape[1] if transpose else shape[0], cols)``
+            representing the matrix-matrix product.
+    """
+    data, unitd = u.split_mantissa_unit(data)
+    B, unitb = u.split_mantissa_unit(B)
+    res = csrmm_p_call(
+        data,
+        indices,
+        indptr,
+        B,
+        shape=shape,
+        transpose=transpose,
+    )[0]
+    return u.maybe_decimal(res * (unitd * unitb))
 
 
 def _csrmm_numba_kernel_generator(
@@ -1162,6 +1162,7 @@ def _csrmm_transpose_rule(
             )[0]
             return jnp.expand_dims(jnp.sum(r * ct), axis=0), indices, indptr, B, _
         else:
+            # TODO
             row, col = _csr_to_coo(indices, indptr)
             if transpose:
                 dCSR = B @ ct.T
@@ -1277,3 +1278,194 @@ csrmm_p.def_tpu_kernel(_csrmm_pallas_kernel_generator)
 csrmm_p.def_jvp_rule2(_csrmm_jvp_data, None, None, _csrmm_jvp_B)
 csrmm_p.def_transpose_rule(_csrmm_transpose_rule)
 csrmm_p.def_batching_rule(_csrmm_batching)
+
+
+def csrmv_yw2y(
+    y: Data,
+    w: Data,
+    indices: Index,
+    indptr: Indptr,
+    *,
+    shape, transpose: bool = False,
+) -> Data:
+    w, w_unit = u.split_mantissa_unit(w)
+    y, _ = u.split_mantissa_unit(y)
+    res = csrmv_yw2y_p_call(y, w, indices, indptr, shape=shape, transpose=transpose)[0]
+    return u.maybe_decimal(res * w_unit)
+
+
+def _csrmv_yw2y_numba_kernel_generator(
+    shape: MatrixShape,
+    transpose: bool,
+    **kwargs
+):
+    if transpose:
+        def kernel(y, w, indices, indptr, posts):
+            for i_col in range(shape[1]):
+                i_row_start = indptr[i_col]
+                i_row_end = indptr[i_col + 1]
+                index = indices[i_row_start: i_row_end]
+                posts[i_row_start: i_row_end] = w[i_row_start: i_row_end] * y[index]
+
+    else:
+        def kernel(y, w, indices, indptr, posts):
+            for i_row in range(shape[0]):
+                i_col_start = indptr[i_row]
+                i_col_end = indptr[i_row + 1]
+                posts[i_col_start: i_col_end] = w[i_col_start: i_col_end] * y[i_row]
+
+    return numba_kernel(kernel)
+
+
+def _csrmv_yw2y_warp_kernel_generator(
+    shape: MatrixShape,
+    transpose: bool,
+    y_info: jax.ShapeDtypeStruct,
+    w_info: jax.ShapeDtypeStruct,
+    indices_info: jax.ShapeDtypeStruct,
+    indptr_info: jax.ShapeDtypeStruct,
+    **kwargs
+):
+    import warp  # pylint: disable=import-outside-toplevel
+
+    if transpose:
+        def kernel(
+            y_ref: jaxinfo_to_warpinfo(y_info),  # [shape[1]]
+            w_ref: jaxinfo_to_warpinfo(w_info),  # [nse]
+            indices_ref: jaxinfo_to_warpinfo(indices_info),  # [nse]
+            indptr_ref: jaxinfo_to_warpinfo(indptr_info),  # [shape[1] + 1]
+            posts_ref: jaxinfo_to_warpinfo(w_info),  # [nse]
+        ):
+            i_col = warp.tid()
+            i_row_start = indptr_ref[i_col]
+            i_row_end = indptr_ref[i_col + 1]
+            for index in range(i_row_start, i_row_end):
+                i_row = indices_ref[index]
+                posts_ref[index] = w_ref[index] * y_ref[i_row]
+
+    else:
+        def kernel(
+            y_ref: jaxinfo_to_warpinfo(y_info),  # [shape[0]]
+            w_ref: jaxinfo_to_warpinfo(w_info),  # [nse]
+            indices_ref: jaxinfo_to_warpinfo(indices_info),  # [nse]
+            indptr_ref: jaxinfo_to_warpinfo(indptr_info),  # [shape[0] + 1]
+            posts_ref: jaxinfo_to_warpinfo(w_info),  # [nse]
+        ):
+            i_row = warp.tid()
+            i_col_start = indptr_ref[i_row]
+            i_col_end = indptr_ref[i_row + 1]
+            for index in range(i_col_start, i_col_end):
+                posts_ref[index] = w_ref[index] * y_ref[i_row]
+
+    return warp_kernel(kernel, dim=shape[1] if transpose else shape[0])
+
+
+def _csrmv_yw2y_pallas_kernel_generator(
+    shape: MatrixShape,
+    transpose: bool,
+    y_info: jax.ShapeDtypeStruct,
+    **kwargs
+):
+    block_dim = generate_block_dim(y_info.shape[0], 512)
+
+    def kernel(
+        y_ref,
+        w_ref,
+        indices_ref,
+        indptr_ref,
+        posts_ref,
+    ):
+        i_col = pl.program_id(0)
+        i_start = indptr_ref[i_col]
+        i_end = indptr_ref[i_col + 1]
+        num_blocks = (i_end - i_start + block_dim - 1) // block_dim
+
+        def loop_fn(i, _):
+            offset = i_start + i * block_dim
+            mask = (offset + jnp.arange(block_dim)) < i_end
+            w = pl.load(w_ref, pl.dslice(offset, block_dim), mask=mask, other=0.0)
+
+            if transpose:
+                index = pl.load(indices_ref, pl.dslice(offset, block_dim), mask=mask, other=0)
+                y = pl.load(y_ref, index, mask=mask, other=0.0)
+                pl.store(posts_ref, pl.dslice(offset, block_dim), w * y)
+            else:
+                pl.store(posts_ref, pl.dslice(offset, block_dim), w * y_ref[i_col])
+
+        jax.lax.fori_loop(0, num_blocks, loop_fn, None)
+
+    return pallas_kernel(kernel, tile=[shape[1] if transpose else shape[0]], outs=kwargs['outs'])
+
+
+def _csrmv_yw2y_jvp_y(y_dot, y, w, indices, indptr, *, shape, transpose, **kwargs):
+    return csrmv_yw2y_p_call(
+        y_dot,
+        w,
+        indices,
+        indptr,
+        shape=shape,
+        transpose=transpose
+    )
+
+
+def _csrmv_yw2y_jvp_w(w_dot, y, w, indices, indptr, *, shape, transpose, **kwargs):
+    return csrmv_yw2y_p_call(
+        y,
+        w_dot,
+        indices,
+        indptr,
+        shape=shape,
+        transpose=transpose
+    )
+
+
+def _csrmv_yw2y_transpose_rule(ct, y, w, indices, indptr, *, shape, transpose, **kwargs):
+    raise NotImplementedError
+
+
+def csrmv_yw2y_p_call(
+    y: Data,
+    w: Data,
+    indices: Index,
+    indptr: Indptr,
+    *,
+    shape: MatrixShape,
+    transpose: bool = False,
+):
+    assert y.dtype == w.dtype, f"y and w must have the same dtype, but got {y.dtype} and {w.dtype}."
+    assert indptr.ndim == 1, "Indptr must be 1D."
+    assert indices.ndim == 1, "Indices must be 1D."
+    assert y.ndim == w.ndim == 1, "y and w must have the same shape."
+    assert jnp.issubdtype(indices.dtype, jnp.integer), "Indices must be an integer type."
+    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    assert jnp.issubdtype(w.dtype, jnp.floating), 'Weights must be a floating-point type.'
+    assert w.shape == indices.shape, f"Weights shape mismatch, expected {indices.shape}, got {w.shape}."
+    if transpose:
+        # [x] @ [h, w] -> [w]
+        assert shape[1] == y.shape[0], "Shape mismatch for transpose operation."
+    else:
+        # [h, w] @ [x] -> [h]
+        assert shape[0] == y.shape[0], "Shape mismatch for non-transpose operation."
+
+    return csrmv_yw2y_p(
+        y,
+        w,
+        indices,
+        indptr,
+        outs=[jax.ShapeDtypeStruct(w.shape, w.dtype)],
+        shape=tuple(shape),
+        transpose=transpose,
+        indices_info=jax.ShapeDtypeStruct(indices.shape, indices.dtype),
+        indptr_info=jax.ShapeDtypeStruct(indptr.shape, indptr.dtype),
+        y_info=jax.ShapeDtypeStruct(y.shape, y.dtype),
+        w_info=jax.ShapeDtypeStruct(w.shape, w.dtype),
+    )
+
+
+csrmv_yw2y_p = XLACustomKernel('csrmv_yw2y')
+csrmv_yw2y_p.def_cpu_kernel(_csrmv_yw2y_numba_kernel_generator)
+csrmv_yw2y_p.def_gpu_kernel(pallas=_csrmv_yw2y_pallas_kernel_generator,
+                            warp=_csrmv_yw2y_warp_kernel_generator,
+                            default='pallas')
+csrmv_yw2y_p.def_tpu_kernel(_csrmv_yw2y_pallas_kernel_generator)
+csrmv_yw2y_p.def_jvp_rule2(_csrmv_yw2y_jvp_y, _csrmv_yw2y_jvp_w, None, None)

--- a/brainevent/_csr_impl_float_test.py
+++ b/brainevent/_csr_impl_float_test.py
@@ -21,7 +21,7 @@ import pytest
 
 import brainevent
 from brainevent._csr_impl_binary_test import TestBatchingVectorCSR, TestBatchingMatrixCSR
-from brainevent._csr_impl_float import csr_yw2y
+from brainevent._csr_impl_float import csrmv_yw2y
 from brainevent._csr_test_util import get_csr, vector_csr, matrix_csr, csr_vector, csr_matrix
 
 pytest.mark.skipif(brainstate.environ.get_platform() != 'cpu', allow_module_level=True)
@@ -309,7 +309,7 @@ class Test_csr_yw2y:
         else:
             y = brainstate.random.rand(m)
 
-        res1 = csr_yw2y(y, csr.data, indices, indptr, shape=[m, n], transpose=transpose)
+        res1 = csrmv_yw2y(y, csr.data, indices, indptr, shape=[m, n], transpose=transpose)
         dense_res1 = csr.with_data(res1).todense()
         dense_res2 = (dense * jnp.expand_dims(y, axis=0)
                       if transpose else

--- a/brainevent/_csr_impl_float_test.py
+++ b/brainevent/_csr_impl_float_test.py
@@ -15,13 +15,13 @@
 
 
 import brainstate
-import brainstate as bst
 import jax
 import jax.numpy as jnp
 import pytest
 
 import brainevent
 from brainevent._csr_impl_binary_test import TestBatchingVectorCSR, TestBatchingMatrixCSR
+from brainevent._csr_impl_float import csr_yw2y
 from brainevent._csr_test_util import get_csr, vector_csr, matrix_csr, csr_vector, csr_matrix
 
 pytest.mark.skipif(brainstate.environ.get_platform() != 'cpu', allow_module_level=True)
@@ -31,11 +31,11 @@ class TestVectorCSR:
     @pytest.mark.parametrize('homo_w', [True, False])
     def test_vector_csr(self, homo_w):
         m, n = 20, 40
-        x = bst.random.rand(m)
+        x = brainstate.random.rand(m)
         indptr, indices = get_csr(m, n, 0.1)
 
         print(f'homo_w = {homo_w}')
-        data = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        data = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
         y = x @ csr
         y2 = vector_csr(x, csr.data, indices, indptr, [m, n])
@@ -44,10 +44,10 @@ class TestVectorCSR:
     @pytest.mark.parametrize('homo_w', [True, False])
     def test_csr_vector(self, homo_w):
         m, n = 20, 40
-        v = bst.random.rand(n)
+        v = brainstate.random.rand(n)
         indptr, indices = get_csr(m, n, 0.1)
 
-        data = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        data = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
         y = csr @ v
         y2 = csr_vector(v, csr.data, indices, indptr, [m, n])
@@ -56,10 +56,10 @@ class TestVectorCSR:
     @pytest.mark.parametrize('homo_w', [True, False])
     def test_vector_csr_vmap_vector(self, homo_w):
         n_batch, m, n = 10, 20, 40
-        xs = bst.random.rand(n_batch, m)
+        xs = brainstate.random.rand(n_batch, m)
         indptr, indices = get_csr(m, n, 0.1)
 
-        data = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        data = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
         y = jax.vmap(lambda x: x @ csr)(xs)
         y2 = jax.vmap(lambda x: vector_csr(x, csr.data, indices, indptr, [m, n]))(xs)
@@ -71,10 +71,10 @@ class TestVectorCSR:
         n_in = 20
         n_out = 30
         shape = [n_in, n_out]
-        x = bst.random.rand(n_in) if transpose else bst.random.rand(n_out)
+        x = brainstate.random.rand(n_in) if transpose else brainstate.random.rand(n_out)
 
         indptr, indices = get_csr(n_in, n_out, 0.2, replace=replace)
-        w = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        w = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((w, indices, indptr), shape=shape)
 
         def f_brainevent(x, w):
@@ -111,10 +111,10 @@ class TestVectorCSR:
         n_in = 20
         n_out = 30
         shape = [n_in, n_out]
-        x = bst.random.rand(n_in if transpose else n_out)
+        x = brainstate.random.rand(n_in if transpose else n_out)
         indptr, indices = get_csr(n_in, n_out, 0.1, replace=replace)
 
-        w = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        w = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((w, indices, indptr), shape=shape)
 
         def f_brainevent(x, w):
@@ -212,10 +212,10 @@ class TestMatrixCSR:
     @pytest.mark.parametrize('homo_w', [True, False])
     def test_matrix_csr(self, homo_w):
         k, m, n = 10, 20, 40
-        x = bst.random.rand(k, m)
+        x = brainstate.random.rand(k, m)
         indptr, indices = get_csr(m, n, 0.1)
 
-        data = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        data = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
         y = x @ csr
         y2 = matrix_csr(x, csr.data, indices, indptr, [m, n])
@@ -224,10 +224,10 @@ class TestMatrixCSR:
     @pytest.mark.parametrize('homo_w', [True, False])
     def test_csr_matrix(self, homo_w):
         m, n, k = 20, 40, 10
-        matrix = bst.random.rand(n, k)
+        matrix = brainstate.random.rand(n, k)
         indptr, indices = get_csr(m, n, 0.1)
 
-        data = 1.5 if homo_w else bst.init.Normal()(indices.shape)
+        data = 1.5 if homo_w else brainstate.init.Normal()(indices.shape)
         csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
         y = csr @ matrix
         y2 = csr_matrix(matrix, csr.data, indices, indptr, [m, n])
@@ -292,3 +292,26 @@ class TestBatchingMatrixCSRFloat(TestBatchingMatrixCSR):
         r2 = jax.jit(lambda: jax.jvp(f_jax, (x, data), (jnp.ones_like(x), jnp.ones_like(data))))()
 
         return r1, r2
+
+
+class Test_csr_yw2y:
+    @pytest.mark.parametrize('transpose', [True, False])
+    def test_csr(self, transpose):
+        m, n = 20, 40
+        indptr, indices = get_csr(m, n, 0.1)
+
+        data = brainstate.init.Normal()(indices.shape)
+        csr = brainevent.CSR((data, indices, indptr), shape=(m, n))
+        dense = csr.todense()
+
+        if transpose:
+            y = brainstate.random.rand(n)
+        else:
+            y = brainstate.random.rand(m)
+
+        res1 = csr_yw2y(y, csr.data, indices, indptr, shape=[m, n], transpose=transpose)
+        dense_res1 = csr.with_data(res1).todense()
+        dense_res2 = (dense * jnp.expand_dims(y, axis=0)
+                      if transpose else
+                      dense * jnp.expand_dims(y, axis=1))
+        assert (jnp.allclose(dense_res1, dense_res2))

--- a/brainevent/_xla_custom_op_pallas.py
+++ b/brainevent/_xla_custom_op_pallas.py
@@ -149,13 +149,7 @@ def pallas_kernel(
 
     @functools.wraps(fn)
     def kernel(*args):
-        fn_call = pl.pallas_call(
-            fn,
-            grid=tuple(tile),
-            input_output_aliases=input_output_aliases,
-            out_shape=outs,
-        )
-        return fn_call(*args)
+        return pl.pallas_call(fn, grid=tuple(tile), input_output_aliases=input_output_aliases, out_shape=outs)(*args)
 
     return PallasKernel(
         kernel=kernel,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 exclude = [
+    "dev*",
     "docs*",
     "tests*",
     "examples*",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ with io.open(os.path.join(here, 'README.md'), 'r', encoding='utf-8') as f:
 # installation packages
 packages = find_packages(
     exclude=[
+        "dev*",
         "docs*",
         "tests*",
         "examples*",


### PR DESCRIPTION
## Summary by Sourcery

Add support for csrmv_yw2y weighted sparse matrix-vector multiplication and integrate it into the CSR/CSC APIs

New Features:
- Introduce csrmv_yw2y custom kernel with CPU, GPU (warp/pallas), and TPU implementations
- Expose yw_to_w method on CSR and CSC classes to perform weighted sparse mat-vec operations

Enhancements:
- Reformat csr_matvec docstrings and consolidate csr_matmat implementation
- Add jaxinfo_to_warpinfo import for improved warp kernel info handling

Tests:
- Add Test_csr_yw2y suite to verify yw_to_w functionality
- Update CSR tests to use brainstate.random and brainstate.init for consistency