### PR TITLE
refactor(_op): simplify kernix modules and use English diagnostics

### DIFF
--- a/benchmark/20_COBA_2005.py
+++ b/benchmark/20_COBA_2005.py
@@ -156,7 +156,7 @@ for s in [1, 2, 4, 6, 8, 10, 20, 40, 60, 80, 100]:
 # scale=100, size=400000, time = 215.4547393321991 s, firing rate = 50.6129150390625 Hz
 
 
-# 2026/02/13, AMD Ryzen 7 7840HS, brainevent 0.0.6, Numba 0.63.1, jax 0.9.0, 小新Win11野兽模式
+# 2026/02/13, AMD Ryzen 7 7840HS, brainevent 0.0.6, Numba 0.63.1, jax 0.9.0, Lenovo Xiaoxin Win11 beast mode
 #
 # scale=1, size=4000, time = 7.121581077575684 s, firing rate = 59.563377380371094 Hz
 # scale=2, size=8000, time = 11.442655324935913 s, firing rate = 59.57026672363281 Hz
@@ -173,7 +173,7 @@ for s in [1, 2, 4, 6, 8, 10, 20, 40, 60, 80, 100]:
 
 
 # --------------------
-# 2026/02/13, i9-12900H, brainevent 0.0.6, Numba 0.63.1, jax 0.9.0.1, 雷神Win11狂暴模式
+# 2026/02/13, i9-12900H, brainevent 0.0.6, Numba 0.63.1, jax 0.9.0.1, Thunderobot Win11 turbo mode
 #
 # scale=1, size=4000, time = 8.120884656906128 s, firing rate = 59.57337951660156 Hz
 # scale=2, size=8000, time = 13.005541324615479 s, firing rate = 59.57312774658203 Hz

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -27,26 +27,26 @@ def visualize(
     labels = list(results.keys())
     ratio = list(results.values())
 
-    x = np.arange(len(labels))  # x轴的位置
-    width = 0.35  # 条形的宽度
+    x = np.arange(len(labels))  # x-axis positions
+    width = 0.35  # bar width
 
     fig, ax = plt.subplots()
     bars = ax.bar(x, ratio, width, label='Ratio')
 
-    # 添加标签
+    # axis labels
     ax.set_xlabel('Configurations')
     ax.set_ylabel('Acceleration Ratio')
     ax.set_title(title)
     ax.set_xticks(x)
     ax.set_xticklabels(labels, rotation=45, ha='right')
 
-    # 在每个条形上添加数值标签
+    # annotate each bar with its value
     for bar in bars:
         height = bar.get_height()
         ax.annotate(
-            f'{height:.2f}',  # 格式化数值
-            xy=(bar.get_x() + bar.get_width() / 2, height),  # 标签位置
-            xytext=(0, 3),  # 偏移量
+            f'{height:.2f}',  # formatted value
+            xy=(bar.get_x() + bar.get_width() / 2, height),  # label anchor
+            xytext=(0, 3),  # offset
             textcoords="offset points",
             ha='center',
             va='bottom'

--- a/brainevent/_op/kernix_codegen.py
+++ b/brainevent/_op/kernix_codegen.py
@@ -59,6 +59,28 @@ _CPP_TYPE_TO_ATTR: dict[str, str] = {
 }
 
 
+def _parse_scalar_param(param: str) -> tuple[str, str, bool] | None:
+    """Split a single C++ parameter into ``(name, cpp_type, is_ptr_or_ref)``.
+
+    Returns ``None`` for an empty parameter.  The variable name is the last
+    whitespace-separated token; ``cpp_type`` is everything before it with any
+    ``*``/``&`` and a leading ``const`` stripped.  ``is_ptr_or_ref`` flags
+    pointer/reference parameters (``float* p`` or ``float *p``), which cannot be
+    passed as XLA FFI scalar attributes.
+    """
+    parts = param.split()
+    if not parts:
+        return None
+    last_part = parts[-1]
+    param_name = last_part.lstrip('*&')
+    cpp_type = ' '.join(parts[:-1]).strip()
+    is_ptr_or_ref = '*' in cpp_type or '&' in cpp_type or last_part != param_name
+    cpp_type = cpp_type.rstrip('*&')
+    if cpp_type.startswith("const "):
+        cpp_type = cpp_type[6:].strip()
+    return param_name, cpp_type, is_ptr_or_ref
+
+
 def _infer_attr_type_from_source(
     source: str, func_name: str, attr_name: str
 ) -> str:
@@ -76,25 +98,12 @@ def _infer_attr_type_from_source(
             f"Use the explicit form 'attr.{attr_name}:<type>' instead."
         )
     for raw_param in m.group(1).split(','):
-        param = raw_param.strip()
-        if not param:
+        parsed = _parse_scalar_param(raw_param.strip())
+        if parsed is None:
             continue
-        parts = param.split()
-        if not parts:
-            continue
-        # Variable name is the last word; '*'/'&' may be attached to it
-        # (C style: "float *ptr") or to the type (C++ style: "float* ptr").
-        last_part = parts[-1]
-        param_name = last_part.lstrip('*&')
+        param_name, cpp_type, is_ptr_or_ref = parsed
         if param_name != attr_name:
             continue
-        # Type is everything before the variable name.
-        cpp_type = ' '.join(parts[:-1]).strip()
-        # Reject pointer / reference types — they cannot be passed as XLA FFI
-        # scalar attrs.  A '*' or '&' may appear in the type token ("float*")
-        # or at the start of the variable token ("*ptr").
-        is_ptr_or_ref = ('*' in cpp_type or '&' in cpp_type
-                         or last_part != param_name)
         if is_ptr_or_ref:
             raise KernelError(
                 f"Cannot map C++ type '{cpp_type}' of '{attr_name}' in "
@@ -103,10 +112,6 @@ def _infer_attr_type_from_source(
                 f"scalar attributes. "
                 f"Use the explicit form 'attr.{attr_name}:<type>' instead."
             )
-        cpp_type = cpp_type.rstrip('*&')
-        # Strip leading 'const' qualifier — scalars are passed by value.
-        if cpp_type.startswith("const "):
-            cpp_type = cpp_type[6:].strip()
         be_type = _CPP_TYPE_TO_ATTR.get(cpp_type)
         if be_type is None:
             raise KernelError(
@@ -167,22 +172,16 @@ def _params_str_to_tokens(params_str: str, func_name: str) -> list[str]:
         elif re.match(r'int64_t\s+stream\b', param):
             tokens.append('stream')
         else:
-            # Try to detect a scalar attribute from known C++ types.
-            parts = param.split()
-            if len(parts) >= 2:
-                last_part = parts[-1]
-                param_name = last_part.lstrip('*&')
-                cpp_type = ' '.join(parts[:-1]).strip()
-                is_ptr_or_ref = ('*' in cpp_type or '&' in cpp_type
-                                 or last_part != param_name)
-                if is_ptr_or_ref:
-                    continue  # silently skip; not a scalar attr
-                cpp_type = cpp_type.rstrip('*&')
-                if cpp_type.startswith("const "):
-                    cpp_type = cpp_type[6:].strip()
-                be_type = _CPP_TYPE_TO_ATTR.get(cpp_type)
-                if be_type is not None:
-                    tokens.append(f'attr.{param_name}:{be_type}')
+            # Detect a scalar attribute from known C++ types.
+            parsed = _parse_scalar_param(param)
+            if parsed is None:
+                continue
+            param_name, cpp_type, is_ptr_or_ref = parsed
+            if is_ptr_or_ref:
+                continue  # silently skip; not a scalar attr
+            be_type = _CPP_TYPE_TO_ATTR.get(cpp_type)
+            if be_type is not None:
+                tokens.append(f'attr.{param_name}:{be_type}')
 
     if not tokens:
         raise KernelError(f"No Tensor parameters found in '{func_name}'. Cannot auto-detect arg_spec.")
@@ -545,13 +544,13 @@ def parse_arg_spec(func_name: str, tokens: list[str]) -> FunctionSpec:
 
 
 # -- Attribute C++ type mapping ------------------------------------------------
-# _ATTR_CPP_TYPE : BE attr type → C++ type used in the generated impl function
-# _ATTR_FFI_TYPE : BE attr type → C++ type used in the XLA FFI .Attr<T>() binding
+# BE attr type → C++ type, used both for the generated impl-function parameter
+# and for the XLA FFI ``.Attr<T>()`` binding (the two are identical).
 #
 # For float16 / bfloat16 there is no registered XLA_FFI_REGISTER_SCALAR_ATTR_DECODING
-# for __half or __nv_bfloat16.  Both are stored as uint16_t raw bits.
-# The user's C++ function must accept uint16_t and reinterpret internally, or
-# the user must use float32/float64 if they want seamless scalar attr passing.
+# for __half or __nv_bfloat16, so both are passed as uint16_t raw bits.  The
+# user's C++ function must accept uint16_t and reinterpret internally, or use
+# float32/float64 for seamless scalar attr passing.
 
 _ATTR_CPP_TYPE = {
     "bool": "bool",
@@ -565,22 +564,6 @@ _ATTR_CPP_TYPE = {
     "uint64": "uint64_t",
     "float16": "uint16_t",  # raw f16 bits
     "bfloat16": "uint16_t",  # raw bf16 bits
-    "float32": "float",
-    "float64": "double",
-}
-
-_ATTR_FFI_TYPE = {
-    "bool": "bool",
-    "int8": "int8_t",
-    "uint8": "uint8_t",
-    "int16": "int16_t",
-    "uint16": "uint16_t",
-    "int32": "int32_t",
-    "uint32": "uint32_t",
-    "int64": "int64_t",
-    "uint64": "uint64_t",
-    "float16": "uint16_t",  # XLA FFI passes as U16 raw bits
-    "bfloat16": "uint16_t",  # XLA FFI passes as U16 raw bits
     "float32": "float",
     "float64": "double",
 }
@@ -681,7 +664,7 @@ def generate_ffi_wrapper(spec: FunctionSpec, allow_cuda_graph: bool = True) -> s
     for _ in range(spec.num_rets):
         binding_parts.append("    .Ret<xla::ffi::AnyBuffer>()")
     for attr_name, attr_type in spec.attrs:
-        ffi_type = _ATTR_FFI_TYPE[attr_type]
+        ffi_type = _ATTR_CPP_TYPE[attr_type]
         binding_parts.append(f'    .Attr<{ffi_type}>("{attr_name}")')
 
     binding = "\n".join(binding_parts)

--- a/brainevent/_op/kernix_compiler.py
+++ b/brainevent/_op/kernix_compiler.py
@@ -56,10 +56,10 @@ def _allow_unsupported_compiler() -> bool:
 def _raise_compile_error(output: str, command: str, stage: str) -> None:
     if _is_host_incompat(output):
         msg = (
-            "host C++ 编译器与当前 CUDA/nvcc 不兼容。\n"
-            "如何修复:\n"
-            "  1) 安装受支持版本的 gcc 并设 CXX=/path/to/g++\n"
-            "  2) 或设 BRAINEVENT_ALLOW_UNSUPPORTED_COMPILER=1 后重试"
+            "host C++ compiler is incompatible with the current CUDA/nvcc.\n"
+            "How to fix:\n"
+            "  1) Install a supported gcc version and set CXX=/path/to/g++\n"
+            "  2) Or set BRAINEVENT_ALLOW_UNSUPPORTED_COMPILER=1 and retry"
         )
         raise HostCompilerIncompatibleError(msg, compiler_output=output, command=command, stage=stage)
     raise CompilationError("compilation failed", compiler_output=output, command=command, stage=stage)
@@ -133,11 +133,6 @@ class CompilerBackend(ABC):
 # ---------------------------------------------------------------------------
 # Ninja build helper
 # ---------------------------------------------------------------------------
-
-def _find_ninja() -> str | None:
-    """Find the ninja binary."""
-    return shutil.which("ninja")
-
 
 class NinjaBuild:
     """Generates and executes a ninja build for CUDA sources.
@@ -269,7 +264,7 @@ default {so_file}
 
         Raises CompilationError on failure.
         """
-        ninja = _find_ninja()
+        ninja = shutil.which("ninja")
         if ninja is None:
             raise KernelToolchainError("ninja not found. Install with: pip install ninja")
 

--- a/brainevent/_op/kernix_pipeline.py
+++ b/brainevent/_op/kernix_pipeline.py
@@ -53,6 +53,40 @@ _cache = CompilationCache()
 _registered_so_paths: set[str] = set()
 
 
+def _join_sources(sources: str | list[str]) -> str:
+    """Concatenate a list of sources, or return a single source unchanged."""
+    return "\n\n".join(sources) if isinstance(sources, list) else sources
+
+
+def _build_specs(
+    functions: dict[str, list[str]], user_source: str
+) -> list[FunctionSpec]:
+    """Parse each function's arg_spec: normalize aliases → resolve bare attrs → parse."""
+    specs: list[FunctionSpec] = []
+    for func_name, tokens in functions.items():
+        tokens = normalize_tokens(tokens)
+        tokens = resolve_bare_attr_types(tokens, func_name, user_source)
+        specs.append(parse_arg_spec(func_name, tokens))
+    return specs
+
+
+def _register_targets(
+    specs: list[FunctionSpec],
+    module: CompiledModule,
+    so_path: str,
+    name: str,
+    target_prefix: str | None,
+    platform: str,
+) -> None:
+    """Register each spec as a JAX FFI target, once per unique so_path."""
+    if so_path in _registered_so_paths:
+        return
+    prefix = target_prefix or name
+    for spec in specs:
+        register_ffi_target(f"{prefix}.{spec.name}", module, spec.name, platform=platform)
+    _registered_so_paths.add(so_path)
+
+
 def set_cache_dir(path: str | Path) -> None:
     """Set the compilation cache directory.
 
@@ -144,11 +178,7 @@ def load_cuda_inline(
     -------
     CompiledModule
     """
-    # Normalise sources
-    if isinstance(cuda_sources, list):
-        user_source = "\n\n".join(cuda_sources)
-    else:
-        user_source = cuda_sources
+    user_source = _join_sources(cuda_sources)
 
     # Discover functions from annotations if not provided
     if functions is None:
@@ -175,12 +205,7 @@ def load_cuda_inline(
     # Check cache
     cached_so = None if force_rebuild else _cache.lookup(name, cache_key)
 
-    # Parse arg_specs: normalize aliases → resolve bare attrs → parse
-    specs: list[FunctionSpec] = []
-    for func_name, tokens in functions.items():
-        tokens = normalize_tokens(tokens)
-        tokens = resolve_bare_attr_types(tokens, func_name, user_source)
-        specs.append(parse_arg_spec(func_name, tokens))
+    specs = _build_specs(functions, user_source)
 
     if cached_so is not None:
         so_path = str(cached_so)
@@ -211,16 +236,10 @@ def load_cuda_inline(
         _cache.store(name, cache_key, so_path)
 
     # Load module
-    func_names = list(functions.keys())
-    module = CompiledModule(so_path, func_names)
+    module = CompiledModule(so_path, list(functions.keys()))
 
-    # Auto-register with JAX FFI — only on the first instantiation of this so.
-    if auto_register and so_path not in _registered_so_paths:
-        prefix = target_prefix or name
-        for spec in specs:
-            target_name = f"{prefix}.{spec.name}"
-            register_ffi_target(target_name, module, spec.name, platform="CUDA")
-        _registered_so_paths.add(so_path)
+    if auto_register:
+        _register_targets(specs, module, so_path, name, target_prefix, platform="CUDA")
 
     return module
 
@@ -341,36 +360,21 @@ def load_cpp_inline(
         Automatically register FFI targets as ``"<prefix>.<func>"``.
     target_prefix : str, optional
         Prefix for auto-registered FFI targets.  Defaults to *name*.
-    platform : str
-        Target platform passed to ``jax.ffi.register_ffi_target``.
-        Default: ``"cpu"``.
 
     Returns
     -------
     CompiledModule
     """
 
-    # Normalise sources
-    if isinstance(cpp_sources, list):
-        user_source = "\n\n".join(cpp_sources)
-    else:
-        user_source = cpp_sources
+    user_source = _join_sources(cpp_sources)
 
     # Resolve functions → dict[str, list[str]]
     if functions is None:
         functions = parse_annotations(user_source)
     elif isinstance(functions, list):
-        func_dict: dict[str, list[str]] = {}
-        for fn in functions:
-            func_dict[fn] = infer_arg_spec_from_source(user_source, fn)
-        functions = func_dict
+        functions = {fn: infer_arg_spec_from_source(user_source, fn) for fn in functions}
 
-    # Parse arg_specs: normalize aliases → resolve bare attrs → parse
-    specs: list[FunctionSpec] = []
-    for func_name, tokens in functions.items():
-        tokens = normalize_tokens(tokens)
-        tokens = resolve_bare_attr_types(tokens, func_name, user_source)
-        specs.append(parse_arg_spec(func_name, tokens))
+    specs = _build_specs(functions, user_source)
 
     # Detect toolchain (CPU — no CUDA needed)
     toolchain = detect_cpp_toolchain()
@@ -407,15 +411,10 @@ def load_cpp_inline(
 
         _cache.store(name, cache_key, so_path)
 
-    func_names = list(functions.keys())
-    module = CompiledModule(so_path, func_names)
+    module = CompiledModule(so_path, list(functions.keys()))
 
-    if auto_register and so_path not in _registered_so_paths:
-        prefix = target_prefix or name
-        for spec in specs:
-            target_name = f"{prefix}.{spec.name}"
-            register_ffi_target(target_name, module, spec.name, platform='cpu')
-        _registered_so_paths.add(so_path)
+    if auto_register:
+        _register_targets(specs, module, so_path, name, target_prefix, platform="cpu")
 
     return module
 

--- a/brainevent/_op/kernix_runtime.py
+++ b/brainevent/_op/kernix_runtime.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Runtime layer: CompiledModule, JAX FFI registration, dtype and attr utilities."""
+"""Runtime layer: CompiledModule and JAX FFI registration."""
 
 import ctypes
 
 import jax
-import ml_dtypes
-import numpy as np
 
 from brainevent._error import KernelError, KernelLoadError, KernelRegistrationError
 
@@ -28,124 +26,21 @@ def _format_load_error(so_path: str, err: Exception) -> str:
     msg = str(err)
     low = msg.lower()
     lines = [
-        "[brainevent GPU 工具链] 加载 .so 失败  (code=E-LOAD)",
+        "[brainevent GPU toolchain] Failed to load .so  (code=E-LOAD)",
         "",
-        f"原因: 无法 dlopen 编译产物：{so_path}",
+        f"Reason: cannot dlopen the compiled artefact: {so_path}",
         f"dlopen: {msg}",
         "",
-        "如何修复:",
+        "How to fix:",
     ]
     if "cudart" in low or "cannot open shared object" in low:
         lines += [
-            "  1) 缺少 CUDA 运行库（典型 cu12）。确保 jax[cuda*] 已正确安装。",
-            "  2) 把 CUDA 运行库目录加入 LD_LIBRARY_PATH（如 site-packages/nvidia/cuda_runtime/lib）。",
+            "  1) Missing CUDA runtime libraries (typically cu12). Ensure jax[cuda*] is installed correctly.",
+            "  2) Add the CUDA runtime library directory to LD_LIBRARY_PATH (e.g. site-packages/nvidia/cuda_runtime/lib).",
         ]
     else:
-        lines += ["  1) 确认编译成功且依赖库可用；设 BRAINEVENT_TOOLCHAIN_DEBUG=1 查看工具链快照。"]
+        lines += ["  1) Verify the build succeeded and dependent libraries are available; set BRAINEVENT_TOOLCHAIN_DEBUG=1 to see a toolchain snapshot."]
     return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
-# Dtype mapping
-# ---------------------------------------------------------------------------
-
-# Must match BE::DType enum in tensor.h
-_JAX_TO_JKB: dict[np.dtype, int] = {
-    np.dtype("float16"): 0,  # Float16
-    np.dtype("float32"): 1,  # Float32
-    np.dtype("float64"): 2,  # Float64
-    np.dtype(ml_dtypes.bfloat16): 3,  # bfloat16 lives in ml_dtypes (JAX's dependency)
-    np.dtype("int8"): 4,  # Int8
-    np.dtype("int16"): 5,  # Int16
-    np.dtype("int32"): 6,  # Int32
-    np.dtype("int64"): 7,  # Int64
-    np.dtype("uint8"): 8,  # UInt8
-    np.dtype("uint16"): 9,  # UInt16
-    np.dtype("uint32"): 10,  # UInt32
-    np.dtype("uint64"): 11,  # UInt64
-    np.dtype("bool"): 12,  # Bool
-    np.dtype("complex64"): 13,  # Complex64
-    np.dtype("complex128"): 14,  # Complex128
-}
-
-_BE_TO_JAX: dict[int, np.dtype] = {v: k for k, v in _JAX_TO_JKB.items()}
-
-# Element byte widths (redundant with C++ side, but useful in Python)
-DTYPE_SIZES: dict[int, int] = {
-    0: 2, 1: 4, 2: 8, 3: 2,  # float types
-    4: 1, 5: 2, 6: 4, 7: 8,  # signed int
-    8: 1, 9: 2, 10: 4, 11: 8,  # unsigned int
-    12: 1, 13: 8, 14: 16,  # bool, complex
-}
-
-
-def jax_dtype_to_jkb(dtype) -> int:
-    """Convert a JAX/NumPy dtype to a BE DType enum value."""
-    dtype = np.dtype(dtype)
-    if dtype not in _JAX_TO_JKB:
-        raise TypeError(f"Unsupported dtype: {dtype}")
-    return _JAX_TO_JKB[dtype]
-
-
-def be_to_jax_dtype(jkb_dtype: int) -> np.dtype:
-    """Convert a BE DType enum value to a NumPy dtype."""
-    if jkb_dtype not in _BE_TO_JAX:
-        raise ValueError(f"Unknown BE dtype enum value: {jkb_dtype}")
-    return _BE_TO_JAX[jkb_dtype]
-
-
-# ---------------------------------------------------------------------------
-# Attribute type mapping
-# ---------------------------------------------------------------------------
-
-# Maps BE attr type name → numpy dtype used when passing from Python.
-# For float16/bfloat16 use numpy.uint16 containing the raw 16-bit pattern.
-ATTR_NUMPY_DTYPE: dict[str, type] = {
-    "bool": bool,
-    "int8": np.int8,
-    "uint8": np.uint8,
-    "int16": np.int16,
-    "uint16": np.uint16,
-    "int32": np.int32,
-    "uint32": np.uint32,
-    "int64": np.int64,
-    "uint64": np.uint64,
-    "float16": np.uint16,  # pass raw bits: np.float16(x).view(np.uint16)
-    "bfloat16": np.uint16,  # pass raw bits: bfloat16_val.view(np.uint16)
-    "float32": np.float32,
-    "float64": np.float64,
-    # complex64 / complex128 omitted: JAX mlir.ir_attribute cannot encode them.
-}
-
-# Legacy alias kept for backward compatibility.
-ATTR_TYPES = {
-    k: {"cpp": v, "python": ATTR_NUMPY_DTYPE[k]}
-    for k, v in {
-        "bool": "bool",
-        "int8": "int8_t",
-        "uint8": "uint8_t",
-        "int16": "int16_t",
-        "uint16": "uint16_t",
-        "int32": "int32_t",
-        "uint32": "uint32_t",
-        "int64": "int64_t",
-        "uint64": "uint64_t",
-        "float16": "uint16_t",
-        "bfloat16": "uint16_t",
-        "float32": "float",
-        "float64": "double",
-    }.items()
-}
-
-
-def validate_attr_value(name: str, value, expected_type: str) -> None:
-    """Validate that a Python attribute value is compatible with *expected_type*."""
-    info = ATTR_TYPES.get(expected_type)
-    if info is None:
-        raise TypeError(
-            f"Unknown attribute type '{expected_type}' for '{name}'. "
-            f"Supported: {list(ATTR_TYPES)}"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/brainevent/_op/kernix_toolchain.py
+++ b/brainevent/_op/kernix_toolchain.py
@@ -66,17 +66,17 @@ class CandidateProbe:
 
 
 _PROBE_LABEL = {
-    "unset": "未设置",
-    "not-found": "未找到",
-    "not-a-file": "不是文件",
-    "ok": "命中",
+    "unset": "unset",
+    "not-found": "not found",
+    "not-a-file": "not a file",
+    "ok": "hit",
 }
 
 
 def _probe_line(p: CandidateProbe) -> str:
     mark = "✓" if p.status == "ok" else "✗"
     if p.status.startswith("rejected:"):
-        label = "拒绝(" + p.status.split(":", 1)[1] + ")"
+        label = "rejected(" + p.status.split(":", 1)[1] + ")"
     else:
         label = _PROBE_LABEL.get(p.status, p.status)
     loc = f"  [{p.path}]" if p.path else ""
@@ -101,19 +101,19 @@ def render_toolchain_error(
         except Exception:
             snapshot = None
 
-    lines = [f"[brainevent GPU 工具链] {stage} 失败  (code={code})", "", f"原因: {summary}"]
+    lines = [f"[brainevent GPU toolchain] {stage} failed  (code={code})", "", f"Reason: {summary}"]
     if probes:
-        lines += ["", "已尝试 (按优先级):"]
+        lines += ["", "Tried (in priority order):"]
         lines += [_probe_line(p) for p in probes]
     if command:
-        lines += ["", "命令:", f"  {command}"]
+        lines += ["", "Command:", f"  {command}"]
     if compiler_output:
-        lines += ["", "编译器输出:", compiler_output]
+        lines += ["", "Compiler output:", compiler_output]
     if remediation:
-        lines += ["", "如何修复:"]
+        lines += ["", "How to fix:"]
         lines += [f"  {i}) {r}" for i, r in enumerate(remediation, 1)]
     if snapshot:
-        lines += ["", "工具链快照:"]
+        lines += ["", "Toolchain snapshot:"]
         lines += [f"  {k} = {v}" for k, v in snapshot.items()]
     return "\n".join(lines)
 
@@ -352,6 +352,33 @@ def collect_toolchain_diagnostics() -> dict:
     return snap
 
 
+def _resolve_xla_ffi_include(summary: str, remediation: "list[str]") -> str:
+    """Return the jaxlib XLA FFI include dir, or raise if ``ffi.h`` is missing."""
+    xla_ffi_include = jax.ffi.include_dir()
+    ffi_header = os.path.join(xla_ffi_include, "xla", "ffi", "api", "ffi.h")
+    if not os.path.isfile(ffi_header):
+        raise HeaderNotFoundError(render_toolchain_error(
+            stage="header resolution", code="E-HDR",
+            summary=summary,
+            probes=[CandidateProbe("jaxlib:xla/ffi/api/ffi.h", ffi_header, "not-found")],
+            remediation=remediation,
+        ))
+    return xla_ffi_include
+
+
+def _resolve_brainevent_include() -> str:
+    """Return the brainevent include dir, or raise if it is missing."""
+    be_include = str(Path(__file__).resolve().parent.parent / "include")
+    if not os.path.isdir(be_include):
+        raise HeaderNotFoundError(render_toolchain_error(
+            stage="header resolution", code="E-HDR",
+            summary="brainevent include directory is missing (the package install may be corrupted).",
+            probes=[CandidateProbe("brainevent/include", be_include, "not-found")],
+            remediation=["Reinstall brainevent: pip install -U --force-reinstall brainevent"],
+        ))
+    return be_include
+
+
 def detect_cuda_toolchain() -> CudaToolchain:
     """Auto-detect nvcc, host C++ compiler, and include paths.
 
@@ -361,13 +388,13 @@ def detect_cuda_toolchain() -> CudaToolchain:
     nvcc, cuda_include_dirs, nvcc_probes = _select_nvcc()
     if nvcc is None:
         raise NvccNotFoundError(render_toolchain_error(
-            stage="nvcc 发现", code="E-NVCC",
-            summary="未找到 CUDA 编译器 nvcc。",
+            stage="nvcc discovery", code="E-NVCC",
+            summary="CUDA compiler nvcc not found.",
             probes=nvcc_probes,
             remediation=[
-                '安装 jax[cuda13]（自带 nvcc，无需系统 CUDA Toolkit）：pip install -U "jax[cuda13]"',
-                "或设 BRAINEVENT_NVCC_PATH 指向 nvcc，或设 CUDA_HOME 指向 CUDA 安装目录",
-                "若想优先用系统 PATH 上的 nvcc：brainevent.config.prefer_system_nvcc()",
+                'Install jax[cuda13] (bundles nvcc, no system CUDA Toolkit required): pip install -U "jax[cuda13]"',
+                "Or set BRAINEVENT_NVCC_PATH to the nvcc path, or set CUDA_HOME to the CUDA install directory",
+                "To prefer the nvcc on the system PATH: brainevent.config.prefer_system_nvcc()",
             ],
         ))
 
@@ -382,49 +409,34 @@ def detect_cuda_toolchain() -> CudaToolchain:
             break
     if not nvcc_version:
         raise NvccNotFoundError(render_toolchain_error(
-            stage="nvcc 发现", code="E-NVCC",
-            summary=f"nvcc 存在但无法获取版本：{nvcc}",
+            stage="nvcc discovery", code="E-NVCC",
+            summary=f"nvcc exists but its version could not be determined: {nvcc}",
             probes=nvcc_probes,
             compiler_output=(proc.stdout + proc.stderr),
-            remediation=["确认该 nvcc 可执行且未损坏，或改用其它 nvcc。"],
+            remediation=["Verify this nvcc is executable and not corrupted, or use a different nvcc."],
         ))
 
     # host compiler
     cxx, cxx_probes = _find_host_cxx()
     if cxx is None:
         raise HostCompilerNotFoundError(render_toolchain_error(
-            stage="host 编译器发现", code="E-CXX",
-            summary="未找到 host C++ 编译器（nvcc 需要它编译 host 侧代码并链接）。pip 不提供 host 编译器。",
+            stage="host compiler discovery", code="E-CXX",
+            summary="host C++ compiler not found (nvcc needs it to compile and link host-side code). pip does not provide a host compiler.",
             probes=cxx_probes,
             remediation=[
-                "conda 环境：conda install -c conda-forge gxx",
-                "Debian/Ubuntu：sudo apt-get install g++",
-                "RHEL/Fedora：sudo dnf install gcc-c++",
-                "或设 CXX=/path/to/g++",
+                "conda environment: conda install -c conda-forge gxx",
+                "Debian/Ubuntu: sudo apt-get install g++",
+                "RHEL/Fedora: sudo dnf install gcc-c++",
+                "Or set CXX=/path/to/g++",
             ],
         ))
     cxx_version = _cxx_version(cxx)
 
-    # XLA FFI include (from jaxlib)
-    xla_ffi_include = jax.ffi.include_dir()
-    ffi_header = os.path.join(xla_ffi_include, "xla", "ffi", "api", "ffi.h")
-    if not os.path.isfile(ffi_header):
-        raise HeaderNotFoundError(render_toolchain_error(
-            stage="头文件解析", code="E-HDR",
-            summary="未找到 XLA FFI 头 ffi.h（jaxlib 与 CUDA wheel 可能不配套或损坏）。",
-            probes=[CandidateProbe("jaxlib:xla/ffi/api/ffi.h", ffi_header, "not-found")],
-            remediation=['重装与 CUDA 匹配的 jaxlib：pip install -U "jax[cuda13]"'],
-        ))
-
-    # brainevent include
-    be_include = str(Path(__file__).resolve().parent.parent / "include")
-    if not os.path.isdir(be_include):
-        raise HeaderNotFoundError(render_toolchain_error(
-            stage="头文件解析", code="E-HDR",
-            summary="brainevent include 目录缺失（包安装可能损坏）。",
-            probes=[CandidateProbe("brainevent/include", be_include, "not-found")],
-            remediation=["重装 brainevent：pip install -U --force-reinstall brainevent"],
-        ))
+    xla_ffi_include = _resolve_xla_ffi_include(
+        summary="XLA FFI header ffi.h not found (jaxlib and the CUDA wheel may be mismatched or corrupted).",
+        remediation=['Reinstall a jaxlib matching your CUDA: pip install -U "jax[cuda13]"'],
+    )
+    be_include = _resolve_brainevent_include()
 
     return CudaToolchain(
         nvcc=nvcc,
@@ -446,36 +458,23 @@ def detect_cpp_toolchain() -> CppToolchain:
     cxx, cxx_probes = _find_host_cxx()
     if cxx is None:
         raise HostCompilerNotFoundError(render_toolchain_error(
-            stage="host 编译器发现", code="E-CXX",
-            summary="未找到 C++ 编译器（CPU 后端需要 g++/clang++）。",
+            stage="host compiler discovery", code="E-CXX",
+            summary="C++ compiler not found (the CPU backend requires g++/clang++).",
             probes=cxx_probes,
             remediation=[
-                "conda 环境：conda install -c conda-forge gxx",
-                "Debian/Ubuntu：sudo apt-get install g++",
-                "RHEL/Fedora：sudo dnf install gcc-c++",
-                "或设 CXX=/path/to/g++",
+                "conda environment: conda install -c conda-forge gxx",
+                "Debian/Ubuntu: sudo apt-get install g++",
+                "RHEL/Fedora: sudo dnf install gcc-c++",
+                "Or set CXX=/path/to/g++",
             ],
         ))
     cxx_version = _cxx_version(cxx)
 
-    xla_ffi_include = jax.ffi.include_dir()
-    ffi_header = os.path.join(xla_ffi_include, "xla", "ffi", "api", "ffi.h")
-    if not os.path.isfile(ffi_header):
-        raise HeaderNotFoundError(render_toolchain_error(
-            stage="头文件解析", code="E-HDR",
-            summary="未找到 XLA FFI 头 ffi.h。",
-            probes=[CandidateProbe("jaxlib:xla/ffi/api/ffi.h", ffi_header, "not-found")],
-            remediation=["重装 jaxlib：pip install -U jax jaxlib"],
-        ))
-
-    be_include = str(Path(__file__).resolve().parent.parent / "include")
-    if not os.path.isdir(be_include):
-        raise HeaderNotFoundError(render_toolchain_error(
-            stage="头文件解析", code="E-HDR",
-            summary="brainevent include 目录缺失。",
-            probes=[CandidateProbe("brainevent/include", be_include, "not-found")],
-            remediation=["重装 brainevent：pip install -U --force-reinstall brainevent"],
-        ))
+    xla_ffi_include = _resolve_xla_ffi_include(
+        summary="XLA FFI header ffi.h not found.",
+        remediation=["Reinstall jaxlib: pip install -U jax jaxlib"],
+    )
+    be_include = _resolve_brainevent_include()
 
     return CppToolchain(
         cxx=cxx,
@@ -581,11 +580,11 @@ def detect_cuda_arch() -> list[str]:
             return sorted(caps)
 
     raise GpuArchDetectionError(render_toolchain_error(
-        stage="算力探测", code="E-ARCH",
-        summary="无法通过 nvidia-smi 探测 GPU 算力（驱动缺失或 nvidia-smi 不可用）。",
+        stage="compute capability detection", code="E-ARCH",
+        summary="Could not detect GPU compute capability via nvidia-smi (driver missing or nvidia-smi unavailable).",
         probes=[CandidateProbe("nvidia-smi", shutil.which("nvidia-smi") or "", "not-found")],
         remediation=[
-            "安装/修复 NVIDIA 驱动，使 nvidia-smi 可用",
-            "或设 BRAINEVENT_COMPUTE_CAPABILITIES（如 '8.6,8.0'）跳过自动探测",
+            "Install/repair the NVIDIA driver so that nvidia-smi works",
+            "Or set BRAINEVENT_COMPUTE_CAPABILITIES (e.g. '8.6,8.0') to skip auto-detection",
         ],
     ))

--- a/brainevent/_op/kernix_toolchain_test.py
+++ b/brainevent/_op/kernix_toolchain_test.py
@@ -18,28 +18,28 @@ def _touch_exec(p):
 
 def test_render_sections_present():
     msg = render_toolchain_error(
-        stage="nvcc 发现", code="E-NVCC", summary="未找到 nvcc。",
+        stage="nvcc discovery", code="E-NVCC", summary="nvcc not found.",
         probes=[
             CandidateProbe("BRAINEVENT_NVCC_PATH", "", "unset"),
             CandidateProbe("PATH:nvcc", "", "not-found"),
         ],
-        remediation=["安装 jax[cuda13]"],
+        remediation=["Install jax[cuda13]"],
     )
     assert "E-NVCC" in msg
-    assert "原因" in msg
-    assert "已尝试" in msg
+    assert "Reason" in msg
+    assert "Tried" in msg
     assert "BRAINEVENT_NVCC_PATH" in msg
-    assert "如何修复" in msg
-    assert "安装 jax[cuda13]" in msg
+    assert "How to fix" in msg
+    assert "Install jax[cuda13]" in msg
 
 
 def test_render_includes_command_for_compile():
     msg = render_toolchain_error(
-        stage="编译", code="E-COMPILE", summary="失败",
+        stage="compile", code="E-COMPILE", summary="failed",
         command="nvcc x.cu", compiler_output="error: boom", remediation=["fix it"],
     )
-    assert "命令" in msg and "nvcc x.cu" in msg
-    assert "编译器输出" in msg and "boom" in msg
+    assert "Command" in msg and "nvcc x.cu" in msg
+    assert "Compiler output" in msg and "boom" in msg
 
 
 # --- discovery preference -------------------------------------------------
@@ -284,4 +284,4 @@ def test_render_appends_snapshot_when_debug(monkeypatch):
     monkeypatch.setenv("BRAINEVENT_TOOLCHAIN_DEBUG", "1")
     monkeypatch.setattr(kt, "collect_toolchain_diagnostics", lambda: {"nvcc": "/n"})
     msg = kt.render_toolchain_error(stage="x", code="E-X", summary="s")
-    assert "工具链快照" in msg and "/n" in msg
+    assert "Toolchain snapshot" in msg and "/n" in msg

--- a/brainevent/config.py
+++ b/brainevent/config.py
@@ -323,21 +323,21 @@ def clear_backends():
 # ──────────────────────────────────────────────────────────────────────
 
 def prefer_system_nvcc(enable: bool = True) -> None:
-    """切换 nvcc 发现优先级。
+    """Switch the nvcc discovery preference.
 
     Parameters
     ----------
     enable : bool
-        ``True`` → 优先使用系统 ``PATH`` 上的 nvcc；
-        ``False`` → 优先使用 ``jax[cuda*]`` 自带的 pip nvcc（默认）。
+        ``True`` → prefer the nvcc on the system ``PATH``;
+        ``False`` → prefer the pip nvcc bundled with ``jax[cuda*]`` (default).
 
     Examples
     --------
     .. code-block:: python
 
         >>> import brainevent
-        >>> brainevent.config.prefer_system_nvcc()       # 改为系统优先
-        >>> brainevent.config.prefer_system_nvcc(False)  # 改回 pip 优先
+        >>> brainevent.config.prefer_system_nvcc()       # switch to system-first
+        >>> brainevent.config.prefer_system_nvcc(False)  # switch back to pip-first
     """
     from brainevent._op.kernix_toolchain import set_nvcc_discovery
     set_nvcc_discovery("system" if enable else "pip")


### PR DESCRIPTION
## Summary
Scoped cleanup of the `brainevent/_op/kernix*.py` modules. Behavior and public APIs are unchanged; the kernix test suite still reports **145 passing** (identical to the pre-change baseline).

- **kernix_runtime.py**: removed the unused dtype/attr utility cluster (`jax_dtype_to_jkb`, `be_to_jax_dtype`, `DTYPE_SIZES`, `ATTR_NUMPY_DTYPE`, `ATTR_TYPES`, `validate_attr_value`, `_JAX_TO_JKB`, `_BE_TO_JAX`) — none were referenced anywhere — plus the now-dead `numpy`/`ml_dtypes` imports.
- **kernix_codegen.py**: merged the identical `_ATTR_CPP_TYPE` / `_ATTR_FFI_TYPE` tables into one, and extracted a shared `_parse_scalar_param` helper used by `_infer_attr_type_from_source` and `_params_str_to_tokens`.
- **kernix_pipeline.py**: factored the duplicated logic in `load_cuda_inline` / `load_cpp_inline` into `_join_sources`, `_build_specs`, and `_register_targets`; removed a stale `platform` docstring entry that described a non-existent parameter.
- **kernix_toolchain.py**: extracted `_resolve_xla_ffi_include` / `_resolve_brainevent_include` to dedupe the two `detect_*` functions.
- **kernix_compiler.py**: inlined the trivial `_find_ninja` wrapper.
- **English diagnostics**: translated all Chinese error/diagnostic strings and comments to English across the kernix modules (with matching test-assertion updates in `kernix_toolchain_test.py`), `config.py`, and the two `benchmark/*.py` scripts that still contained Chinese comments.

## Test plan
- [x] `pytest brainevent/_op/kernix_*_test.py` → 145 passed (matches baseline)
- [x] AST parse + import sanity of all edited modules
- [x] No unused imports introduced
- [x] No Chinese characters remain in any `.py` file