### PR TITLE
Refactor: Improve block CSR-to-COO logic and performance

### DIFF
--- a/brainevent/_block_csr_test.py
+++ b/brainevent/_block_csr_test.py
@@ -16,12 +16,11 @@
 # -*- coding: utf-8 -*-
 
 
-import brainstate
 import brainunit as u
 import jax.numpy as jnp
 import numpy as np
-from scipy.sparse import bsr_matrix
 import pytest
+from scipy.sparse import bsr_matrix
 
 import brainevent
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the block CSR-to-COO conversion function for clearer logic and improved performance

Enhancements:
- Rename miniblock_nse to mini_block_nse for naming consistency
- Include row index in loop state to simplify inner while-loop
- Refactor dynamic_update_slice calls and loop constructs for readability