### PR TITLE
Ship PEP 561 inline types via py.typed, gated by a mypy CI ratchet

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,6 +113,36 @@ jobs:
           pytest brainevent/ -p no:faulthandler
 
 
+  type_check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.13" ]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.13.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install type-check tooling
+        run: |
+          python -m pip install --upgrade pip --no-cache-dir
+          python -m pip install -r requirements-typecheck.txt --no-cache-dir
+      - name: mypy ratchet (PEP 561)
+        # mypy still exits non-zero while the baseline errors exist, so the ratchet
+        # verdict comes solely from `mypy-baseline filter`, which fails ONLY when a new
+        # error appears. `--allow-unsynced` lets contributors fix errors without having
+        # to re-sync the baseline in the same PR.
+        run: |
+          mypy brainevent/ > mypy-report.txt || true
+          mypy-baseline filter --allow-unsynced --baseline-path mypy-baseline.txt < mypy-report.txt
+
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,7 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+mypy-report.txt
 
 # Pyre type checker
 .pyre/

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1,0 +1,91 @@
+brainevent/_data.py:0: error: Need type annotation for "_buffer_registry" (hint: "_buffer_registry: set[<type>] = ...")  [var-annotated]
+brainevent/_op/kernix_runtime.py:0: error: Name "ctypes._CFuncPtr" is not defined  [name-defined]
+brainevent/_misc.py:0: error: Need type annotation for "_cache" (hint: "_cache: dict[<type>, <type>] = ...")  [var-annotated]
+brainevent/_misc.py:0: error: Incompatible default for parameter "fn" (default has type "None", parameter has type "Callable[..., Any]")  [assignment]
+brainevent/_misc.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/_misc.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_misc.py:0: error: Incompatible default for parameter "name" (default has type "None", parameter has type "str")  [assignment]
+brainevent/_misc.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/_misc.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_op/kernix_toolchain.py:0: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
+brainevent/_op/kernix_toolchain.py:0: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
+brainevent/_fcn/layouts.py:0: error: Incompatible return value type (got "tuple[int, ...]", expected "tuple[int, int]")  [return-value]
+brainevent/_fcn/layouts.py:0: error: Item "Number" of "Any | Number" has no attribute "T"  [union-attr]
+brainevent/_fcn/layouts.py:0: error: Incompatible return value type (got "tuple[int, ...]", expected "tuple[int, int]")  [return-value]
+brainevent/_op/main.py:0: error: Incompatible default for parameter "doc" (default has type "None", parameter has type "str")  [assignment]
+brainevent/_op/main.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/_op/main.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_op/main.py:0: error: Argument 1 to "tuple" has incompatible type "ShapeDtype | Sequence[ShapeDtype]"; expected "Iterable[Any]"  [arg-type]
+brainevent/_op/main.py:0: error: Argument 1 to "tuple" has incompatible type "ShapeDtype | Sequence[ShapeDtype]"; expected "Iterable[ShapeDtype]"  [arg-type]
+brainevent/_op/main.py:0: error: Argument 1 to "len" has incompatible type "ShapeDtype | Sequence[ShapeDtype]"; expected "Sized"  [arg-type]
+brainevent/_op/numba_cuda_ffi.py:0: error: Incompatible types in assignment (expression has type "tuple[int, int]", variable has type "tuple[int]")  [assignment]
+brainevent/_op/numba_cuda_ffi.py:0: error: Incompatible types in assignment (expression has type "tuple[int, Any]", variable has type "tuple[int]")  [assignment]
+brainevent/_op/numba_cuda_ffi.py:0: error: Tuple index out of range  [misc]
+brainevent/_op/numba_cuda_ffi.py:0: error: Incompatible types in assignment (expression has type "tuple[int, int, int]", variable has type "tuple[int]")  [assignment]
+brainevent/_op/numba_cuda_ffi.py:0: error: Incompatible types in assignment (expression has type "tuple[int, Any, Any]", variable has type "tuple[int]")  [assignment]
+brainevent/_op/numba_cuda_ffi.py:0: error: Tuple index out of range  [misc]
+brainevent/_op/numba_cuda_ffi.py:0: error: Tuple index out of range  [misc]
+brainevent/pararnn/_parallel_reduce.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_parallel_reduce.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_parallel_reduce.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_parallel_reduce.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_parallel_reduce.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_parallel_reduce.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_parallel_reduce.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_parallel_reduce.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_parallel_reduce.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_parallel_reduce.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_parallel_reduce.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_parallel_reduce.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_parallel_reduce.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_parallel_reduce.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_parallel_reduce.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "ndim"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/yw2y.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/pararnn/_fused.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_fused.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_fused.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_fused.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_fused.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_fused.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_fused.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_fused.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_fused.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/pararnn/_fused.py:0: error: Incompatible default for parameter "backend" (default has type "None", parameter has type "str")  [assignment]
+brainevent/pararnn/_fused.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/pararnn/_fused.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_jit_normal/main.py:0: error: Item "Number" of "Any | Number" has no attribute "T"  [union-attr]
+brainevent/_jit_normal/main.py:0: error: Item "Number" of "Any | Number" has no attribute "T"  [union-attr]
+brainevent/_fcn/main.py:0: error: Missing return statement  [return]
+brainevent/_fcn/main.py:0: error: Incompatible types in assignment (expression has type "CscLayout", variable has type "None")  [assignment]
+brainevent/_fcn/main.py:0: error: Incompatible return value type (got "None", expected "CscLayout")  [return-value]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/main.py:0: error: Incompatible default for parameter "nse" (default has type "None", parameter has type "int")  [assignment]
+brainevent/_csr/main.py:0: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
+brainevent/_csr/main.py:0: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Number" has no attribute "shape"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_csr/main.py:0: error: Item "Number" of "Any | Number" has no attribute "dtype"  [union-attr]
+brainevent/_cli.py:0: error: Argument "key" to "max" has incompatible type overloaded function; expected "Callable[[str], SupportsDunderLT[Any] | SupportsDunderGT[Any]]"  [arg-type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ build-backend = "setuptools.build_meta"
 # The wildcard key "*" applies to every discovered package/subpackage.
 "*" = ["*.cu", "*.h"]
 # Explicitly include nested C++ headers (brainevent/ subdir is 2 levels deep in include/).
-"brainevent" = ["include/brainevent/*.h"]
+# "py.typed" is the PEP 561 marker that tells downstream type checkers brainevent ships
+# inline type information; it must be bundled in the wheel to have any effect.
+"brainevent" = ["include/brainevent/*.h", "py.typed"]
 
 
 [tool.setuptools.packages.find]
@@ -105,3 +107,17 @@ cuda12 = ['jax[cuda12]>=0.7.2', "ninja"]
 cuda13 = ['jax[cuda13]>=0.7.2', "ninja"]
 tpu = ['jax[tpu]>=0.7.2']
 testing = ['pytest']
+
+
+[tool.mypy]
+# Configuration for the mypy CI ratchet (see .github/workflows/CI.yml `type_check`).
+#
+# The ratchet runs with ONLY mypy + mypy-baseline installed (no runtime deps), so every
+# third-party import must resolve to `Any` via ignore_missing_imports. python_version and
+# platform are pinned so the committed mypy-baseline.txt reproduces exactly on CI.
+files = ["brainevent"]
+exclude = ['_test\.py$']
+python_version = "3.13"
+platform = "linux"
+ignore_missing_imports = true
+show_error_codes = true

--- a/requirements-typecheck.txt
+++ b/requirements-typecheck.txt
@@ -1,0 +1,8 @@
+# Pinned tooling for the mypy ratchet (see .github/workflows/CI.yml `type_check`).
+#
+# Only mypy + mypy-baseline are installed here -- deliberately NOT the project's
+# runtime/dev dependencies. The ratchet relies on `ignore_missing_imports` so every
+# third-party import collapses to `Any`, which keeps the committed mypy-baseline.txt
+# reproducible regardless of which typed packages happen to be installed.
+mypy==2.1.0
+mypy-baseline==0.7.4


### PR DESCRIPTION
- Add brainevent/py.typed marker and bundle it in the wheel (package-data)
  so downstream type checkers honor brainevent's inline annotations.
- Add a [tool.mypy] config pinned to python 3.13 / linux with
  ignore_missing_imports, scoped to the brainevent package (tests excluded).
- Add a mypy ratchet CI job: mypy-baseline filter fails only on NEW type
  errors; the 63 pre-existing errors are recorded in mypy-baseline.txt and
  --allow-unsynced lets contributors fix them without re-syncing.
- Pin tooling in requirements-typecheck.txt so the baseline reproduces in CI.

## Summary by Sourcery

Add a PEP 561 py.typed marker for the brainevent package and enforce type checking via a mypy CI ratchet.

Enhancements:
- Add a mypy configuration scoped to the brainevent package with pinned Python and platform settings and relaxed import resolution to support the CI ratchet.

Build:
- Bundle a py.typed marker file for the brainevent package via package data configuration in pyproject.toml.

CI:
- Introduce a dedicated type_check GitHub Actions job that runs mypy and enforces a baseline-based ratchet for new type errors.

Chores:
- Check in mypy-baseline and type-checking requirements files to keep the type-checking environment and error baseline reproducible.