### PR TITLE
Refine testing workflow and add tests for FCNMM and Bitpack Compact;

### DIFF
--- a/brainevent/_fcn/binary_test.py
+++ b/brainevent/_fcn/binary_test.py
@@ -243,7 +243,7 @@ def test_binary_fcnmv_forward_matches_reference_in_large_scale(implementation, h
         )
         y_ref = _mv_reference(weights, indices, events, shape, transpose)
         
-        assert jnp.allclose(y, y_ref, rtol=1e-2, atol=1e-2)
+        assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2)
         
         jax.block_until_ready((indices, weights, events, y, y_ref))
         

--- a/brainevent/_fcn/bitpack_binary.py
+++ b/brainevent/_fcn/bitpack_binary.py
@@ -134,6 +134,121 @@ def _bitpack_binary_fcnmv_cuda_kernel(
 
     return kernel
 
+# ---------------------------------------------------------------------------
+# JAX GPU kernel
+# ---------------------------------------------------------------------------
+'''
+def _binary_fcnmv_jax_kernel(
+    shape: Tuple[int, int],
+    transpose: bool,
+    **kwargs,
+):
+    """Pure JAX reference implementation for benchmarking comparison."""
+    n_pre, n_post = shape
+
+    def kernel(weights, indices, spikes):
+        # Convert spikes to float: bool→{0,1}, float→{0,1} based on >0
+        #bool_spk = u.math.asarray(spikes, dtype=bool)
+        
+        if spikes.dtype == jnp.bool_:
+            spk_f = spikes.astype(weights.dtype)
+        else:
+            spk_f = (spikes > 0).astype(weights.dtype)
+        
+        #spk_f = u.math.asarray(spikes, dtype=bool)
+
+        if transpose:
+            # Scatter: y[indices[i,k]] += weights[i,k] * spk_f[i]
+            masked = jnp.broadcast_to(spk_f[:, None] * weights, indices.shape)
+            return jax.ops.segment_sum(masked.ravel(), indices.ravel(), num_segments=n_post),
+        else:
+            # Gather: y[i] = sum_k weights[i,k] * spk_f[indices[i,k]]
+            if weights.size == 1:
+                w = weights[0]
+                return jax.vmap(lambda ind: w * jnp.sum(spk_f[ind]))(indices),
+            else:
+                return jax.vmap(lambda w, ind: jnp.sum(w * spk_f[ind]))(weights, indices),
+
+    return kernel
+'''
+# ---------------------------------------------------------------------------
+# JAX/Cuda GPU kernel
+# ---------------------------------------------------------------------------
+
+def bitpack_binary_fcnmv_jax_cuda_joint_kernel(
+    transpose: bool,
+    pack_axis: int,
+    shape: Tuple[int, int],
+    **kwargs,
+):
+    """Select a JAX or CUDA implementation for bit-packed fcnmv on GPU."""
+    n_pre, n_post = shape
+
+    def jax_kernel_part(weights, indices, packed, spikes):
+        # Convert spikes to float: bool→{0,1}, float→{0,1} based on >0
+        #bool_spk = u.math.asarray(spikes, dtype=bool)
+        
+        if spikes.dtype == jnp.bool_:
+            spk_f = spikes.astype(weights.dtype)
+        else:
+            spk_f = (spikes > 0).astype(weights.dtype)
+        
+        #spk_f = u.math.asarray(spikes, dtype=bool)
+
+        if weights.size == 1:
+            w = weights[0]
+            return jax.vmap(lambda ind: w * jnp.sum(spk_f[ind]))(indices),
+        else:
+            return jax.vmap(lambda w, ind: jnp.sum(w * spk_f[ind]))(weights, indices),
+
+    weight_info = kwargs['weight_info']
+    homo = weight_info.size == 1
+    indices_info = kwargs.get('indices_info', None)
+    n_conn = indices_info.shape[1] if indices_info is not None else 251
+    if not homo:
+        if (n_pre < 100 * 4000) or (n_pre < 500 * 4000 and n_pre > 250 * 4000 and n_conn < 500):
+            print("using jax")
+            return jax_kernel_part
+    else:
+        if (n_pre < 500 * 4000 and n_conn < 500):
+            print("using jax")
+            return jax_kernel_part
+    '''
+    if homo:
+        use_jax = (n_pre < 500 * 4000 and n_post < 500)
+        if use_jax:
+            print("using jax")
+            return jax_kernel_part
+    else:
+        use_jax = (n_pre < 500 * 4000 and n_post < 500) or (n_post > 1750)
+        if use_jax:
+            print("using jax")
+            return jax_kernel_part
+    '''
+    load_cuda_file(
+        Path(__file__).parent.joinpath('bitpack_binary_fcnmv.cu'),
+        name='fcn_bitpack_binary_mv',
+    )
+
+    out_info = kwargs['outs']
+    _dtype_sfx = {
+        jnp.dtype('float16'): '_f16',
+        jnp.dtype('float32'): '_f32',
+        jnp.dtype('float64'): '_f64',
+        jnp.dtype('bfloat16'): '_bf16'
+    }
+    sfx = _dtype_sfx.get(jnp.dtype(weight_info.dtype), '_f32')
+    mode_sfx = '_homo' if homo else '_hetero'
+    dir_sfx = '_gather'
+    kernel_name = f'fcn_bitpack_binary_mv.bitpack_binary_fcnmv{dir_sfx}{mode_sfx}{sfx}'
+
+    def cuda_kernel_part(weights, indices, packed, spikes):
+        print("using cuda")
+        return jax.ffi.ffi_call(
+            kernel_name, out_info
+        )(weights, indices, packed, pack_axis=pack_axis)
+
+    return cuda_kernel_part
 
 # ---------------------------------------------------------------------------
 # Numba CPU kernel
@@ -397,6 +512,7 @@ to the CUDA kernel.
 )
 bitpack_binary_fcnmv_p.def_numba_kernel(_bitpack_binary_fcnmv_numba_kernel)
 bitpack_binary_fcnmv_p.def_cuda_raw_kernel(_bitpack_binary_fcnmv_cuda_kernel, asdefault=True)
+bitpack_binary_fcnmv_p.def_kernel('jax_cuda_joint', 'gpu', bitpack_binary_fcnmv_jax_cuda_joint_kernel, asdefault=True)
 bitpack_binary_fcnmv_p.def_jvp_rule2(
     _bitpack_binary_fcnmv_jvp_weights,  # arg 0: weights
     None,  # arg 1: indices (not differentiable)

--- a/brainevent/_fcn/bitpack_binary.py
+++ b/brainevent/_fcn/bitpack_binary.py
@@ -512,7 +512,7 @@ to the CUDA kernel.
 )
 bitpack_binary_fcnmv_p.def_numba_kernel(_bitpack_binary_fcnmv_numba_kernel)
 bitpack_binary_fcnmv_p.def_cuda_raw_kernel(_bitpack_binary_fcnmv_cuda_kernel, asdefault=True)
-bitpack_binary_fcnmv_p.def_kernel('jax_cuda_joint', 'gpu', bitpack_binary_fcnmv_jax_cuda_joint_kernel, asdefault=True)
+#bitpack_binary_fcnmv_p.def_kernel('jax_cuda_joint', 'gpu', bitpack_binary_fcnmv_jax_cuda_joint_kernel, asdefault=True)
 bitpack_binary_fcnmv_p.def_jvp_rule2(
     _bitpack_binary_fcnmv_jvp_weights,  # arg 0: weights
     None,  # arg 1: indices (not differentiable)

--- a/brainevent/_fcn/bitpack_binary_fcnmv.cu
+++ b/brainevent/_fcn/bitpack_binary_fcnmv.cu
@@ -383,7 +383,7 @@ void bitpack_binary_fcnmv_gather_homo##SUFFIX(                                  
     const uint32_t*   d_pk  = static_cast<const uint32_t*>(packed.data_ptr());                    \
     WEIGHT_C_T*       d_out = static_cast<WEIGHT_C_T*>(output.data_ptr());                        \
     size_t smem_bytes = (size_t)n_words * sizeof(uint32_t);                                       \
-    if (n_conn <= 512) {                                                                          \
+    if (n_conn < 256 && n_pre < 625 * 40000) {                                                                          \
         int bsz = 256;                                                                            \
         int n_blocks = (n_pre + bsz - 1) / bsz;                                                  \
         if (smem_bytes <= 48u * 1024u) {                                                          \
@@ -422,7 +422,7 @@ void bitpack_binary_fcnmv_gather_hetero##SUFFIX(                                
     const uint32_t*   d_pk  = static_cast<const uint32_t*>(packed.data_ptr());                    \
     WEIGHT_C_T*       d_out = static_cast<WEIGHT_C_T*>(output.data_ptr());                        \
     size_t smem_bytes = (size_t)n_words * sizeof(uint32_t);                                       \
-    if (n_conn <= 512) {                                                                          \
+    if (n_conn <= 256) {                                                                          \
         int bsz = 256;                                                                            \
         int n_blocks = (n_pre + bsz - 1) / bsz;                                                  \
         if (smem_bytes <= 48u * 1024u) {                                                          \
@@ -443,6 +443,7 @@ void bitpack_binary_fcnmv_gather_hetero##SUFFIX(                                
         }                                                                                         \
     }                                                                                             \
 }
+//n_conn < 256 && n_pre < 625 * 40000
 
 // ---- FFI macro: scatter homo packed (always TPR) ----
 #define FFI_BS_HOMO_PACKED(SUFFIX, WEIGHT_C_T)                                                    \

--- a/brainevent/_fcn/bitpack_binary_test.py
+++ b/brainevent/_fcn/bitpack_binary_test.py
@@ -232,7 +232,7 @@ def test_bitpack_fcnmv_forward(homo_w, transpose, shape):
     y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
 
     assert y.shape == y_ref.shape
-    assert jnp.allclose(y, y_ref, rtol=1e-3, atol=1e-3), (
+    assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
         f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
         f"homo_w={homo_w}  transpose={transpose}"
     )
@@ -291,7 +291,7 @@ def test_bitpack_fcnmv_forward_in_large_scale(homo_w):
         y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
 
         assert y.shape == y_ref.shape
-        assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
+        assert jnp.allclose(y, y_ref, rtol=1e-3, atol=1e-3), (
             f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
             f"homo_w={homo_w}  conn={conn}"
         )

--- a/brainevent/_fcn/bitpack_binary_test.py
+++ b/brainevent/_fcn/bitpack_binary_test.py
@@ -100,6 +100,115 @@ def _ref_mm(weights, indices, matrix, shape, transpose):
     return dense @ M  # (n_pre, n_post) @ (n_post, k) → (n_pre, k)
 
 
+def generate_cs_pairs(
+    memory_limit: float = 4,
+    homo_or_not: bool = True,
+    scale_max: int = 2000,
+    conn_max: int = 4000,
+    _N: int = 4000,
+    data_size: int = 4,
+    num_points: int = 5,
+    include_dense_ref: bool = False,
+):
+    """Generate ``(conn, m)`` pairs near the GPU memory boundary.
+
+    Returns a list of ``(conn, m)`` tuples where ``m = scale * _N``, such
+    that the estimated memory usage stays just below *memory_limit* GiB.
+    Integer truncation (``int()``) is used so that values always lean
+    toward the **smaller** side to avoid overflow.
+
+    Memory model
+    -------------
+    * **Sparse arrays only** (``include_dense_ref=False``):
+      ``m * conn * data_size * times``
+      where *times* = 1 (homo, indices only) or 2 (hetero, indices + weights).
+
+    * **With dense reference** (``include_dense_ref=True``):
+      ``m * conn * data_size * times  +  m² * data_size``
+      Use this when the test constructs a full ``(m, m)`` dense matrix for
+      correctness comparison.
+
+    Parameters
+    ----------
+    memory_limit : float
+        GPU memory budget in GiB.
+    homo_or_not : bool
+        True  → only indices are stored (1× sparse budget).
+        False → indices + weights are stored (2× sparse budget).
+    scale_max : int
+        Upper bound for the scale factor *s* (``m = s * _N``).
+    conn_max : int
+        Maximum number of connections per row.
+    _N : int
+        Base neuron count per scale unit.
+    data_size : int
+        Bytes per element (4 for float32 / int32).
+    num_points : int
+        Number of sample points to generate.
+    include_dense_ref : bool
+        If True, the budget also accounts for a dense ``(m, m)`` reference
+        matrix of size ``m² * data_size``.
+    """
+    import math
+    import numpy as np
+    limit_bytes = memory_limit * (1024 ** 3)
+    times = 1 if homo_or_not else 2
+
+    # K = budget expressed in units of (_N * data_size) bytes
+    K = limit_bytes / (_N * data_size)
+
+    # --- valid scale range ---------------------------------------------------
+    if include_dense_ref:
+        # For conn > 0 we need  K - s² * _N > 0  →  s < sqrt(K / _N)
+        s_max = min(scale_max, int(math.sqrt(K / _N)))
+    else:
+        # conn = K / (s * times) >= 1  →  s <= K / times
+        s_max = min(scale_max, int(K / times))
+
+    # s_min: when *not* including the dense ref, large s → small conn,
+    # which is fine; but very small s → conn > conn_max, wasting budget.
+    if not include_dense_ref:
+        s_min = max(1, math.ceil(K / (times * conn_max)))
+    else:
+        s_min = 1
+
+    if s_min > s_max:
+        raise ValueError(
+            f"No valid (conn, m) pairs: s_min={s_min} > s_max={s_max}. "
+            f"Try increasing memory_limit or decreasing scale_max/conn_max."
+        )
+
+    s_samples = np.geomspace(s_min, s_max, num_points)
+
+    valid_pairs = []
+    seen = set()
+
+    for s_val in s_samples:
+        s_int = max(1, int(round(s_val)))
+        s_int = min(s_int, s_max)  # clamp
+
+        # Compute max conn (floor to stay below the boundary)
+        if include_dense_ref:
+            budget_for_sparse = K - s_int ** 2 * _N
+            if budget_for_sparse <= 0:
+                continue
+            c_int = int(budget_for_sparse / (s_int * times))
+        else:
+            c_int = int(K / (s_int * times))
+
+        c_int = min(c_int, conn_max)
+
+        m = s_int * _N
+
+        if c_int > 0 and c_int <= m and s_int <= scale_max:
+            pair = (c_int, m)
+            if pair not in seen:
+                seen.add(pair)
+                valid_pairs.append(pair)
+
+    return valid_pairs
+
+
 # ===========================================================================
 # 1. Forward correctness — fcnmv
 # ===========================================================================
@@ -160,6 +269,36 @@ def test_bitpack_fcnmv_forward_all_ones(homo_w, transpose, shape):
     y = bitpack_binary_fcnmv(weights, indices, packed, spikes, shape=shape, transpose=transpose)
     y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
     assert jnp.allclose(y, y_ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize('homo_w', [True, False])
+def test_bitpack_fcnmv_forward_in_large_scale(homo_w):
+    """bitpack_binary_fcnmv forward matches dense reference at large scale (transpose=False)."""
+    import gc
+
+    for conn, m in generate_cs_pairs(homo_or_not=homo_w, include_dense_ref=True):
+        indices = generate_fixed_conn_num_indices(m, m, conn)
+        weights = _mk_homo_w() if homo_w else _mk_hetero_w(indices)
+
+        transpose = False
+        shape = (m, m)
+        spikes = _mk_spikes(m)
+        packed = bitpack(spikes, axis=0)
+
+        y = bitpack_binary_fcnmv(
+            weights, indices, packed, spikes, shape=shape, transpose=transpose,
+        )
+        y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
+
+        assert y.shape == y_ref.shape
+        assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
+            f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
+            f"homo_w={homo_w}  conn={conn}"
+        )
+        jax.block_until_ready((indices, weights, y, y_ref))
+
+        del indices, weights, spikes, packed, y, y_ref
+        gc.collect()
 
 
 # ===========================================================================

--- a/brainevent/_fcn/bitpack_binary_test.py
+++ b/brainevent/_fcn/bitpack_binary_test.py
@@ -232,7 +232,7 @@ def test_bitpack_fcnmv_forward(homo_w, transpose, shape):
     y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
 
     assert y.shape == y_ref.shape
-    assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
+    assert jnp.allclose(y, y_ref, rtol=1e-3, atol=1e-3), (
         f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
         f"homo_w={homo_w}  transpose={transpose}"
     )
@@ -291,7 +291,7 @@ def test_bitpack_fcnmv_forward_in_large_scale(homo_w):
         y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
 
         assert y.shape == y_ref.shape
-        assert jnp.allclose(y, y_ref, rtol=1e-3, atol=1e-3), (
+        assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
             f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
             f"homo_w={homo_w}  conn={conn}"
         )

--- a/brainevent/_fcn/compact_binary_test.py
+++ b/brainevent/_fcn/compact_binary_test.py
@@ -299,7 +299,7 @@ def test_compact_binary_fcnmv_forward_in_large_scale(homo_w):
         y_ref = _ref_mv(weights, indices, spikes, shape, transpose)
 
         assert y.shape == y_ref.shape
-        assert jnp.allclose(y, y_ref, rtol=1e-2, atol=1e-2), (
+        assert jnp.allclose(y, y_ref, rtol=5e-2, atol=5e-2), (
             f"max diff={jnp.max(jnp.abs(y - y_ref)):.4e}  shape={shape}  "
             f"homo_w={homo_w}  conn={conn}"
         )

--- a/dev/fcn/BenchmarkTools.py
+++ b/dev/fcn/BenchmarkTools.py
@@ -5,24 +5,10 @@ import jax
 from pathlib import Path
 
 class CSV_record():
-    """Generic CSV recorder used by benchmarks.
 
-    Features:
-    - accepts arbitrary extra fields per row and tracks fieldnames
-    - configurable output directory
-    - append or overwrite mode
-    - convenience helper `single_COBA_data_add` kept for compatibility
-    - automatic handling of brainunit Quantity objects (extracts numeric values)
-    - automatic append mode detection for existing files
-    """
-    
     @staticmethod
     def _extract_value(param):
-        """Extract numeric value from parameter, handling brainunit.Quantity objects.
-        
-        If the parameter is a brainunit Quantity object, extracts the magnitude.
-        Otherwise returns the parameter as-is.
-        """
+ 
         if hasattr(param, '__class__') and param.__class__.__name__ == 'Quantity':
             return param.magnitude
         return param
@@ -33,26 +19,42 @@ class CSV_record():
         operator: str,
         testing_type: str,
         duration: float,
-        conn: int | None = None,
         suffix: str = '',
         output_dir: str | None = None,
         append: bool = False,
+        conn: int | None = None,
     ) -> None:
         self.name = CSV_name
         self.suffix = suffix
         self.conn = conn
+        self.operator_name = operator
         # Handle brainunit Quantity objects
         self.duration = self._extract_value(duration)
 
         # default common fields
-        self.fieldnames: list[str] = [
-            'operator', 'data_type', 'backend', 'synaptic_type', 'scale', 'conn_num',
-            'elapsed_s', 'firing_rate', 'duration', 'homo'
-        ]
+        if 'mv' in self.operator_name:   
+            self.fieldnames: list[str] = [
+                'operator', 'data_type', 'backend', 'synaptic_type', 'scale', 'conn_num',
+                'elapsed_s', 'firing_rate', 'duration', 'homo'
+            ]
+            self.operator_type = 'mv'
+        elif 'mm' in self.operator_name:
+            self.fieldnames: list[str] = [
+                'operator', 'data_type', 'backend', 'synaptic_type', 'scale', 'conn_num',
+                'batch_size', 'elapsed_s', 'firing_rate', 'duration', 'homo'
+            ]
+            self.operator_type = 'mm'
+        else:
+            self.fieldnames: list[str] = [
+                'operator', 'data_type', 'backend', 'synaptic_type', 'scale', 'conn_num',
+                'elapsed_s', 'firing_rate', 'duration', 'homo'
+            ]
+            self.operator_type = 'unknown'
+        
         self.rows: list[dict] = []
+
         self.testing_type = testing_type  
         if testing_type == 'COBA': self.testing_type = 'coba' # coba or benchmark
-        self.operator_name = operator
 
         # output dir default: same folder as this file /results
         try:
@@ -67,7 +69,7 @@ class CSV_record():
 
         self.width = 70
 
-    def _write_csv(self, file_name: str, rows: list[dict], fieldnames: list[str], mode: str = 'w') -> None:
+    def _write_csv(self, file_name: str, rows: list[dict], fieldnames: list[str], mode: str = 'w', silent: bool = False) -> None:
         import csv
         from pathlib import Path
 
@@ -95,7 +97,8 @@ class CSV_record():
                 writer.writeheader()
             writer.writerows(rows)
 
-        print(f"result has been saved: {file_path}")
+        if not silent:
+            print(f"result has been saved: {file_path}")
 
     def add_tag(self, tag_name: str, tag_value) -> None:
         """Set a persistent tag that will be automatically included in all subsequent rows.
@@ -132,12 +135,14 @@ class CSV_record():
                              firing_rate: float,
                              duration: float,
                              homo: str = 'default',
+                             batch_size: int = 1,
                              **kwargs):
         """Backwards-compatible helper used by existing benchmarks.
         
         Automatically extracts numeric values from brainunit Quantity objects.
         """
-        row = {
+        if self.operator_type == 'mv':   
+            row = {
             'operator': self.operator_name,
             'data_type': data_type,
             'backend': backend,
@@ -150,12 +155,42 @@ class CSV_record():
             'duration': self._extract_value(duration),
             'homo': homo,
         }
+        elif self.operator_type == 'mm':
+            row = {
+                'operator': self.operator_name,
+                'data_type': data_type,
+                'backend': backend,
+                'testing_type': self.testing_type,
+                'synaptic_type': synaptic_type,
+                'scale': scale,
+                'conn_num': conn_num,
+                'batch_size': batch_size,
+                'elapsed_s': self._extract_value(elapsed_s),
+                'firing_rate': self._extract_value(firing_rate),
+                'duration': self._extract_value(duration),
+                'homo': homo,
+            }
+        else:
+            row = {
+                'operator': self.operator_name,
+                'data_type': data_type,
+                'backend': backend,
+                'testing_type': self.testing_type,
+                'synaptic_type': synaptic_type,
+                'scale': scale,
+                'conn_num': conn_num,
+                'elapsed_s': self._extract_value(elapsed_s),
+                'firing_rate': self._extract_value(firing_rate),
+                'duration': self._extract_value(duration),
+                'homo': homo,
+            }
 
         # merge extras, also extract values from them
         for key, value in kwargs.items():
             row[key] = self._extract_value(value)
 
         self.add_row(row)
+
 
     def record_finish(self, dir:str = '', suffix: str = '', file_name: str | None = None) -> None:
         """Write accumulated rows to disk.
@@ -168,7 +203,9 @@ class CSV_record():
         - For other files, automatically detects if the target file exists and
           appends if it does.
         """
-        if dir is not '':
+        if not self.rows:
+            return
+        if dir != '':
             self.output_dir = self.base / dir
             self.output_dir.mkdir(parents=True, exist_ok=True)
             
@@ -192,6 +229,37 @@ class CSV_record():
             mode = 'a' if file_path.exists() else 'w'
 
         self._write_csv(out_name, self.rows, self.fieldnames, mode=mode)
+
+    def flush_and_clear(self, file_name: str, dir: str = '') -> 'Path | None':
+        """Immediately write buffered rows to disk and clear the buffer.
+
+        Use this for incremental flushing after each completed test round
+        instead of waiting for ``record_finish`` at the end.
+        If there are no buffered rows this is a no-op.
+
+        Parameters
+        ----------
+        file_name : str
+            Output filename (without .csv extension).
+        dir : str, optional
+            Sub-directory under ``self.base`` to write into.
+            If empty, uses the current ``self.output_dir``.
+        """
+        if not self.rows:
+            return
+        if dir:
+            target_dir = self.base / dir
+            target_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            target_dir = self.output_dir
+        file_path = target_dir / f'{file_name}.csv'
+        mode = 'a' if file_path.exists() else 'w'
+        _saved = self.output_dir
+        self.output_dir = target_dir
+        self._write_csv(file_name, self.rows, self.fieldnames, mode=mode, silent=True)
+        self.output_dir = _saved
+        self.rows = []
+        return file_path
 
 
     def print_header(self, *, operator: str, data_type: str, backend: str,
@@ -223,9 +291,15 @@ class CSV_record():
         print('  ' + ' | '.join(parts))
         print(f'{"=" * self.width}')
 
-    def print_table_header(self, show_conn: bool = False) -> None:
+    def print_table_header(self, show_conn: bool = False, show_batch: bool = False) -> None:
         """Print column header for the standard result table."""
-        if show_conn:
+        if show_batch and show_conn:
+            print(f'  {"Scale":>5s} | {"BatchSz":>7s} | {"ConnNum":>8s} | {"Neurons":>7s} | {"Elapsed (s)":>11s} | {"Rate (Hz)":>9s}')
+            print(f'  {"-----":>5s}-+-{"-------":>7s}-+-{"--------":>8s}-+-{"-------":>7s}-+-{"----------":>11s}-+-{"------":>9s}')
+        elif show_batch:
+            print(f'  {"Scale":>5s} | {"BatchSz":>7s} | {"Neurons":>7s} | {"Elapsed (s)":>11s} | {"Rate (Hz)":>9s}')
+            print(f'  {"-----":>5s}-+-{"-------":>7s}-+-{"-------":>7s}-+-{"----------":>11s}-+-{"------":>9s}')
+        elif show_conn:
             print(f'  {"Scale":>5s} | {"ConnNum":>8s} | {"Neurons":>7s} | {"Elapsed (s)":>11s} | {"Rate (Hz)":>9s}')
             print(f'  {"-----":>5s}-+-{"--------":>8s}-+-{"-------":>7s}-+-{"----------":>11s}-+-{"------":>9s}')
         else:
@@ -233,9 +307,13 @@ class CSV_record():
             print(f'  {"-----":>5s}-+-{"-------":>7s}-+-{"----------":>11s}-+-{"------":>9s}')
 
     @staticmethod
-    def print_row(scale: int, neurons: int, elapsed: float, rate: float, conn_num=None) -> None:
+    def print_row(scale: int, neurons: int, elapsed: float, rate: float, conn_num=None, batch_size=None) -> None:
         """Print one benchmark result row."""
-        if conn_num is not None:
+        if batch_size is not None and conn_num is not None:
+            print(f'  {scale:>5d} | {batch_size:>7d} | {conn_num:>8g} | {neurons:>7d} | {elapsed:>11.3f} | {float(rate):>9.2f}')
+        elif batch_size is not None:
+            print(f'  {scale:>5d} | {batch_size:>7d} | {neurons:>7d} | {elapsed:>11.3f} | {float(rate):>9.2f}')
+        elif conn_num is not None:
             print(f'  {scale:>5d} | {conn_num:>8g} | {neurons:>7d} | {elapsed:>11.3f} | {float(rate):>9.2f}')
         else:
             print(f'  {scale:>5d} | {neurons:>7d} | {elapsed:>11.3f} | {float(rate):>9.2f}')
@@ -268,98 +346,528 @@ def dump_jax_ir(func, args=(), kwargs=None, prefix="dump"):
     
     return jaxpr_path, hlo_path
 
-def generate_params(
-    dis_type: str = 'log',
-    _N: int = 4000,
-    limit_gb: float = 24,
-    target_samples: int = 500,
-    data_size: int = 4,
-    scale_max: int = 2000,
-    conn_max: int = 4000,
-    homo: bool = True
-) -> list:
-    """
-    Generates a list of valid (scale, conn_num) parameter states within VRAM limits.
 
-    Boundary conditions
-    -------------------
-    - matrix_memory_bytes = conn_num * scale * _N * data_size * 2 <= limit_bytes
-    - conn_num <= _N * scale
+class TestingParamsGenerator_mv():
 
-    Parameters
-    ----------
-    dis_type : str
-        Sampling strategy: 'uniform' (linear grid), 'log' (geometric grid),
-        or 'monte_carlo' (random sampling).
-    _N : int
-        Number of neurons per scale unit.
-    limit_gb : float
-        VRAM limit in gigabytes.
-    target_samples : int
-        Approximate number of valid states to generate (actual count ≈ ±50).
-    data_size : int
-        Bytes per element (4 for float32/int32, 1 for bool/int8).
-    scale_max : int
-        Upper bound of scale search range.
-    conn_max : int
-        Upper bound of conn_num search range.
-
-    Returns
-    -------
-    list of (scale, conn_num) tuples, sorted by memory footprint.
-    """
-    import numpy as np
-
-    limit_bytes = limit_gb * (1024 ** 3)
-
-    def is_valid(s, c, homo):
+    def __init__(self,
+                 limit_GB: int,
+                 _N: int,
+                 scale_max: int = 2000,
+                 conn_max: int = 4000,
+                 sample_points:int = 50):
+        
+        self._limit_GB = limit_GB
+        self._N = _N
+        self._limit_bytes = self._limit_GB * (1024)**3
+        self.scale_max = scale_max
+        self.conn_max = conn_max
+        self.sample_points = sample_points
+    
+    def is_valid_mv(self, scale, conn, homo, data_size):
         if homo:
             times = 1
         else:
             times = 2
-        matrix_memory_bytes = c * s * _N * data_size * times #1 if homo else 2
-        return matrix_memory_bytes <= limit_bytes and c <= _N * s
+        matrix_memory_bytes = conn * scale * self._N * data_size * times #1 if homo else 2
+        return matrix_memory_bytes <= self._limit_bytes and conn <= self._N * scale
 
-    if dis_type == 'monte_carlo':
-        valid_states = set()
-        while len(valid_states) < target_samples:
-            s = int(np.random.uniform(1, scale_max + 1))
-            c = int(np.random.uniform(1, conn_max + 1))
-            if is_valid(s, c, homo):
-                valid_states.add((s, c))
-        sorted_states = sorted(list(valid_states), key=lambda state: state[0] * state[1])
-        print(f"Generated {len(sorted_states)} valid parameter states under {limit_gb}GB boundary.")
-        return sorted_states
+    def generate_params(
+        self,
+        dis_type: str = 'log',
+        target_samples: int = 500,
+        data_size: int = 4,
+        homo: bool = True
+    ) -> list:
+        """
+        Generates a list of valid (scale, conn_num) parameter states within VRAM limits.
 
-    # For grid-based methods: the valid region is a curved hyperbolic area;
-    # ~3x oversampling of grid points relative to target gives ~±50 accuracy after filtering.
-    grid_res = int(np.sqrt(target_samples * 3))
+        Boundary conditions
+        -------------------
+        - matrix_memory_bytes = conn_num * scale * _N * data_size * 2 <= limit_bytes
+        - conn_num <= _N * scale
 
-    if dis_type == 'uniform':
-        scales_raw = np.unique(np.linspace(1, scale_max, num=grid_res, dtype=int))
-        conn_nums_raw = np.unique(np.linspace(1, conn_max, num=grid_res, dtype=int))
-    elif dis_type == 'log':
-        scales_raw = np.unique(np.geomspace(1, scale_max, num=grid_res, dtype=int))
-        conn_nums_raw = np.unique(np.geomspace(1, conn_max, num=grid_res, dtype=int))
-    else:
-        raise ValueError(f"Unknown dis_type: '{dis_type}'. Choose from 'uniform', 'log', 'monte_carlo'.")
+        Parameters
+        ----------
+        dis_type : str
+            Sampling strategy: 'uniform' (linear grid), 'log' (geometric grid),
+            or 'monte_carlo' (random sampling).
+        _N : int
+            Number of neurons per scale unit.
+        limit_gb : float
+            VRAM limit in gigabytes.
+        target_samples : int
+            Approximate number of valid states to generate (actual count ≈ ±50).
+        data_size : int
+            Bytes per element (4 for float32/int32, 1 for bool/int8).
+        scale_max : int
+            Upper bound of scale search range.
+        conn_max : int
+            Upper bound of conn_num search range.
 
-    valid_states = [
-        (int(s), int(c))
-        for s in scales_raw
-        for c in conn_nums_raw
-        if is_valid(s, c, homo)
-    ]
-    valid_states.sort(key=lambda state: state[0] * state[1])
-    print(f"Generated {len(valid_states)} valid parameter states under {limit_gb}GB boundary.")
-    return valid_states
+        Returns
+        -------
+        list of (scale, conn_num) tuples, sorted by memory footprint.
+        """
+        import numpy as np
 
-def memory_limit( conn_nums, scale:int ,_N:int = 4000 , limit: int = 16, data_type: str = 'float'):
-    if data_type == 'float': data_size = 4
-    if data_type == 'int': data_size = 4
-    if data_type == 'bool': data_size = 1
-    if data_type == 'char': data_size = 1
-    if conn_nums * data_size * scale * _N * 2 > limit * (1024 ** 3):
-        return True
-    else:
-        return False
+        if dis_type == 'monte_carlo':
+            valid_states = set()
+            while len(valid_states) < target_samples:
+                s = int(np.random.uniform(1, self.scale_max + 1))
+                c = int(np.random.uniform(1, self.conn_max + 1))
+                if self.is_valid_mv(s, c, homo, data_size):
+                    valid_states.add((s, None, c))
+            sorted_states = sorted(list(valid_states), key=lambda state: state[0] * state[2])
+            print(f"Generated {len(sorted_states)} valid parameter states under {self._limit_GB}GB boundary.")
+            return sorted_states
+
+        # For grid-based methods: the valid region is a curved hyperbolic area;
+        # ~3x oversampling of grid points relative to target gives ~±50 accuracy after filtering.
+        grid_res = int(np.sqrt(target_samples * 3))
+
+        if dis_type == 'uniform':
+            scales_raw = np.unique(np.linspace(1, self.scale_max, num=grid_res, dtype=int))
+            conn_nums_raw = np.unique(np.linspace(1, self.conn_max, num=grid_res, dtype=int))
+        elif dis_type == 'log':
+            scales_raw = np.unique(np.geomspace(1, self.scale_max, num=grid_res, dtype=int))
+            conn_nums_raw = np.unique(np.geomspace(1, self.conn_max, num=grid_res, dtype=int))
+        else:
+            raise ValueError(f"Unknown dis_type: '{dis_type}'. Choose from 'uniform', 'log', 'monte_carlo'.")
+
+        valid_states = [
+            (int(s), None, int(c))
+            for s in scales_raw
+            for c in conn_nums_raw
+            if self.is_valid_mv(s, c, homo, data_size)
+        ]
+        valid_states.sort(key=lambda state: state[0] * state[2])
+        print(f"Generated {len(valid_states)} valid parameter states under {self._limit_GB}GB boundary.")
+        return valid_states
+
+    def generate_boundary_params(
+        self,
+        homo_or_not: bool = True,
+        _N: int = 4000,
+        data_size: int = 4,
+        sample_points: int = 10,
+        include_dense_ref: bool = False,
+    ):
+        """Generate ``(conn, m)`` pairs near the GPU memory boundary.
+
+        Returns a list of ``(conn, m)`` tuples where ``m = scale * _N``, such
+        that the estimated memory usage stays just below *memory_limit* GiB.
+        Integer truncation (``int()``) is used so that values always lean
+        toward the **smaller** side to avoid overflow.
+
+        Memory model
+        -------------
+        * **Sparse arrays only** (``include_dense_ref=False``):
+        ``m * conn * data_size * times``
+        where *times* = 1 (homo, indices only) or 2 (hetero, indices + weights).
+
+        * **With dense reference** (``include_dense_ref=True``):
+        ``m * conn * data_size * times  +  m² * data_size``
+        Use this when the test constructs a full ``(m, m)`` dense matrix for
+        correctness comparison.
+
+        Parameters
+        ----------
+        memory_limit : float
+            GPU memory budget in GiB.
+        homo_or_not : bool
+            True  → only indices are stored (1× sparse budget).
+            False → indices + weights are stored (2× sparse budget).
+        scale_max : int
+            Upper bound for the scale factor *s* (``m = s * _N``).
+        conn_max : int
+            Maximum number of connections per row.
+        _N : int
+            Base neuron count per scale unit.
+        data_size : int
+            Bytes per element (4 for float32 / int32).
+        sample_points : int
+            Number of sample points to generate.
+        include_dense_ref : bool
+            If True, the budget also accounts for a dense ``(m, m)`` reference
+            matrix of size ``m² * data_size``.
+        """
+        
+        import math
+        import numpy as np
+
+        times = 1 if homo_or_not else 2
+
+        # K = budget expressed in units of (_N * data_size) bytes
+        K = self._limit_bytes / (_N * data_size)
+
+        # --- valid scale range ---------------------------------------------------
+        if include_dense_ref:
+            # For conn > 0 we need  K - s² * _N > 0  →  s < sqrt(K / _N)
+            s_max = min(self.scale_max, int(math.sqrt(K / _N)))
+        else:
+            # conn = K / (s * times) >= 1  →  s <= K / times
+            s_max = min(self.scale_max, int(K / times))
+
+        # s_min: when *not* including the dense ref, large s → small conn,
+        # which is fine; but very small s → conn > conn_max, wasting budget.
+        if not include_dense_ref:
+            s_min = max(1, math.ceil(K / (times * self.conn_max)))
+        else:
+            s_min = 1
+
+        if s_min > s_max:
+            raise ValueError(
+                f"No valid (conn, m) pairs: s_min={s_min} > s_max={s_max}. "
+                f"Try increasing memory_limit or decreasing scale_max/conn_max."
+            )
+
+        s_samples = np.geomspace(s_min, s_max, sample_points)
+
+        valid_pairs = []
+        seen = set()
+
+        for s_val in s_samples:
+            s_int = max(1, int(round(s_val)))
+            s_int = min(s_int, s_max)  # clamp
+
+            # Compute max conn (floor to stay below the boundary)
+            if include_dense_ref:
+                budget_for_sparse = K - s_int ** 2 * _N
+                if budget_for_sparse <= 0:
+                    continue
+                c_int = int(budget_for_sparse / (s_int * times))
+            else:
+                c_int = int(K / (s_int * times))
+
+            c_int = min(c_int, self.conn_max)
+
+            m = s_int * _N
+
+            if c_int > 0 and c_int <= m and s_int <= self.scale_max:
+                pair = (s_int, c_int)
+                if pair not in seen:
+                    seen.add(pair)
+                    valid_pairs.append(pair)
+
+        return valid_pairs
+
+    def make_simulation_params_probs(self, 
+                                     conn_prob : list, 
+                                     scale: list, 
+                                     limit_memory:int = 24,
+                                     data_size:int = 4,
+                                     homo:bool = True):
+        """Generate valid (scale, conn_num) pairs from probability & scale lists.
+
+        Parameters
+        ----------
+        conn_prob : list of float
+            Connection probabilities.
+        scale : list of int
+            Scale values to test.
+        limit_memory : int, optional
+            Override VRAM limit in GB (uses constructor default if None).
+        data_size : int
+            Bytes per element.
+        homo : bool
+            Homogeneous (1×) or heterogeneous (2×) memory multiplier.
+
+        Returns
+        -------
+        list of (scale, conn_num) tuples, filtered by VRAM limit.
+        """
+        valid_pairs = []
+        for s in scale:
+            for prob in conn_prob:
+                conn_number = int(prob * s * self._N)
+                if conn_number < 1:
+                    conn_number = 1
+                if self.is_valid_mv(s, conn_number, homo, data_size):
+                    single_point = (int(s), None, int(conn_number))
+                    valid_pairs.append(single_point)
+                else:
+                    continue
+        return valid_pairs
+
+    def generate_coba_vram_sequence(self,
+                                    vram_steps: list | None = None,
+                                    sample_points: int = 5,
+                                    homo: bool = True,
+                                    data_size: int = 4):
+        """Generate test parameters for progressive VRAM limit testing.
+
+        For each VRAM level, uses :meth:`generate_cs_pairs` to produce
+        ``(scale, conn)`` pairs near that VRAM boundary.
+
+        Parameters
+        ----------
+        vram_steps : list of int, optional
+            VRAM levels in GB to test (default: 1..24).
+        sample_points : int
+            Number of sample points per VRAM level.
+        homo : bool
+            Homogeneous or heterogeneous memory model.
+        data_size : int
+            Bytes per element.
+
+        Returns
+        -------
+        OrderedDict mapping vram_gb -> list of (scale, conn) tuples.
+        """
+        from collections import OrderedDict
+
+        if vram_steps is None:
+            vram_steps = list(range(1, 25))
+
+        result = OrderedDict()
+        for vram_gb in vram_steps:
+            gen = TestingParamsGenerator(
+                limit_GB=vram_gb,
+                _N=self._N,
+                scale_max=self.scale_max,
+                conn_max=self.conn_max,
+            )
+            try:
+                pairs = gen.generate_boundary_params(
+                    homo_or_not=homo,
+                    _N=self._N,
+                    data_size=data_size,
+                    sample_points=sample_points,
+                )
+                if pairs:
+                    result[vram_gb] = pairs
+            except ValueError:
+                continue
+
+        print(f"Generated VRAM sequence: {len(result)} levels, "
+              f"total {sum(len(v) for v in result.values())} parameter pairs.")
+        return result
+
+
+# Backward-compatible alias: external code uses ``BT.TestingParamsGenerator``
+TestingParamsGenerator = TestingParamsGenerator_mv
+
+
+class TestingParamsGenerator_mm:
+    """Generate valid (scale, batch_size, conn_num) triples for mm benchmarks.
+
+    Memory model
+    -------------
+    Total VRAM ≈ conn_num * m * data_size * times  +  batch_size * m * data_size
+    where ``m = scale * _N`` and ``times = 1`` (homo) or ``2`` (hetero).
+
+    The first term is the sparse connection index (and weight) storage;
+    the second is the batched event / result matrices.
+    """
+
+    def __init__(
+        self,
+        limit_GB: int = 24,
+        _N: int = 4000,
+        scale_max: int = 200,
+        conn_max: int = 4000,
+        batch_max: int = 128,
+    ):
+        self._limit_GB = limit_GB
+        self._N = _N
+        self._limit_bytes = self._limit_GB * (1024) ** 3
+        self.scale_max = scale_max
+        self.conn_max = conn_max
+        self.batch_max = batch_max
+
+    def is_valid_mm(self, scale: int, batch_size: int, conn: int,
+                 homo: bool, data_size: int = 4) -> bool:
+        times = 1 if homo else 2
+        size = scale * self._N
+        mem = conn * size * times + batch_size * size + size * batch_size
+        mem = mem * data_size
+        return mem <= self._limit_bytes and conn <= size
+
+    def generate_params(
+        self,
+        dis_type: str = 'uniform',
+        target_samples: int = 500,
+        data_size: int = 4,
+        homo: bool = True,
+    ) -> list:
+        """Generate valid ``(scale, batch_size, conn_num)`` triples within VRAM limits.
+
+        Parameters
+        ----------
+        dis_type : str
+            ``'uniform'`` (linear grid), ``'log'`` (geometric grid),
+            or ``'monte_carlo'`` (random sampling).
+        target_samples : int
+            Approximate number of valid triples to generate.
+        data_size : int
+            Bytes per element (4 for float32/int32).
+        homo : bool
+            Homogeneous (1×) or heterogeneous (2×) memory multiplier.
+
+        Returns
+        -------
+        list of ``(scale, batch_size, conn_num)`` tuples, sorted by estimated
+        memory footprint.
+        """
+        import numpy as np
+
+        if dis_type == 'monte_carlo':
+            valid = set()
+            while len(valid) < target_samples:
+                s = int(np.random.uniform(1, self.scale_max + 1))
+                b = int(np.random.uniform(1, self.batch_max + 1))
+                c = int(np.random.uniform(1, self.conn_max + 1))
+                if self.is_valid_mm(s, b, c, homo, data_size):
+                    valid.add((s, b, c))
+            result = sorted(valid, key=lambda t: t[0] * t[1] * t[2])
+            print(f"Generated {len(result)} valid mm parameter states under {self._limit_GB}GB boundary.")
+            return result
+
+        # For grid-based methods: cube-root oversampling
+        grid_res = max(3, int(round(target_samples ** (1.0 / 3) * 1.5)))
+
+        if dis_type == 'uniform':
+            scales_raw = np.unique(np.linspace(1, self.scale_max, num=grid_res, dtype=int))
+            batches_raw = np.unique(np.linspace(1, self.batch_max, num=grid_res, dtype=int))
+            conns_raw = np.unique(np.linspace(1, self.conn_max, num=grid_res, dtype=int))
+        elif dis_type == 'log':
+            scales_raw = np.unique(np.geomspace(1, self.scale_max, num=grid_res, dtype=int))
+            batches_raw = np.unique(np.geomspace(1, self.batch_max, num=grid_res, dtype=int))
+            conns_raw = np.unique(np.geomspace(1, self.conn_max, num=grid_res, dtype=int))
+        else:
+            raise ValueError(f"Unknown dis_type: '{dis_type}'. Choose from 'uniform', 'log', 'monte_carlo'.")
+
+        valid = [
+            (int(s), int(b), int(c))
+            for s in scales_raw
+            for b in batches_raw
+            for c in conns_raw
+            if self.is_valid_mm(s, b, c, homo, data_size)
+        ]
+        valid.sort(key=lambda t: t[0] * t[1] * t[2])
+        print(f"Generated {len(valid)} valid mm parameter states under {self._limit_GB}GB boundary.")
+        return valid
+
+    def make_simulation_params_probs(self, 
+                                     conn_prob : list, 
+                                     scale: list, 
+                                     batch_size: list,
+                                     limit_memory:int = 24,
+                                     data_size:int = 4,
+                                     
+                                     homo:bool = True):
+
+        valid_pairs = []
+        for s in scale:
+            for batch in batch_size:
+                for prob in conn_prob:
+                    conn_number = int(prob * s * self._N)
+                    if conn_number < 1:
+                        conn_number = 1
+                    if self.is_valid_mm(s, batch, conn_number, homo, data_size):
+                        single_point = (int(s), prob, int(conn_number), batch)
+                        valid_pairs.append(single_point)
+                    else:
+                        continue
+        return valid_pairs
+    
+    def generate_params_steps(
+        self,
+        target_points: int = 100,
+        step_ratio: tuple[float, float, float] = (1.0, 1.0, 1.0),
+        data_size: int = 4,
+        homo: bool = True,
+    ) -> list[tuple[int, int, int]]:
+        import math
+        import numpy as np
+
+        if target_points < 1:
+            raise ValueError("target_points must be >= 1")
+
+        if len(step_ratio) != 3:
+            raise ValueError("step_ratio must be a tuple of length 3: (scale_ratio, conn_ratio, batch_ratio)")
+
+        rs, rc, rb = step_ratio
+        if rs <= 0 or rc <= 0 or rb <= 0:
+            raise ValueError("All step_ratio values must be > 0")
+
+        def make_axis_points(max_val: int, n_points: int) -> np.ndarray:
+            """在 [1, max_val] 上均匀取 n_points 个整数点，并保证包含端点。"""
+            if max_val < 1:
+                raise ValueError(f"max_val must be >= 1, got {max_val}")
+            if n_points <= 1:
+                return np.array([1, max_val], dtype=int) if max_val > 1 else np.array([1], dtype=int)
+
+            pts = np.linspace(1, max_val, num=n_points)
+            pts = np.rint(pts).astype(int)
+            pts[0] = 1
+            pts[-1] = max_val
+            return np.unique(pts)
+
+        # 按比例分配三个维度的“采样密度”
+        # 希望 ns * nc * nb ≈ target_points
+        # 同时步长比例 ~ step_ratio
+        #
+        # 令三个维度采样点数与 1/ratio 成正比：
+        # ratio 越大，步长越粗，点数越少
+        inv_rs, inv_rc, inv_rb = 1.0 / rs, 1.0 / rc, 1.0 / rb
+        base = (target_points / (inv_rs * inv_rc * inv_rb)) ** (1.0 / 3.0)
+
+        n_scale = max(2, int(round(base * inv_rs)))
+        n_conn = max(2, int(round(base * inv_rc)))
+        n_batch = max(2, int(round(base * inv_rb)))
+
+        # 微调，尽量让乘积接近 target_points
+        def prod(a, b, c):
+            return a * b * c
+
+        counts = [n_scale, n_conn, n_batch]
+        invs = [inv_rs, inv_rc, inv_rb]
+
+        # 若点数太少，不断给“最该加密”的维度加 1
+        while prod(*counts) < target_points:
+            scores = [invs[i] / counts[i] for i in range(3)]
+            idx = int(np.argmax(scores))
+            counts[idx] += 1
+
+        # 若点数明显过多，尝试减小
+        while min(counts) > 2:
+            current = prod(*counts)
+            best_idx = None
+            best_over = current - target_points
+            for i in range(3):
+                if counts[i] <= 2:
+                    continue
+                trial = counts.copy()
+                trial[i] -= 1
+                trial_prod = prod(*trial)
+                if trial_prod >= target_points and (trial_prod - target_points) < best_over:
+                    best_idx = i
+                    best_over = trial_prod - target_points
+            if best_idx is None:
+                break
+            counts[best_idx] -= 1
+
+        n_scale, n_conn, n_batch = counts
+
+        scales_raw = make_axis_points(self.scale_max, n_scale)
+        conns_raw = make_axis_points(self.conn_max, n_conn)
+        batches_raw = make_axis_points(self.batch_max, n_batch)
+
+        valid = [
+            (int(s), int(b), int(c))
+            for s in scales_raw
+            for c in conns_raw
+            for b in batches_raw
+            if self.is_valid_mm(s, b, c, homo, data_size)
+        ]
+
+        valid.sort(key=lambda t: (t[0], t[2], t[1]))
+
+        print(
+            f"Generated {len(valid)} valid mm parameter states "
+            f"under {self._limit_GB}GB boundary. "
+            f"(grid: {len(scales_raw)} x {len(conns_raw)} x {len(batches_raw)} = "
+            f"{len(scales_raw) * len(conns_raw) * len(batches_raw)})"
+        )
+        return valid

--- a/dev/fcn/COBA_2005_binary_fcnmm_CsvOuput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmm_CsvOuput.py
@@ -44,480 +44,86 @@ scales_pre = [1, 2, 4, 6, 8, 10, 20, 40, 60]
 backends = ['jax_raw', 'cuda_raw']
 conn_nums = [20, 40, 80, 160, 320, 640]
 probs = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64]
+default_batch_sizes = [1, 4, 16]
 
-def benchmark_post_conn(batch_size=16, conn_num=None, conn_prob=None, data_type='binary', duration=1e3 * u.ms, homo: bool = True, backend: str | None = None, probs_or_conn='conn'):
-    # --------------------------------
-    # 2026/03/08, batch_size, conn_num, data_type, duration = 16, 80, 'binary', 1e3 * u.ms
-    # --------------------------------
-    #
-    # scale=1, size=4000, time = 0.2206423282623291 s, firing rate = 59.4550666809082 Hz
-    # scale=2, size=8000, time = 0.31554341316223145 s, firing rate = 59.44181442260742 Hz
-    # scale=4, size=16000, time = 0.6682348251342773 s, firing rate = 59.4439697265625 Hz
-    # scale=6, size=24000, time = 0.9589388370513916 s, firing rate = 59.44413375854492 Hz
-    # scale=8, size=32000, time = 1.2952101230621338 s, firing rate = 59.44554901123047 Hz
-    # scale=10, size=40000, time = 1.708672285079956 s, firing rate = 59.44718551635742 Hz
-    # scale=20, size=80000, time = 3.7858314514160156 s, firing rate = 59.445011138916016 Hz
-    # scale=40, size=160000, time = 7.926112413406372 s, firing rate = 59.444637298583984 Hz
-    # scale=60, size=240000, time = 12.231749296188354 s, firing rate = 59.444488525390625 Hz
-    # scale=80, size=320000, time = 16.75143575668335 s, firing rate = 59.44343566894531 Hz
-    # scale=100, size=400000, time = 21.40729546546936 s, firing rate = 59.444156646728516 Hz
-    #
-    # --------------------------------
-    # 2026/03/09, batch_size, conn_num, data_type, duration = 16, 80, 'binary', 1e3 * u.ms
-    # --------------------------------
-    #
-    # scale=1, size=4000, time = 0.20499849319458008 s, firing rate = 59.44215774536133 Hz
-    # scale=2, size=8000, time = 0.26866841316223145 s, firing rate = 59.4437141418457 Hz
-    # scale=4, size=16000, time = 0.5763185024261475 s, firing rate = 59.44135665893555 Hz
-    # scale=6, size=24000, time = 0.8228826522827148 s, firing rate = 59.4480094909668 Hz
-    # scale=8, size=32000, time = 1.1048240661621094 s, firing rate = 59.441978454589844 Hz
-    # scale=10, size=40000, time = 1.4418222904205322 s, firing rate = 59.44264221191406 Hz
-    # scale=20, size=80000, time = 3.3926408290863037 s, firing rate = 59.442787170410156 Hz
-    # scale=40, size=160000, time = 7.364571809768677 s, firing rate = 59.44438552856445 Hz
-    # scale=60, size=240000, time = 11.60580325126648 s, firing rate = 59.443275451660156 Hz
-    # scale=80, size=320000, time = 15.990403890609741 s, firing rate = 59.44479751586914 Hz
-    # scale=100, size=400000, time = 20.511342525482178 s, firing rate = 59.44398880004883 Hz
+def benchmark_conn( mode = 'post',  
+                   conn_num=None, 
+                   conn_prob=None, 
+                   data_type='binary', 
+                   duration=1e3 * u.ms, homo: bool = True, backend: str | None = None, probs_or_conn='conn'):
+
     print('Benchmarking post-synaptic connection updates...')
 
     import dev.fcn.BenchmarkTools as BT
 
     backends_to_use = [backend] if backend is not None else backends
 
-    if probs_or_conn == 'conn':
-        use_conn_nums = True
-        conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
+    if mode == 'post':
+        scales = scales_post
     else:
-        use_conn_nums = False
-        probs_to_use = [conn_prob] if conn_prob is not None else probs
+        scales = scales_pre
 
-    csv_recorder = BT.CSV_record('binary_post', 'fcnmm', 'coba', duration=duration, conn=conn_num)
+    batch_list = default_batch_sizes
+    TPGenerator = BT.TestingParamsGenerator_mm(limit_GB=6)
+
+    if probs_or_conn == 'conn':
+        conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
+        valid_pairs = []
+        for s in scales:
+            for b in batch_list:
+                for cn in conn_nums_to_use:
+                    #if TPGenerator.is_valid_mm(s, b, cn, homo):
+                    valid_pairs.append((s, None, cn, b))
+    else:
+        probs_to_use = [conn_prob] if conn_prob is not None else probs
+        valid_pairs = TPGenerator.make_simulation_params_probs(probs_to_use, scales, batch_list)
+
+    csv_recorder = BT.CSV_record(f'binary_{mode}', 'fcnmm', 'coba', duration=duration)
+
+    homo_str = 'homo' if homo else 'hetero'
+    last_path = None
 
     for back in backends_to_use:
         brainevent.config.set_backend('gpu', back)
+        csv_recorder.print_header(operator='fcnmm', data_type=data_type, backend=back,
+                mode=mode, duration=duration, homo=('homo' if homo else 'hetero'))
+        csv_recorder.print_table_header(show_batch=True, show_conn=True)
 
-        if use_conn_nums:
-            for cn in conn_nums_to_use:
-                csv_recorder.print_header(operator='fcnmm', data_type=data_type, backend=back,
-                        mode='post', batch_size=batch_size, conn_num=cn,
-                        duration=duration, homo=('homo' if homo else 'hetero'))
-                csv_recorder.print_table_header()
+        for scale, prob, cn, batch in valid_pairs:
 
-                for s in scales_post:
-                    try:
-                        run = make_simulation_batch_run(
-                            scale=s,
-                            batch_size=batch_size,
-                            data_type=data_type,
-                            efferent_target='post',
-                            duration=duration,
-                            conn_num=cn,
-                            homo=homo,
-                        )
+            try:
+                run = make_simulation_batch_run(
+                    scale=scale,
+                    batch_size=batch,
+                    data_type=data_type,
+                    efferent_target=mode,
+                    duration=duration,
+                    conn_num=cn,
+                    homo=homo,
+                )
 
-                        jax.block_until_ready(run())
+                jax.block_until_ready(run())
 
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate))
-                        csv_recorder.single_COBA_data_add('fcnmm', data_type, back, 'post', cn, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={cn}: {e}')
-                        continue
-        else:
-            for prob in probs_to_use:
-                csv_recorder.print_header(operator='fcnmm', data_type=data_type, backend=back,
-                        mode='post', batch_size=batch_size, duration=duration,
-                        homo=('homo' if homo else 'hetero'), prob=prob)
-                csv_recorder.print_table_header(show_conn=True)
+                t0 = time.time()
+                n, rate = jax.block_until_ready(run())
+                t1 = time.time()
+                elapsed = t1 - t0
+                csv_recorder.print_row(scale, n, elapsed, float(rate), batch_size=batch, conn_num=cn)
+                
+                csv_recorder.single_COBA_data_add('fcnmm', data_type, back, mode, cn, scale, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'), batch_size=batch)
+                
+                flush_file_name = f'mm_{data_type}_{homo_str}_{back}_{mode}'
 
-                for s in scales_post:
-                    actual_conn_num = s * prob
-                    try:
-                        run = make_simulation_batch_run(
-                            scale=s,
-                            batch_size=batch_size,
-                            data_type=data_type,
-                            efferent_target='post',
-                            duration=duration,
-                            conn_num=actual_conn_num,
-                            homo=homo,
-                        )
+                last_path = csv_recorder.flush_and_clear(flush_file_name, dir='result-mm')
+            except Exception as e:
+                print(f'  [Error] scale={scale}, conn_num={cn}: {e}')
+                continue
 
-                        jax.block_until_ready(run())
+    if last_path:
+        print(f'\nDone. Results saved to: {last_path}')
 
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=actual_conn_num)
-                        csv_recorder.single_COBA_data_add('fcnmm', data_type, back, 'post', actual_conn_num, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={actual_conn_num}: {e}')
-                        continue
-    csv_recorder.record_finish('test')
-
-def benchmark_pre_conn(batch_size=16, conn_num=None, conn_prob=None, data_type='binary', duration=1e3 * u.ms, homo: bool = True, backend: str | None = None, probs_or_conn='conn'):
-    print('Benchmarking pre-synaptic connection updates...')
-    import dev.fcn.BenchmarkTools as BT
-
-    backends_to_use = [backend] if backend is not None else backends
-
-    if probs_or_conn == 'conn':
-        use_conn_nums = True
-        conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
-    else:
-        use_conn_nums = False
-        probs_to_use = [conn_prob] if conn_prob is not None else probs
-
-    csv_recorder = BT.CSV_record('binary_pre', 'fcnmm', 'coba', duration=duration, conn=conn_num)
-
-    for back in backends_to_use:
-        brainevent.config.set_backend('gpu', back)
-
-        if use_conn_nums:
-            for cn in conn_nums_to_use:
-                csv_recorder.print_header(operator='fcnmm', data_type=data_type, backend=back,
-                        mode='pre', batch_size=batch_size, conn_num=cn,
-                        duration=duration, homo=('homo' if homo else 'hetero'))
-                csv_recorder.print_table_header()
-
-                for s in scales_pre:
-                    try:
-                        run = make_simulation_batch_run(
-                            scale=s,
-                            batch_size=batch_size,
-                            data_type=data_type,
-                            efferent_target='pre',
-                            duration=duration,
-                            conn_num=cn,
-                            homo=homo,
-                        )
-
-                        jax.block_until_ready(run())
-
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate))
-                        csv_recorder.single_COBA_data_add('fcnmm', data_type, back, 'pre', cn, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={cn}: {e}')
-                        continue
-        else:
-            for prob in probs_to_use:
-                csv_recorder.print_header(operator='fcnmm', data_type=data_type, backend=back,
-                        mode='pre', batch_size=batch_size, duration=duration,
-                        homo=('homo' if homo else 'hetero'), prob=prob)
-                csv_recorder.print_table_header(show_conn=True)
-
-                for s in scales_pre:
-                    actual_conn_num = s * prob  # non-linear: conn_num scales with network size
-                    try:
-                        run = make_simulation_batch_run(
-                            scale=s,
-                            batch_size=batch_size,
-                            data_type=data_type,
-                            efferent_target='pre',
-                            duration=duration,
-                            conn_num=actual_conn_num,
-                            homo=homo,
-                        )
-
-                        jax.block_until_ready(run())
-
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=actual_conn_num)
-                        csv_recorder.single_COBA_data_add('fcnmm', data_type, back, 'pre', actual_conn_num, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={actual_conn_num}: {e}')
-                        continue
-    csv_recorder.record_finish('default')
-
-def run_benchmark(batch_size, conn_num=None, mode='post', homo: bool = True, backend: str | None = None):
-
-    import dev.fcn.BenchmarkTools as BT
-
-    conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
-    dur = 1e3 * u.ms if mode == 'post' else 1e2 * u.ms
-
-    # Scales to benchmark (network sizes: scale * 4000 neurons)
-    SCALES = [1, 4, 10, 40, 100]
-
-    # Determine which backends to use
-    backends_to_use = [backend] if backend is not None else backends
-
-    for cn in conn_nums_to_use:
-        kernel = 'warp' if cn <= 32 else 'basic'
-
-        # CSV recorder for this configuration
-        csv_recorder = BT.CSV_record(f'binary_bs{batch_size}_conn{cn}', 'fcnmm', 'benchmark', duration=dur, conn=cn)
-
-        for back in backends_to_use:
-            brainevent.config.set_backend('gpu', back)
-            csv_recorder.print_header(operator='fcnmm', data_type='binary', backend=back,
-                    mode=mode, batch_size=batch_size, conn_num=cn,
-                    duration=dur, kernel=kernel, homo=('homo' if homo else 'hetero'))
-            csv_recorder.print_table_header()
-
-            for s in SCALES:
-                try:
-                    run = make_simulation_batch_run(
-                        scale=s,
-                        batch_size=batch_size,
-                        data_type='binary',
-                        efferent_target=mode,
-                        duration=dur,
-                        conn_num=cn,
-                        homo=homo,
-                    )
-
-                    # Warmup
-                    jax.block_until_ready(run())
-
-                    # Timed run
-                    t0 = time.time()
-                    n, rate = jax.block_until_ready(run())
-                    t1 = time.time()
-                    elapsed = t1 - t0
-                    csv_recorder.print_row(s, n, elapsed, float(rate))
-                    csv_recorder.single_COBA_data_add('fcnmm', 'binary', back, mode, cn, s, elapsed, float(rate), dur, homo=('homo' if homo else 'hetero'))
-                except Exception as e:
-                    print(f'  [Error] scale={s}, conn_num={cn}: {e}')
-                    continue
-
-        # flush CSV for this config
-        csv_recorder.record_finish('default')
-
-
+'''
 def bench_fcnmm():
-    # Binary FCNMM Kernel Benchmark, 2026/03/08
-    # ======================================================================
-    # 
-    #   batch_size=16, conn_num=16 (warp kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.158s, rate=53.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.451s, rate=53.5 Hz
-    #   scale= 10, neurons= 40000, time=   1.118s, rate=53.5 Hz
-    #   scale= 40, neurons=160000, time=   4.851s, rate=53.5 Hz
-    #   scale=100, neurons=400000, time=  12.255s, rate=53.5 Hz
-    # 
-    #   batch_size=16, conn_num=32 (warp kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.197s, rate=54.2 Hz
-    #   scale=  4, neurons= 16000, time=   0.502s, rate=54.2 Hz
-    #   scale= 10, neurons= 40000, time=   1.144s, rate=54.2 Hz
-    #   scale= 40, neurons=160000, time=   5.175s, rate=54.2 Hz
-    #   scale=100, neurons=400000, time=  13.472s, rate=54.2 Hz
-    # 
-    #   batch_size=32, conn_num=16 (warp kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.207s, rate=53.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.802s, rate=53.5 Hz
-    #   scale= 10, neurons= 40000, time=   2.146s, rate=53.5 Hz
-    #   scale= 40, neurons=160000, time=   8.700s, rate=53.5 Hz
-    #   scale=100, neurons=400000, time=  22.231s, rate=53.5 Hz
-    # 
-    #   batch_size=32, conn_num=32 (warp kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.202s, rate=54.2 Hz
-    #   scale=  4, neurons= 16000, time=   0.799s, rate=54.2 Hz
-    #   scale= 10, neurons= 40000, time=   2.286s, rate=54.2 Hz
-    #   scale= 40, neurons=160000, time=   9.847s, rate=54.2 Hz
-    #   scale=100, neurons=400000, time=  25.579s, rate=54.2 Hz
-    # 
-    #   batch_size=16, conn_num=80 (basic kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.223s, rate=59.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.651s, rate=59.5 Hz
-    #   scale= 10, neurons= 40000, time=   1.742s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=   8.071s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time=  21.558s, rate=59.4 Hz
-    # 
-    #   batch_size=16, conn_num=128 (basic kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.226s, rate=70.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.653s, rate=70.6 Hz
-    #   scale= 10, neurons= 40000, time=   1.763s, rate=70.6 Hz
-    #   scale= 40, neurons=160000, time=   9.650s, rate=70.6 Hz
-    #   scale=100, neurons=400000, time=  28.570s, rate=70.6 Hz
-    # 
-    #   batch_size=32, conn_num=80 (basic kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.350s, rate=59.4 Hz
-    #   scale=  4, neurons= 16000, time=   1.318s, rate=59.4 Hz
-    #   scale= 10, neurons= 40000, time=   3.556s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=  15.561s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time=  41.009s, rate=59.4 Hz
-    # 
-    #   batch_size=32, conn_num=128 (basic kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.344s, rate=70.6 Hz
-    #   scale=  4, neurons= 16000, time=   1.262s, rate=70.6 Hz
-    #   scale= 10, neurons= 40000, time=   3.759s, rate=70.6 Hz
-    #   scale= 40, neurons=160000, time=  21.000s, rate=70.6 Hz
-    #   scale=100, neurons=400000, time=  68.620s, rate=70.6 Hz
-    # 
-    #   batch_size=64, conn_num=80 (basic kernel) [post-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   1.220s, rate=59.4 Hz
-    #   scale=  4, neurons= 16000, time=   5.679s, rate=59.4 Hz
-    #   scale= 10, neurons= 40000, time=  16.934s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=  78.643s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time= 205.231s, rate=59.4 Hz
-    # 
-    # 
-    # ######################################################################
-    # # Scatter mode (pre-synaptic)
-    # ######################################################################
-    # 
-    #   batch_size=16, conn_num=16 (warp kernel) [pre-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.107s, rate=53.8 Hz
-    #   scale=  4, neurons= 16000, time=   0.110s, rate=53.8 Hz
-    #   scale= 10, neurons= 40000, time=   0.249s, rate=53.8 Hz
-    #   scale= 40, neurons=160000, time=   1.565s, rate=53.9 Hz
-    #   scale=100, neurons=400000, time=   4.551s, rate=53.9 Hz
-    # 
-    #   batch_size=16, conn_num=80 (basic kernel) [pre-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.079s, rate=73.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.294s, rate=73.5 Hz
-    #   scale= 10, neurons= 40000, time=   1.102s, rate=73.6 Hz
-    #   scale= 40, neurons=160000, time=   6.170s, rate=73.6 Hz
-    #   scale=100, neurons=400000, time=  18.775s, rate=73.6 Hz
-    # 
-    #   batch_size=32, conn_num=80 (basic kernel) [pre-synaptic]
-    # -------
-    #   scale=  1, neurons=  4000, time=   0.116s, rate=73.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.494s, rate=73.6 Hz
-    #   scale= 10, neurons= 40000, time=   1.349s, rate=73.6 Hz
-    #   scale= 40, neurons=160000, time=  12.581s, rate=73.6 Hz
-    #   scale=100, neurons=400000, time=  43.576s, rate=73.6 Hz
-    # 
-
-    # Binary FCNMM Kernel Benchmark, 2026/03/09
-    # ======================================================================
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=16 (warp kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.165s, rate=53.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.381s, rate=53.5 Hz
-    #   scale= 10, neurons= 40000, time=   0.948s, rate=53.5 Hz
-    #   scale= 40, neurons=160000, time=   4.219s, rate=53.5 Hz
-    #   scale=100, neurons=400000, time=  10.843s, rate=53.5 Hz
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=32 (warp kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.196s, rate=54.2 Hz
-    #   scale=  4, neurons= 16000, time=   0.482s, rate=54.2 Hz
-    #   scale= 10, neurons= 40000, time=   1.014s, rate=54.2 Hz
-    #   scale= 40, neurons=160000, time=   4.761s, rate=54.2 Hz
-    #   scale=100, neurons=400000, time=  12.749s, rate=54.2 Hz
-    #
-    # ======================================================================
-    #   batch_size=32, conn_num=16 (warp kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.197s, rate=53.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.788s, rate=53.5 Hz
-    #   scale= 10, neurons= 40000, time=   2.038s, rate=53.5 Hz
-    #   scale= 40, neurons=160000, time=   8.396s, rate=53.5 Hz
-    #   scale=100, neurons=400000, time=  21.495s, rate=53.5 Hz
-    #
-    # ======================================================================
-    #   batch_size=32, conn_num=32 (warp kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.218s, rate=54.2 Hz
-    #   scale=  4, neurons= 16000, time=   0.794s, rate=54.2 Hz
-    #   scale= 10, neurons= 40000, time=   2.192s, rate=54.2 Hz
-    #   scale= 40, neurons=160000, time=   9.736s, rate=54.2 Hz
-    #   scale=100, neurons=400000, time=  25.324s, rate=54.2 Hz
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=80 (basic kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.215s, rate=59.4 Hz
-    #   scale=  4, neurons= 16000, time=   0.579s, rate=59.4 Hz
-    #   scale= 10, neurons= 40000, time=   1.446s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=   7.382s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time=  20.410s, rate=59.4 Hz
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=128 (basic kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.207s, rate=70.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.588s, rate=70.6 Hz
-    #   scale= 10, neurons= 40000, time=   1.502s, rate=70.6 Hz
-    #   scale= 40, neurons=160000, time=   9.337s, rate=70.6 Hz
-    #   scale=100, neurons=400000, time=  28.471s, rate=70.6 Hz
-    #
-    # ======================================================================
-    #   batch_size=32, conn_num=80 (basic kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.236s, rate=59.4 Hz
-    #   scale=  4, neurons= 16000, time=   0.923s, rate=59.4 Hz
-    #   scale= 10, neurons= 40000, time=   2.891s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=  14.404s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time=  39.242s, rate=59.4 Hz
-    #
-    # ======================================================================
-    #   batch_size=32, conn_num=128 (basic kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.243s, rate=70.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.964s, rate=70.6 Hz
-    #   scale= 10, neurons= 40000, time=   3.355s, rate=70.6 Hz
-    #   scale= 40, neurons=160000, time=  20.675s, rate=70.6 Hz
-    #   scale=100, neurons=400000, time=  58.189s, rate=70.6 Hz
-    #
-    # ======================================================================
-    #   batch_size=64, conn_num=80 (basic kernel) [post-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.501s, rate=59.5 Hz
-    #   scale=  4, neurons= 16000, time=   2.040s, rate=59.4 Hz
-    #   scale= 10, neurons= 40000, time=   6.091s, rate=59.4 Hz
-    #   scale= 40, neurons=160000, time=  30.282s, rate=59.4 Hz
-    #   scale=100, neurons=400000, time=  80.439s, rate=59.4 Hz
-    #
-    #
-    # ######################################################################
-    # # Scatter mode (pre-synaptic)
-    # ######################################################################
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=16 (warp kernel) [pre-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.089s, rate=53.9 Hz
-    #   scale=  4, neurons= 16000, time=   0.104s, rate=53.9 Hz
-    #   scale= 10, neurons= 40000, time=   0.212s, rate=53.8 Hz
-    #   scale= 40, neurons=160000, time=   0.734s, rate=53.9 Hz
-    #   scale=100, neurons=400000, time=   1.781s, rate=53.9 Hz
-    #
-    # ======================================================================
-    #   batch_size=16, conn_num=80 (basic kernel) [pre-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.116s, rate=73.5 Hz
-    #   scale=  4, neurons= 16000, time=   0.381s, rate=73.6 Hz
-    #   scale= 10, neurons= 40000, time=   0.841s, rate=73.6 Hz
-    #   scale= 40, neurons=160000, time=   2.992s, rate=73.6 Hz
-    #   scale=100, neurons=400000, time=   8.067s, rate=73.6 Hz
-    #
-    # ======================================================================
-    #   batch_size=32, conn_num=80 (basic kernel) [pre-synaptic]
-    # ======================================================================
-    #   scale=  1, neurons=  4000, time=   0.137s, rate=73.6 Hz
-    #   scale=  4, neurons= 16000, time=   0.360s, rate=73.6 Hz
-    #   scale= 10, neurons= 40000, time=   0.947s, rate=73.6 Hz
-    #   scale= 40, neurons=160000, time=   3.346s, rate=73.6 Hz
-    #   scale=100, neurons=400000, time=   8.856s, rate=73.6 Hz
-
-
 
     brainevent.config.set_backend('gpu', 'cuda_raw')
 
@@ -555,10 +161,15 @@ def bench_fcnmm():
     ]
     for batch_size, conn_num, desc in scatter_configs:
         run_benchmark(batch_size, conn_num, mode='pre', backend=None)
-
+'''
 
 if __name__ == '__main__':
-    benchmark_post_conn(batch_size=16, conn_num=80, data_type='binary', duration=1e3 * u.ms, homo = True)
+    benchmark_conn(data_type='compact',mode='post',  duration=1e2 * u.ms, homo = True, backend='cuda_raw', probs_or_conn='conn')
+    benchmark_conn(data_type='compact',mode='pre',  duration=1e2 * u.ms, homo = True, backend='cuda_raw', probs_or_conn='conn')
+    benchmark_conn(data_type='bitpack',mode='post',  duration=1e2 * u.ms, homo = True, backend='cuda_raw', probs_or_conn='conn')
+    benchmark_conn(data_type='bitpack',mode='pre',  duration=1e2 * u.ms, homo = True, backend='cuda_raw', probs_or_conn='conn')
+
+    #benchmark_conn(data_type='binary',mode='post',  duration=1e2 * u.ms, homo = True, backend='jax_raw')
     #benchmark_pre_conn(batch_size=16, conn_num=80, data_type='binary', duration=1e3 * u.ms, homo = True)
     #bench_fcnmm()
     

--- a/dev/fcn/COBA_2005_binary_fcnmm_VRAM_limit_CsvOutput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmm_VRAM_limit_CsvOutput.py
@@ -1,0 +1,362 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+VRAM boundary benchmark for COBA 2005 (binary_fcnmm operator).
+
+This version connects:
+1. BT.TestingParamsGenerator_mm.generate_params_steps(...)
+2. the simulation / operator run path
+3. CSV recording of both theoretical memory estimate and actual runtime outcome
+
+Recommended use for memory-boundary probing:
+    backend='cuda_fake'
+"""
+
+import gc
+import sys
+import time
+import warnings
+import logging
+from pathlib import Path
+
+_project_root = str(Path(__file__).resolve().parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+import brainunit as u
+import jax
+
+import brainevent
+from COBA_2005_benchmark import make_simulation_batch_run
+
+backends = ['cuda_fake']
+DEFAULT_DATA_SIZE = 4
+
+
+class _WarningCollector(logging.Handler):
+    """Temporary logging handler that collects warning-level records."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def has_memory_warning(self) -> bool:
+        keywords = ('memory', 'allocation', 'resource', 'oom', 'exceeds')
+        for r in self.records:
+            msg = r.getMessage().lower()
+            if any(k in msg for k in keywords):
+                return True
+        return False
+
+    def clear(self):
+        self.records.clear()
+
+
+def _estimate_mm_bytes(scale: int, batch_size: int, conn: int, _N: int, homo: bool, data_size: int) -> int:
+    """
+    Match the current static memory model used by TestingParamsGenerator_mm.is_valid_mm:
+        size = scale * _N
+        mem_elems = conn * size * times + batch_size * size + size * batch_size
+        mem_bytes = mem_elems * data_size
+    """
+    times = 1 if homo else 2
+    size = scale * _N
+    mem_elems = conn * size * times + batch_size * size + size * batch_size
+    return int(mem_elems * data_size)
+
+
+def _safe_clear_runtime_cache():
+    """Best-effort cleanup between test points."""
+    try:
+        jax.clear_caches()
+    except Exception:
+        pass
+    gc.collect()
+
+
+def benchmark_vram_limit(
+    data_type: str = 'binary',
+    duration=1e2 * u.ms,
+    homo: bool = True,
+    backend: str | None = None,
+    efferent_target: str = 'pre',
+    _N: int = 4000,
+    vram_limit: int = 23,
+    sample_points: int = 100,
+    scale_max: int = 1000,
+    conn_max: int = 1000,
+    batch_max: int = 1000,
+    data_size: int = DEFAULT_DATA_SIZE,
+    stop_on_oom: bool = False,
+    do_warmup: bool = True,
+):
+    """
+    VRAM-boundary benchmark for the fcnmm operator.
+
+    Workflow
+    --------
+    1. Build candidate (scale, batch_size, conn) points with
+       BT.TestingParamsGenerator_mm.generate_params_steps(...).
+    2. Run the operator path through make_simulation_batch_run(...)
+       using the selected backend (recommended: cuda_fake).
+    3. Record per-point outcome into CSV.
+
+    Notes
+    -----
+    - The generated parameter points are filtered by the BT-side static memory model.
+    - Actual runtime may still show JAX warnings or OOM due to allocator/runtime overhead.
+    """
+
+    import dev.fcn.BenchmarkTools as BT
+
+    print('=== VRAM boundary benchmark (fcnmm) ===')
+
+    backends_to_use = [backend] if backend is not None else backends
+
+    generator = BT.TestingParamsGenerator_mm(
+        limit_GB=vram_limit,
+        _N=_N,
+        scale_max=scale_max,
+        conn_max=conn_max,
+        batch_max=batch_max,
+    )
+
+    # Hook into the BT generator the user is building.
+    vram_params = generator.generate_params_steps(
+    target_points=100,
+    step_ratio=(1.0, 1.0, 4.0),
+    data_size=data_size,
+    homo=homo,
+    )
+
+    print(f'Generated {len(vram_params)} candidate points from BT generator.')
+
+    csv_recorder = BT.CSV_record(
+        f'vram_limit_{efferent_target}',
+        'fcnmm',
+        'coba',
+        duration=duration,
+    )
+
+    log_collector = _WarningCollector()
+    jax_logger = logging.getLogger('jax')
+    xla_logger = logging.getLogger('jaxlib')
+    root_logger = logging.getLogger()
+    for lgr in (jax_logger, xla_logger, root_logger):
+        lgr.addHandler(log_collector)
+
+    homo_str = 'homo' if homo else 'hetero'
+    flush_file_name = f'mm-vram_limit_{data_type}_{homo_str}_{efferent_target}'
+    last_path = None
+
+    total_points = len(vram_params)
+    n_ok = 0
+    n_warn = 0
+    n_oom = 0
+    n_error = 0
+
+    try:
+        for back in backends_to_use:
+            print(f'\n--- Backend: {back} ---')
+            brainevent.config.set_backend('gpu', back)
+
+            csv_recorder.print_header(
+                operator='fcnmm',
+                data_type=data_type,
+                backend=back,
+                mode=efferent_target,
+                duration=duration,
+                homo=homo_str,
+            )
+            csv_recorder.print_table_header(show_conn=True, show_batch=True)
+
+            for idx, (scale, batch_size, conn) in enumerate(vram_params, start=1):
+                _safe_clear_runtime_cache()
+                log_collector.clear()
+
+                current_vram_bytes = _estimate_mm_bytes(
+                    scale=scale,
+                    batch_size=batch_size,
+                    conn=conn,
+                    _N=_N,
+                    homo=homo,
+                    data_size=data_size,
+                )
+                current_vram_gib = current_vram_bytes / (1024 ** 3)
+
+                csv_recorder.add_tag('current_VRAM_GiB', f'{current_vram_gib:.6f}')
+                csv_recorder.add_tag('current_VRAM_bytes', current_vram_bytes)
+                csv_recorder.add_tag('limit_GB', vram_limit)
+                csv_recorder.add_tag('backend_test', back)
+                csv_recorder.add_tag('point_index', f'{idx}/{total_points}')
+                csv_recorder.add_tag('params', f'scale={scale},batch={batch_size},conn={conn}')
+
+                try:
+                    with warnings.catch_warnings(record=True) as py_warnings:
+                        warnings.simplefilter('always')
+
+                        run = make_simulation_batch_run(
+                            scale=scale,
+                            batch_size=batch_size,
+                            data_type=data_type,
+                            efferent_target=efferent_target,
+                            duration=duration,
+                            conn_num=conn,
+                            homo=homo,
+                        )
+
+                        if do_warmup:
+                            jax.block_until_ready(run())
+
+                        t0 = time.time()
+                        out = jax.block_until_ready(run())
+                        t1 = time.time()
+                        elapsed = t1 - t0
+
+                    # Keep compatibility with the original benchmark's expected return.
+                    if isinstance(out, tuple) and len(out) >= 2:
+                        n, rate = out[0], out[1]
+                        rate_value = float(rate)
+                    else:
+                        n = -1
+                        rate_value = -1.0
+
+                    jax_warned = log_collector.has_memory_warning()
+                    py_mem_warned = any(
+                        any(k in str(w.message).lower() for k in ('memory', 'allocation', 'resource', 'oom', 'exceeds'))
+                        for w in py_warnings
+                    )
+
+                    if jax_warned or py_mem_warned:
+                        msg = 'JAX_warning'
+                        n_warn += 1
+                    else:
+                        msg = 'OK'
+                        n_ok += 1
+
+                    csv_recorder.add_tag('message', msg)
+                    csv_recorder.print_row(
+                        scale,
+                        n,
+                        elapsed,
+                        rate_value,
+                        conn_num=conn,
+                        batch_size=batch_size,
+                    )
+                    csv_recorder.single_COBA_data_add(
+                        'fcnmm',
+                        data_type,
+                        back,
+                        efferent_target,
+                        conn,
+                        scale,
+                        elapsed,
+                        rate_value,
+                        duration,
+                        homo=homo_str,
+                        batch_size=batch_size,
+                    )
+                    last_path = csv_recorder.flush_and_clear(
+                        flush_file_name,
+                        dir='result-vram-limit_cuda-fake',
+                    )
+
+                    print(
+                        f'[{idx:04d}/{total_points:04d}] {msg:<12} '
+                        f'scale={scale:<4d} batch={batch_size:<6d} conn={conn:<6d} '
+                        f'est={current_vram_gib:8.4f} GiB elapsed={elapsed:8.4f}s'
+                    )
+
+                except Exception as e:
+                    error_msg = str(e).lower()
+                    is_oom = any(
+                        kw in error_msg for kw in (
+                            'resource_exhausted',
+                            'resource exhausted',
+                            'out of memory',
+                            'oom',
+                            'failed to allocate',
+                        )
+                    )
+
+                    if is_oom:
+                        n_oom += 1
+                        csv_recorder.add_tag('message', 'Device_error')
+                    else:
+                        n_error += 1
+                        csv_recorder.add_tag('message', 'Error')
+
+                    csv_recorder.add_tag('exception', str(e))
+                    csv_recorder.add_tag('current_VRAM_GiB', f'{current_vram_gib:.6f}')
+                    csv_recorder.add_tag('current_VRAM_bytes', current_vram_bytes)
+
+                    csv_recorder.single_COBA_data_add(
+                        'fcnmm',
+                        data_type,
+                        back,
+                        efferent_target,
+                        conn,
+                        scale,
+                        -1,
+                        -1,
+                        duration,
+                        homo=homo_str,
+                        batch_size=batch_size,
+                    )
+                    last_path = csv_recorder.flush_and_clear(
+                        flush_file_name,
+                        dir='result-vram-limit_cuda-fake',
+                    )
+
+                    label = 'Device_error' if is_oom else 'Error'
+                    print(
+                        f'[{idx:04d}/{total_points:04d}] {label:<12} '
+                        f'scale={scale:<4d} batch={batch_size:<6d} conn={conn:<6d} '
+                        f'est={current_vram_gib:8.4f} GiB err={e}'
+                    )
+
+                    if is_oom and stop_on_oom:
+                        print('Stopping on first OOM as requested.')
+                        break
+
+            print(
+                f'Backend {back} summary: '
+                f'OK={n_ok}, JAX_warning={n_warn}, Device_error={n_oom}, Error={n_error}'
+            )
+
+    finally:
+        for lgr in (jax_logger, xla_logger, root_logger):
+            lgr.removeHandler(log_collector)
+
+    if last_path:
+        print(f'\nDone. Results saved to: {last_path}')
+
+
+if __name__ == '__main__':
+    benchmark_vram_limit(
+        data_type='binary',
+        duration=1e2 * u.ms,
+        efferent_target='post',
+        homo=True,
+        backend='cuda_fake',
+        vram_limit=6,
+        sample_points=4,
+        data_size=4,
+        stop_on_oom=False,
+    )

--- a/dev/fcn/COBA_2005_binary_fcnmm_boundary_CsvOuput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmm_boundary_CsvOuput.py
@@ -1,0 +1,127 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+#
+# Implementation of the paper:
+#
+# - Brette, R., Rudolph, M., Carnevale, T., Hines, M., Beeman, D., Bower, J. M., et al. (2007),
+#   Simulation of networks of spiking neurons: a review of tools and strategies., J. Comput. Neurosci., 23, 3, 349–98
+#
+# which is based on the balanced network proposed by:
+#
+# - Vogels, T. P. and Abbott, L. F. (2005), Signal propagation and logic gating in networks of integrate-and-fire neurons., J. Neurosci., 25, 46, 10786–95
+#
+# Boundary benchmark for fcnmm (matrix-matrix) operator.
+# Tests across three dimensions: scale, batch_size, conn_num.
+#
+
+import sys
+from pathlib import Path
+_project_root = str(Path(__file__).resolve().parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+import time
+
+import brainunit as u
+import jax
+
+import brainevent
+from COBA_2005_benchmark import make_simulation_batch_run
+
+backends = ['cuda_raw']
+homo = True
+
+
+def benchmark_conn(
+    data_type='binary',
+    duration=1e2 * u.ms,
+    homo: bool = True,
+    mode: str = 'post',
+    backend: str | None = None,
+    _N: int = 4000,
+    limit_gb: int = 6,
+    scales: list | None = None,
+    batch_sizes: list | None = None,
+    conn_nums: list | None = None,
+    target_samples : int = 25
+):
+    import dev.fcn.BenchmarkTools as BT
+
+    print('Benchmarking...')
+
+    backends_to_use = [backend] if backend is not None else backends
+
+    generator = BT.TestingParamsGenerator_mm(
+        limit_GB=limit_gb, _N=_N, conn_max = 2000, scale_max=500, batch_max=400
+    )
+    valid_states = generator.generate_params(dis_type='uniform', target_samples=target_samples, homo=homo)
+    
+    device_error_hit = False
+    homo_str = 'homo' if homo else 'hetero'
+    last_path = None
+    csv_recorder = BT.CSV_record(f'binary_{mode}', 'fcnmm', 'coba', duration=duration)
+
+    for back in backends_to_use:
+        brainevent.config.set_backend('gpu', back)
+        csv_recorder.print_header(
+            operator='fcnmm', data_type=data_type, backend=back,
+            mode=mode, duration=duration, homo=('homo' if homo else 'hetero')
+        )
+        csv_recorder.print_table_header(show_conn=True, show_batch=True)
+
+        for s, bs, cn in valid_states:
+            try:
+                run = make_simulation_batch_run(
+                    scale=s,
+                    batch_size=bs,
+                    data_type=data_type,
+                    efferent_target=mode,
+                    duration=duration,
+                    conn_num=cn,
+                    homo=homo,
+                )
+
+                jax.block_until_ready(run())
+
+                t0 = time.time()
+                n, rate = jax.block_until_ready(run())
+                t1 = time.time()
+                elapsed = t1 - t0
+
+                csv_recorder.add_tag('VRAM-limit', limit_gb)
+                csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=cn, batch_size = bs)
+                csv_recorder.single_COBA_data_add(
+                    'fcnmm', data_type, back, mode, cn, s, elapsed, float(rate), duration,
+                    homo=('homo' if homo else 'hetero'),
+                    batch_size=bs,
+                )
+
+                flush_file_name = f'mm-boundary_{data_type}_{homo_str}_{back}_{mode}'
+
+                last_path = csv_recorder.flush_and_clear(flush_file_name, dir='result-boundary-mm')
+            except Exception as e:
+                error_msg = str(e).lower()
+                continue
+
+    if last_path:
+        print(f'\nDone. Results saved to: {last_path}')
+
+if __name__ == '__main__':
+    
+    #benchmark_conn(data_type='binary', mode = 'pre', duration=1e2 * u.ms, homo=True, backend='cuda_raw')
+    #benchmark_conn(data_type='compack',  mode = 'post',duration=1e2 * u.ms, homo=True, backend='cuda_raw')
+    benchmark_conn(data_type='binary', mode = 'pre', duration=1e2 * u.ms, homo=True, backend='jax_raw')
+    #benchmark_pre_conn(data_type='binary', duration=1e2 * u.ms, homo=True)

--- a/dev/fcn/COBA_2005_binary_fcnmv_CsvOuput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmv_CsvOuput.py
@@ -32,6 +32,7 @@ if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
 
 import time
+from typing import Any, Callable, cast
 
 import brainunit as u
 import jax
@@ -39,203 +40,123 @@ import jax
 import brainevent
 from COBA_2005_benchmark import make_simulation_run
 
+scales = [1, 2, 4, 6, 8, 10, 20, 40, 60]
+backends = ['jax_raw', 'cuda_raw']
+conn_nums = [20, 40, 80, 160, 320, 640]
+probs = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64]
+default_batch_sizes = [1, 4, 16]
 
-scales = [1140]
-backends = ['cuda_raw']
-
-conn_nums = [686]
-
-probs = [0.001, 0.004,  0.016 ,0.064, 0.128, 0.256, 0.512]
+CompiledRun = Callable[[], tuple[int, Any]]
 
 
-def benchmark_post_conn(
-    conn_num=None,
-    conn_prob=None,
-    data_type='binary',
-    duration=1e4 * u.ms,
-    homo: bool = True,
-    backend: str | None = None,
-    probs_or_conn='conn',
-    _N : int = 4000
-):
-    import dev.fcn.BenchmarkTools as BT
+def _run_and_block(run: CompiledRun) -> tuple[int, Any]:
+    result = run()
+    blocked_result = jax.block_until_ready(result)
+    return cast(tuple[int, Any], blocked_result)
 
-    print('Benchmarking post-synaptic connection updates...')
+def benchmark_conn(
+                        mode = 'post',
+                        conn_num=None,
+                        conn_prob=None,
+                        data_type='binary',
+                        duration=1e4 * u.ms,
+                        homo: bool = True,
+                        backend: str | None = None,
+                        params_type='conn',
+                        _N : int = 4000,
+                        limit_GB = 16,
+    ):
+    import BenchmarkTools as BT
 
-    backends_to_use = [backend] if backend is not None else backends
+    duration = cast(u.Quantity, duration)
+    csv_duration = cast(Any, duration)
 
-    if probs_or_conn == 'conn':
-        use_conn_nums = True
-        conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
-    else:
-        use_conn_nums = False
-        probs_to_use = [conn_prob] if conn_prob is not None else probs
+    print(f'Benchmarking {mode}-synaptic connection updates...')
 
-    csv_recorder = BT.CSV_record('binary_post', 'fcnmv', 'coba', duration=duration, conn=conn_num)
-
-    for back in backends_to_use:
-        brainevent.config.set_backend('gpu', back)
-
-        if use_conn_nums:
-            for cn in conn_nums_to_use:
-                csv_recorder.print_header(operator='fcnmv', data_type=data_type, backend=back,
-                        mode='post', conn_num=cn, duration=duration,
-                        homo=('homo' if homo else 'hetero'))
-                csv_recorder.print_table_header()
-
-                for s in scales:
-                    try:
-                        print(jax.devices())
-                        run = make_simulation_run(
-                            scale=s,
-                            data_type=data_type,
-                            efferent_target='post',
-                            duration=duration,
-                            conn_num=cn,
-                            homo=homo
-                        )
-
-                        jax.block_until_ready(run())
-
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate))
-                        csv_recorder.single_COBA_data_add('fcnmv', data_type, back, 'post', cn, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={cn}: {e}')
-                        continue
-        else:
-            for prob in probs_to_use:
-                csv_recorder.print_header(operator='fcnmv', data_type=data_type, backend=back,
-                        mode='post', duration=duration,
-                        homo=('homo' if homo else 'hetero'), prob=prob)
-                csv_recorder.print_table_header(show_conn=True)
-
-                for s in scales:
-                    actual_conn_num = int(s * prob * _N)
-                    if actual_conn_num < 1 : actual_conn_num = 1
-                    if BT.memory_limit(actual_conn_num, scale=s): continue
-                    try:
-                        run = make_simulation_run(
-                            scale=s,
-                            data_type=data_type,
-                            efferent_target='post',
-                            duration=duration,
-                            conn_num=actual_conn_num,
-                            homo=homo
-                        )
-
-                        jax.block_until_ready(run())
-
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=actual_conn_num)
-                        csv_recorder.single_COBA_data_add('fcnmv', data_type, back, 'post', actual_conn_num, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={actual_conn_num}: {e}')
-                        continue
-
-    csv_recorder.record_finish('float_mode_single_point_with_spconn-scale')
-
-def benchmark_pre_conn(
-        conn_num=None, 
-        conn_prob=None,
-        data_type='binary', 
-        duration=1e2 * u.ms, 
-        homo:bool = True, 
-        backend: str | None = None,
-        probs_or_conn='conn',
-        _N : int = 4000
-        ):
-    print('Benchmarking pre-synaptic connection updates...')
-    import dev.fcn.BenchmarkTools as BT
+    TPGenerator = BT.TestingParamsGenerator_mv(limit_GB=limit_GB, _N=_N, sample_points=100, conn_max=3000, scale_max=1000)
 
     backends_to_use = [backend] if backend is not None else backends
 
-    if probs_or_conn == 'conn':
-        use_conn_nums = True
+    if params_type == 'conn':
         conn_nums_to_use = [conn_num] if conn_num is not None else conn_nums
-    else:
-        use_conn_nums = False
+        valid_pairs = []
+        for s in scales:
+            for cn in conn_nums_to_use:
+                #if TPGenerator.is_valid_mm(s, b, cn, homo):
+                valid_pairs.append((s, None, cn))
+    elif params_type == 'prob':
         probs_to_use = [conn_prob] if conn_prob is not None else probs
+        valid_pairs = TPGenerator.make_simulation_params_probs(probs_to_use, scales, homo=homo)
+    elif params_type == 'dist':
+        valid_pairs = TPGenerator.generate_params(dis_type='uniform', target_samples=50, data_size = 4, homo=homo)
 
-    csv_recorder = BT.CSV_record('binary_pre', 'fcnmv', 'coba', duration=duration, conn=conn_num)
+
+    csv_recorder = BT.CSV_record(f'binary_{mode}', 'fcnmv', 'coba', duration=csv_duration, conn=conn_num)
+
+
+    homo_str = 'homo' if homo else 'hetero'
+    last_path = None
+    header_conn_num = conn_num if params_type == 'conn' and conn_num is not None else None
 
     for back in backends_to_use:
         brainevent.config.set_backend('gpu', back)
+        csv_recorder.print_header(operator='fcnmv', data_type=data_type, backend=back,
+                mode=mode, conn_num=header_conn_num, duration=duration,
+                homo=('homo' if homo else 'hetero'))
+        csv_recorder.print_table_header(show_conn=True)
 
-        if use_conn_nums:
-            for cn in conn_nums_to_use:
-                csv_recorder.print_header(operator='fcnmv', data_type=data_type, backend=back,
-                        mode='pre', conn_num=cn, duration=duration,
-                        homo=('homo' if homo else 'hetero'))
-                csv_recorder.print_table_header()
+        for scale, prob, cn in valid_pairs:
 
-                for s in scales:
-                    try:
-                        run = make_simulation_run(
-                            scale=s,
-                            data_type=data_type,
-                            efferent_target='pre',
-                            duration=duration,
-                            conn_num=cn,
-                            homo=homo,
-                        )
+            try:
+                run = cast(CompiledRun, make_simulation_run(
+                    scale=scale,
+                    data_type=data_type,
+                    efferent_target=mode,
+                    duration=duration,
+                    conn_num=cn,
+                    homo=homo,
+                ))
 
-                        jax.block_until_ready(run())
+                _run_and_block(run)
 
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate))
-                        csv_recorder.single_COBA_data_add('fcnmv', data_type, back, 'pre', cn, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={cn}: {e}')
-                        continue
-        else:
-            for prob in probs_to_use:
-                csv_recorder.print_header(operator='fcnmv', data_type=data_type, backend=back,
-                        mode='pre', duration=duration,
-                        homo=('homo' if homo else 'hetero'), prob=prob)
-                csv_recorder.print_table_header(show_conn=True)
+                t0 = time.time()
+                n, rate = _run_and_block(run)
+                t1 = time.time()
+                elapsed = t1 - t0
 
-                for s in scales:
-                    actual_conn_num = int(s * prob * _N)  # non-linear: conn_num scales with network size
-                    if actual_conn_num < 1 : actual_conn_num = 1
-                    if BT.memory_limit(actual_conn_num, scale=s): continue
-                    try:
-                        run = make_simulation_run(
-                            scale=s,
-                            data_type=data_type,
-                            efferent_target='pre',
-                            duration=duration,
-                            conn_num=actual_conn_num,
-                            homo=homo,
-                        )
+                csv_recorder.add_tag('limit_GB', f'{limit_GB}')
 
-                        jax.block_until_ready(run())
+                #csv_recorder.add_tag('wat', f'tpr')
 
-                        t0 = time.time()
-                        n, rate = jax.block_until_ready(run())
-                        t1 = time.time()
-                        elapsed = t1 - t0
-                        csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=actual_conn_num)
-                        csv_recorder.single_COBA_data_add('fcnmv', data_type, back, 'pre', actual_conn_num, s, elapsed, float(rate), duration, homo=('homo' if homo else 'hetero'))
-                    except Exception as e:
-                        print(f'  [Error] scale={s}, conn_num={actual_conn_num}: {e}')
-                        continue
+                csv_recorder.print_row(scale, n, elapsed, float(rate), conn_num=cn)
+                
+                csv_recorder.single_COBA_data_add('fcnmv', data_type, back, mode, cn, scale, elapsed, float(rate), csv_duration, homo=('homo' if homo else 'hetero'))
+                
+                #flush_file_name = f'forbit-jax-mv_{data_type}_{homo_str}_{back}_{mode}-float-input-{limit_GB}GB'
+                flush_file_name = 'test'
+                last_path = csv_recorder.flush_and_clear(flush_file_name, dir='test')
+            except Exception as e:
+                print(f'  [Error] scale={scale}, conn_num={cn}: {e}')
+                continue
 
-    csv_recorder.record_finish('test')
+    if last_path:
+        print(f'\nDone. Results saved to: {last_path}')
+
 
 
 if __name__ == '__main__':
-    #benchmark_post_conn(data_type='compact', duration=1e2 * u.ms, probs_or_conn='conn')
-    benchmark_post_conn(data_type='binary', duration=1e2 * u.ms, probs_or_conn='conn')
-    #benchmark_pre_conn(conn_num=80, data_type='bitpack', duration=1e3 * u.ms)
-    #benchmark_pre_conn(data_type='binary',duration=1e3 * u.ms, probs_or_conn='conn')
-    #benchmark_pre_conn(data_type='bitpack',duration=1e3 * u.ms, probs_or_conn='conn')
+
+    #benchmark_conn(data_type='compact', mode = 'post', duration=1e2 * u.ms, params_type='dist', homo= True , backend='cuda_raw', limit_GB = 18)
+    #benchmark_conn(data_type='compact', mode = 'post', duration=1e2 * u.ms, params_type='dist', homo= False , backend='cuda_raw', limit_GB = 9)
+    #benchmark_conn(data_type='bitpack', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= True , backend='cuda_raw', limit_GB = 9)
+    #benchmark_conn(data_type='bitpack', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= False , backend='cuda_raw', limit_GB = 7)
+
+    #benchmark_conn(data_type='binary', mode = 'post', duration=1e2 * u.ms, params_type='dist', homo= True , backend='jax_raw', limit_GB = 18)
+    #benchmark_conn(data_type='binary', mode = 'post', duration=1e2 * u.ms, params_type='dist', homo= False , backend='jax_raw', limit_GB = 9)
+    #benchmark_conn(data_type='binary', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= True , backend='jax_raw', limit_GB = 9)
+    #benchmark_conn(data_type='binary', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= False , backend='jax_raw', limit_GB = 7)
+
+    
+    benchmark_conn(data_type='bitpack', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= False , backend='jax_cuda_joint', limit_GB = 7)
+    #benchmark_conn(data_type='bitpack', mode = 'pre', duration=1e2 * u.ms, params_type='dist', homo= True , backend='jax-cuda-joint', limit_GB = 9)
+#18 9 9 7

--- a/dev/fcn/COBA_2005_binary_fcnmv_VRAM_limit_CsvOutput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmv_VRAM_limit_CsvOutput.py
@@ -1,0 +1,263 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+#
+# VRAM-limit progressive benchmark for COBA 2005 (fcnmv operator).
+#
+# Starts from a small VRAM budget and increases step by step.
+# - When JAX emits memory-related warnings  → tag ``message = JAX_warning``
+# - When RESOURCE_EXHAUSTED is raised        → tag ``message = Device_error``, stop.
+#
+
+import sys
+import time
+import warnings
+import logging
+from pathlib import Path
+
+_project_root = str(Path(__file__).resolve().parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+import brainunit as u
+import jax
+
+import brainevent
+from COBA_2005_benchmark import make_simulation_run
+
+backends = ['jax_raw']
+data_size = 4
+
+# ---------------------------------------------------------------------------
+#  Logging handler to capture JAX / XLA memory warnings
+# ---------------------------------------------------------------------------
+class _WarningCollector(logging.Handler):
+    """Temporary logging handler that collects warning-level records."""
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def has_memory_warning(self) -> bool:
+        keywords = ('memory', 'allocation', 'resource', 'oom', 'exceeds')
+        for r in self.records:
+            msg = r.getMessage().lower()
+            if any(k in msg for k in keywords):
+                return True
+        return False
+
+    def clear(self):
+        self.records.clear()
+
+
+def benchmark_vram_limit(
+    data_type: str = 'binary',
+    duration=1e2 * u.ms,
+    homo: bool = True,
+    backend: str | None = None,
+    efferent_target: str = 'pre',
+    _N: int = 4000,
+    vram_start: int = 1,
+    vram_end: int = 24,
+    vram_step: int = 1,
+    sample_points: int = 5,
+    scale_max: int = 2000,
+    conn_max: int = 4000,
+):
+    """Progressive VRAM-limit benchmark.
+
+    For each VRAM level from *vram_start* to *vram_end* (step *vram_step*),
+    generate ``(scale, conn)`` pairs near that boundary using
+    ``TestingParamsGenerator.generate_cs_pairs`` and run the COBA simulation.
+
+    Tags recorded per row:
+      - ``current_VRAM``  – the VRAM budget (GB) being tested.
+      - ``message``       – ``OK`` | ``JAX_warning`` | ``Device_error``.
+    """
+    import dev.fcn.BenchmarkTools as BT
+
+    print('=== VRAM-limit progressive benchmark ===')
+
+    backends_to_use = [backend] if backend is not None else backends
+    vram_steps = list(range(vram_start, vram_end + 1, vram_step))
+
+    #data_size = data_size
+
+    # Generate parameter sequence for all VRAM levels
+    generator = BT.TestingParamsGenerator(
+        limit_GB=vram_end, _N=_N,
+        scale_max=scale_max, conn_max=conn_max,
+    )
+    vram_params = generator.generate_coba_vram_sequence(
+        vram_steps=vram_steps,
+        sample_points=sample_points,
+        homo=homo,
+        data_size=data_size,
+    )
+
+    csv_recorder = BT.CSV_record(
+        f'vram_limit_{efferent_target}', 'fcnmv', 'coba', duration=duration,
+    )
+
+    # Attach a temporary log handler to capture JAX/XLA warnings
+    log_collector = _WarningCollector()
+    jax_logger = logging.getLogger('jax')
+    xla_logger = logging.getLogger('jaxlib')
+    root_logger = logging.getLogger()
+    for lgr in (jax_logger, xla_logger, root_logger):
+        lgr.addHandler(log_collector)
+
+    device_error_hit = False
+
+    try:
+        for back in backends_to_use:
+            brainevent.config.set_backend('gpu', back)
+
+            csv_recorder.print_header(
+                operator='fcnmv', data_type=data_type, backend=back,
+                mode=efferent_target, duration=duration,
+                homo=('homo' if homo else 'hetero'),
+            )
+            csv_recorder.print_table_header(show_conn=True)
+
+            for vram_gb, pairs in vram_params.items():
+                if device_error_hit:
+                    break
+
+                print(f'\n--- Testing VRAM budget: {vram_gb} GB '
+                      f'({len(pairs)} parameter pairs) ---')
+
+                for scale, conn in pairs:
+                    if device_error_hit:
+                        break
+
+                    csv_recorder.add_tag('current_VRAM', vram_gb)
+                    log_collector.clear()
+
+                    try:
+                        # Also catch Python-level warnings
+                        with warnings.catch_warnings(record=True) as py_warnings:
+                            warnings.simplefilter('always')
+
+                            run = make_simulation_run(
+                                scale=scale,
+                                data_type=data_type,
+                                efferent_target=efferent_target,
+                                duration=duration,
+                                conn_num=conn,
+                                homo=homo,
+                            )
+
+                            # Warm-up run
+                            jax.block_until_ready(run())
+
+                            # Timed run
+                            t0 = time.time()
+                            n, rate = jax.block_until_ready(run())
+                            t1 = time.time()
+                            elapsed = t1 - t0
+
+                        # Determine message tag
+                        jax_warned = log_collector.has_memory_warning()
+                        py_mem_warned = any(
+                            any(k in str(w.message).lower()
+                                for k in ('memory', 'allocation', 'resource'))
+                            for w in py_warnings
+                        )
+
+                        if jax_warned or py_mem_warned:
+                            csv_recorder.add_tag('message', 'JAX_warning')
+                            print(f'  [JAX_warning] scale={scale}, conn={conn}, '
+                                  f'VRAM={vram_gb}GB')
+                        else:
+                            csv_recorder.add_tag('message', 'OK')
+
+                        csv_recorder.print_row(scale, n, elapsed, float(rate),
+                                               conn_num=conn)
+                        csv_recorder.single_COBA_data_add(
+                            'fcnmv', data_type, back, efferent_target, conn,
+                            scale, elapsed, float(rate), duration,
+                            homo=('homo' if homo else 'hetero'),
+                        )
+
+                    except Exception as e:
+                        error_msg = str(e).lower()
+                        is_oom = any(kw in error_msg for kw in (
+                            'resource_exhausted', 'resource exhausted',
+                            'out of memory', 'oom',
+                        ))
+
+                        if is_oom:
+                            csv_recorder.add_tag('message', 'Device_error')
+                            csv_recorder.add_tag('current_VRAM', vram_gb)
+                            csv_recorder.single_COBA_data_add(
+                                'fcnmv', data_type, back, efferent_target,
+                                conn, scale, -1, -1, duration,
+                                homo=('homo' if homo else 'hetero'),
+                            )
+                            print(f'  [Device_error] RESOURCE_EXHAUSTED at '
+                                  f'scale={scale}, conn={conn}, '
+                                  f'VRAM={vram_gb}GB')
+                            print('  Stopping test.')
+                            device_error_hit = True
+                            break
+                        else:
+                            print(f'  [Error] scale={scale}, conn={conn}: {e}')
+                            continue
+
+    finally:
+        # Clean up logging handlers
+        for lgr in (jax_logger, xla_logger, root_logger):
+            lgr.removeHandler(log_collector)
+
+    homo_str = 'homo' if homo else 'hetero'
+    csv_recorder.record_finish(
+        dir='result-vram-limit_jax',
+        file_name=f'vram_limit_{data_type}_{homo_str}_{efferent_target}',
+    )
+
+
+if __name__ == '__main__':
+
+
+    '''
+    benchmark_vram_limit(
+                data_type='binary',
+                duration=1e2 * u.ms,
+                efferent_target='pre',
+                homo=True,
+            )
+    
+    for homo in [True, False]:
+        for data_type in ['pre','post']:
+            benchmark_vram_limit(
+                data_type='binary',
+                duration=1e2 * u.ms,
+                efferent_target=data_type,
+                homo=homo,
+                backend='cuda_raw'
+            )
+    '''        
+    benchmark_vram_limit(
+                data_type='binary',
+                duration=1e2 * u.ms,
+                efferent_target=data_type,
+                homo=homo,
+                backend='cuda_raw'
+            )
+
+    

--- a/dev/fcn/COBA_2005_binary_fcnmv_boundary_CsvOuput.py
+++ b/dev/fcn/COBA_2005_binary_fcnmv_boundary_CsvOuput.py
@@ -46,36 +46,63 @@ import jax
 import brainevent
 from COBA_2005_benchmark import make_simulation_run
 
+#JAX_CAPTURED_CONSTANTS_REPORT_FRAMES = -1
 
-backends = ['jax_raw']
+backends = ['cuda_raw']
 homo = True
-def benchmark_post_conn(
+
+
+def _is_oom_error(exc: Exception) -> bool:
+    error_msg = str(exc).lower()
+    return any(token in error_msg for token in (
+        'resource_exhausted',
+        'resource exhausted',
+        'out of memory',
+        'oom',
+    ))
+
+
+def benchmark_conn(
     conn_num=None,
     conn_prob=None,
+    mode = 'pre',
     data_type='binary',
     duration=1e4 * u.ms,
     homo: bool = True,
     backend: str | None = None,
     probs_or_conn='conn',
     _N : int = 4000,
-    limit_gb: int = 17,
+    limit_gb: int = 16,
     target_samples: int = 50
 ):
-    import dev.fcn.BenchmarkTools as BT
+    import BenchmarkTools as BT
 
-    print('Benchmarking post-synaptic connection updates...')
+    if mode not in ('pre', 'post'):
+        raise ValueError("mode must be either 'pre' or 'post'.")
+
+    print(f'Benchmarking {mode}-synaptic connection updates...')
 
     backends_to_use = [backend] if backend is not None else backends
 
-    valid_states = BT.generate_params(dis_type= 'uniform' ,_N=_N, limit_gb=limit_gb, target_samples=target_samples ,homo=homo)
+    generator = BT.TestingParamsGenerator(limit_GB=limit_gb, _N=_N)
+    valid_states = generator.generate_boundary_params(
+        homo_or_not=homo,
+        _N=_N,
+        sample_points=target_samples,
+    )
+    if not valid_states:
+        raise ValueError(f'No valid boundary states generated under {limit_gb}GB.')
 
-    csv_recorder = BT.CSV_record('binary_post', 'fcnmv', 'coba', duration=duration,)
+    csv_recorder = BT.CSV_record(f'{data_type}_{mode}_boundary', 'fcnmv', 'coba', duration=duration)
+    csv_recorder.add_tag('VRAM-limit', limit_gb)
+    homo_str = 'homo' if homo else 'hetero'
+    last_path = None
 
     for back in backends_to_use:
         brainevent.config.set_backend('gpu', back)
         csv_recorder.print_header(
             operator='fcnmv', data_type=data_type, backend=back,
-            mode='post', duration=duration, homo=('homo' if homo else 'hetero')
+            mode=mode, duration=duration, homo=('homo' if homo else 'hetero')
         )
         csv_recorder.print_table_header(show_conn=True)
 
@@ -84,69 +111,7 @@ def benchmark_post_conn(
                 run = make_simulation_run(
                     scale=s,
                     data_type=data_type,
-                    efferent_target='post',
-                    duration=duration,
-                    conn_num=cn,
-                    homo=homo
-                )
-
-                jax.block_until_ready(run())
-
-                t0 = time.time()
-                n, rate = jax.block_until_ready(run())
-                t1 = time.time()
-                elapsed = t1 - t0
-                
-                #csv_recorder.add_tag('warp_or_thread', 'tpr')
-                csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=cn)
-                csv_recorder.single_COBA_data_add(
-                    'fcnmv', data_type, back, 'post', cn, s, elapsed, float(rate), duration, 
-                    homo=('homo' if homo else 'hetero')
-                )
-            except Exception as e:
-                error_msg = str(e).lower()
-                #if "resource_exhausted" in error_msg or "resource exhausted" in error_msg or "out of memory" in error_msg or "oom" in error_msg:
-                #    jax.profiler.save_device_memory_profile(f"memory_snapshot-scale{s}-conn{cn}.prof")
-                continue
-
-    csv_recorder.record_finish(dir='result-stage2',file_name='homo-boundary-18-mvpost-cudawat')
-
-def benchmark_pre_conn(
-        conn_num=None, 
-        conn_prob=None,
-        data_type='binary', 
-        duration=1e2 * u.ms, 
-        homo:bool = True, 
-        backend: str | None = None,
-        probs_or_conn='conn',
-        _N : int = 4000,
-        limit_gb: int = 16,
-        target_samples: int = 50
-        ):
-    print('Benchmarking pre-synaptic connection updates...')
-    import dev.fcn.BenchmarkTools as BT
-
-    backends_to_use = [backend] if backend is not None else backends
-
-    
-    valid_states = BT.generate_params(dis_type= 'uniform' ,_N=_N, limit_gb=limit_gb, target_samples=target_samples)
-
-    csv_recorder = BT.CSV_record('binary_pre', 'fcnmv', 'coba', duration=duration, conn=conn_num)
-
-    for back in backends_to_use:
-        brainevent.config.set_backend('gpu', back)
-        csv_recorder.print_header(
-            operator='fcnmv', data_type=data_type, backend=back,
-            mode='pre', duration=duration, homo=('homo' if homo else 'hetero')
-        )
-        csv_recorder.print_table_header(show_conn=True)
-
-        for s, cn in valid_states:
-            try:
-                run = make_simulation_run(
-                    scale=s,
-                    data_type=data_type,
-                    efferent_target='pre',
+                    efferent_target=mode,
                     duration=duration,
                     conn_num=cn,
                     homo=homo
@@ -161,22 +126,32 @@ def benchmark_pre_conn(
                 
                 csv_recorder.print_row(s, n, elapsed, float(rate), conn_num=cn)
                 csv_recorder.single_COBA_data_add(
-                    'fcnmv', data_type, back, 'pre', cn, s, elapsed, float(rate), duration, 
+                    'fcnmv', data_type, back, mode, cn, s, elapsed, float(rate), duration, 
                     homo=('homo' if homo else 'hetero')
                 )
-            except Exception as e:
-                error_msg = str(e).lower()
-                if "resource_exhausted" in error_msg or "resource exhausted" in error_msg or "out of memory" in error_msg or "oom" in error_msg:
-                    jax.profiler.save_device_memory_profile(f"memory_snapshot-scale{s}-conn{cn}.prof")
-                continue
 
-    csv_recorder.record_finish(dir='result-stage2',file_name='boundary_floatmode_bitpack')
+                flush_file_name = f'mv-boundary_{data_type}_{homo_str}_{back}_{mode}-float-input-16GB'
+
+                last_path = csv_recorder.flush_and_clear(flush_file_name, dir='result-boundary-mv-4.1-final')
+
+            except Exception as exc:
+                if _is_oom_error(exc):
+                    print(f'Skipping scale={s}, conn_num={cn} due to OOM: {exc}')
+                    continue
+                raise
+
+    if last_path is not None:
+        print(f'Results saved to: {last_path}')
+
+    #csv_recorder.record_finish(dir='result-stage2',file_name='post-boundary-compact-homo-jaxandcuda')
 
 
 if __name__ == '__main__':
     #benchmark_post_conn(conn_num=80, data_type='binary', duration=1e4 * u.ms, backend='jax_raw')
-    benchmark_post_conn(data_type='binary', duration=1e2 * u.ms, homo = homo)
-    #benchmark_post_conn(data_type='compact', duration=1e2 * u.ms)
-    #benchmark_pre_conn(data_type='bitpack', duration=1e2 * u.ms)
+    #benchmark_post_conn(data_type='binary', duration=1e2 * u.ms, homo = homo)
+    #benchmark_post_conn(data_type='compact', duration=1e2 * u.ms, homo = True)
+    #benchmark_conn(data_type='bitpack', mode='pre', duration=1e2 * u.ms, homo = True, backend='cuda_raw')
+    benchmark_conn(data_type='binary', mode='pre', duration=1e2 * u.ms, homo = True, backend='jax_raw')
+    #benchmark_pre_conn(data_type='compact', duration=1e2 * u.ms, homo= False)
     #benchmark_pre_conn(data_type='binary',duration=1e2 * u.ms)
     


### PR DESCRIPTION
## Summary by Sourcery

Refine FCN benchmark tooling and VRAM-boundary workflows, and extend tests and kernels to cover compact and bitpacked FCN matrix-vector/matrix-matrix operators at large scales.

New Features:
- Introduce parameter generator classes for FCN matrix-vector and matrix-matrix benchmarks that respect GPU VRAM constraints and support various sampling strategies.
- Add VRAM-limit benchmarking scripts for FCNMM and FCNMV operators, including boundary and progressive tests for different backends and synaptic modes.
- Add large-scale correctness tests for bitpacked FCNMV forward passes using memory-aware (scale, connectivity) generation.

Enhancements:
- Extend CSV benchmark recorder to support operator-specific field layouts, batch size recording, incremental flushing, and quieter writes.
- Unify FCNMM/FCNMV benchmark entry points into more flexible `benchmark_conn` helpers that generate valid parameter grids and stream results to disk.
- Relax numerical tolerances in large-scale binary and compact FCNMV tests to account for expected discrepancies between implementations.
- Add a hybrid JAX/CUDA bitpack FCNMV kernel selector and tune CUDA gather-kernel launch heuristics for better performance across shapes.

Tests:
- Add VRAM-aware large-scale bitpacked FCNMV forward test that compares against dense reference while avoiding OOM via generated parameter pairs.