### PR TITLE
test: split slow numba variants from fast runs and trim parametrization

### DIFF
--- a/.github/workflows/CI-daily.yml
+++ b/.github/workflows/CI-daily.yml
@@ -69,5 +69,7 @@ jobs:
           python -m pip install . || exit 1
       - name: Test with pytest
         run: |
-          pytest brainevent/
+          # Run the FULL suite, including `slow` (compilation-heavy numba) variants that the
+          # default `pytest` invocation skips via addopts in pyproject.toml.
+          pytest brainevent/ -m ""
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,9 @@ jobs:
           pip install .  --no-cache-dir
       - name: Test with pytest
         run: |
-          pytest brainevent/
+          # Run the FULL suite, including `slow` (compilation-heavy numba) variants that the
+          # default `pytest` invocation skips via addopts in pyproject.toml.
+          pytest brainevent/ -m ""
 
 
   test_macos:
@@ -80,7 +82,9 @@ jobs:
           pip install .  --no-cache-dir
       - name: Test with pytest
         run: |
-          pytest brainevent/
+          # Run the FULL suite, including `slow` (compilation-heavy numba) variants that the
+          # default `pytest` invocation skips via addopts in pyproject.toml.
+          pytest brainevent/ -m ""
 
 
   test_windows:
@@ -110,7 +114,8 @@ jobs:
           pip install .  --no-cache-dir
       - name: Test with pytest
         run: |
-          pytest brainevent/ -p no:faulthandler
+          # Run the FULL suite, including `slow` (compilation-heavy numba) variants.
+          pytest brainevent/ -m "" -p no:faulthandler
 
 
   type_check:

--- a/brainevent/_csr/binary_test.py
+++ b/brainevent/_csr/binary_test.py
@@ -24,6 +24,11 @@ import pytest
 from brainevent._csr.binary import binary_csrmv, binary_csrmv_p, binary_csrmm, binary_csrmm_p
 from brainevent._csr.test_util import get_csr, vector_csr, matrix_csr, csr_vector, csr_matrix
 
+# Every test loops over all native backends (incl. ``numba``), which compile per test and
+# dominate wall-clock. Mark the whole module ``slow`` so the default ``pytest`` run skips it;
+# CI runs it via ``pytest -m ""``.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 CSRMV_IMPLEMENTATIONS = tuple(binary_csrmv_p.available_backends(platform))
 CSRMM_IMPLEMENTATIONS = tuple(binary_csrmm_p.available_backends(platform))

--- a/brainevent/_csr/main_test.py
+++ b/brainevent/_csr/main_test.py
@@ -27,6 +27,12 @@ import pytest
 import brainevent
 from brainevent._csr.test_util import get_csr, vector_csr, matrix_csr, csr_vector, csr_matrix
 
+# Every test in this module dispatches to the native ``numba`` backend (the default backend),
+# which compiles per test and dominates wall-clock. Mark the whole module ``slow`` so the
+# default ``pytest`` run skips it; CI runs it via ``pytest -m ""``. Kernel correctness on the
+# cheap ``jax_raw`` backend is still covered by ``float_test.py`` in the default run.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 BINARY_CSRMV_IMPLEMENTATIONS = tuple(brainevent.binary_csrmv_p.available_backends(platform))
 FLOAT_CSRMV_IMPLEMENTATIONS = tuple(brainevent.csrmv_p.available_backends(platform))
@@ -164,9 +170,14 @@ class Test_CSR_FloatVectorOperator:
 
         jax.block_until_ready((xs, indptr, indices, data, y, y_ref))
 
-    @pytest.mark.parametrize('homo_w', [True, False])
-    @pytest.mark.parametrize('replace', [True, False])
-    @pytest.mark.parametrize('transpose', [True, False])
+    # Covering set: every value of homo_w/replace/transpose appears at least once (4 rows
+    # instead of the full 2x2x2 = 8 product).
+    @pytest.mark.parametrize('homo_w,replace,transpose', [
+        (True, True, True),
+        (False, False, False),
+        (True, False, True),
+        (False, True, False),
+    ])
     def test_vjp(self, homo_w, replace, transpose):
         n_in = 20
         n_out = 30
@@ -195,9 +206,12 @@ class Test_CSR_FloatVectorOperator:
 
         jax.block_until_ready((x, indptr, indices, w, r, r_ref))
 
-    @pytest.mark.parametrize('homo_w', [True, False])
-    @pytest.mark.parametrize('replace', [True, False])
-    @pytest.mark.parametrize('transpose', [True, False])
+    @pytest.mark.parametrize('homo_w,replace,transpose', [
+        (True, True, True),
+        (False, False, False),
+        (True, False, True),
+        (False, True, False),
+    ])
     def test_jvp(self, homo_w, replace, transpose):
         n_in = 20
         n_out = 30

--- a/brainevent/_fcn/main_test.py
+++ b/brainevent/_fcn/main_test.py
@@ -48,6 +48,11 @@ from brainevent._test_util import (
     ones_like,
 )
 
+# Every test in this module dispatches to the native ``numba`` backend, which compiles per
+# test and dominates wall-clock. Mark the whole module ``slow`` so the default ``pytest`` run
+# skips it; CI runs it via ``pytest -m ""``.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 
 if platform == 'cpu':

--- a/brainevent/_jit_normal/main_test.py
+++ b/brainevent/_jit_normal/main_test.py
@@ -27,6 +27,11 @@ if jax.default_backend() == 'gpu' and jax.config.jax_default_matmul_precision is
 import brainevent
 from brainevent._test_util import allclose, gen_events
 
+# Every test in this module dispatches to the native ``numba`` backend (the only backend for
+# JIT-connectivity kernels), which compiles per test and dominates wall-clock. Mark the whole
+# module ``slow`` so the default ``pytest`` run skips it; CI runs it via ``pytest -m ""``.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 
 if platform == 'cpu':
@@ -300,10 +305,14 @@ class Test_JITC_To_Dense:
         assert allclose(out1, out4)
         jax.block_until_ready((out1, out2, out3, out4))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wloc', [-1., 0.])
-    @pytest.mark.parametrize('wscale', [1., 2.])
+    # Covering set: every value of shape/corder/wloc/wscale appears at least once (4 rows
+    # instead of the full 2x2x2x2 = 16 product; gradient correctness is value-independent).
+    @pytest.mark.parametrize('shape,corder,wloc,wscale', [
+        (shapes[0], True, -1., 1.),
+        (shapes[1], False, 0., 2.),
+        (shapes[0], False, -1., 2.),
+        (shapes[1], True, 0., 1.),
+    ])
     def test_vjp(self, shape, corder, wloc, wscale):
         base = brainevent.JITCNormalR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 
@@ -338,10 +347,12 @@ class Test_JITC_To_Dense:
              expected_wloc_grad, expected_wscale_grad, jitc_wloc_grad, jitc_wscale_grad)
         )
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wloc', [-1., 0.])
-    @pytest.mark.parametrize('wscale', [1., 2.])
+    @pytest.mark.parametrize('shape,corder,wloc,wscale', [
+        (shapes[0], True, -1., 1.),
+        (shapes[1], False, 0., 2.),
+        (shapes[0], False, -1., 2.),
+        (shapes[1], True, 0., 1.),
+    ])
     def test_jvp(self, shape, corder, wloc, wscale):
         base = brainevent.JITCNormalR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
         tagents = (brainstate.random.random(), brainstate.random.random())
@@ -359,11 +370,13 @@ class Test_JITC_To_Dense:
         assert allclose(true_grad, jitc_grad, atol=1e-3, rtol=1e-3)
         jax.block_until_ready((base, tagents[0], tagents[1], primals, true_grad, jitc_grad))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wloc', [-1., 0.])
-    @pytest.mark.parametrize('wscale', [1., 2.])
-    @pytest.mark.parametrize('dwloc', [1., 2.])
+    # Covering set over the 2x2x2x2x2 = 32 product (every value appears at least once).
+    @pytest.mark.parametrize('shape,corder,wloc,wscale,dwloc', [
+        (shapes[0], True, -1., 1., 1.),
+        (shapes[1], False, 0., 2., 2.),
+        (shapes[0], False, -1., 2., 2.),
+        (shapes[1], True, 0., 1., 1.),
+    ])
     def test_jvp_wloc(self, shape, corder, wloc, wscale, dwloc):
         base = brainevent.JITCNormalR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 
@@ -383,11 +396,12 @@ class Test_JITC_To_Dense:
         assert allclose(true_grad, jitc_grad)
         jax.block_until_ready((base, primals, true_grad, expected_grad, jitc_grad))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wloc', [-1., 0.])
-    @pytest.mark.parametrize('wscale', [1., 2.])
-    @pytest.mark.parametrize('dw_high', [1., 2.])
+    @pytest.mark.parametrize('shape,corder,wloc,wscale,dw_high', [
+        (shapes[0], True, -1., 1., 1.),
+        (shapes[1], False, 0., 2., 2.),
+        (shapes[0], False, -1., 2., 2.),
+        (shapes[1], True, 0., 1., 1.),
+    ])
     def test_jvp_wscale(self, shape, corder, wloc, wscale, dw_high):
         base = brainevent.JITCNormalR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 

--- a/brainevent/_jit_scalar/main_test.py
+++ b/brainevent/_jit_scalar/main_test.py
@@ -22,6 +22,11 @@ import pytest
 import brainevent
 from brainevent._test_util import allclose, gen_events
 
+# Every test in this module dispatches to the native ``numba`` backend (the only backend for
+# JIT-connectivity kernels), which compiles per test and dominates wall-clock. Mark the whole
+# module ``slow`` so the default ``pytest`` run skips it; CI runs it via ``pytest -m ""``.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 
 if platform == 'cpu':
@@ -295,9 +300,14 @@ class Test_JITC_To_Dense:
         assert allclose(out1, out4)
         jax.block_until_ready((out1, out2, out3, out4))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('weight', [-1., 1.])
+    # Covering set: every value of shape/corder/weight appears at least once (4 rows instead
+    # of the full 2x2x2 = 8 product; gradient correctness is value-independent).
+    @pytest.mark.parametrize('shape,corder,weight', [
+        (shapes[0], True, -1.),
+        (shapes[1], False, 1.),
+        (shapes[0], False, 1.),
+        (shapes[1], True, -1.),
+    ])
     def test_vjp(self, shape, corder, weight):
         base = brainevent.JITCScalarR((1.0, 0.1, 123), shape=shape, corder=corder).todense()
 
@@ -322,9 +332,12 @@ class Test_JITC_To_Dense:
         assert allclose(true_weight_grad, jitc_weight_grad)
         jax.block_until_ready((base, ct, primals, true_weight_grad, expected_weight_grad, jitc_weight_grad))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('weight', [-1., 1.])
+    @pytest.mark.parametrize('shape,corder,weight', [
+        (shapes[0], True, -1.),
+        (shapes[1], False, 1.),
+        (shapes[0], False, 1.),
+        (shapes[1], True, -1.),
+    ])
     def test_jvp(self, shape, corder, weight):
         base = brainevent.JITCScalarR((1., 0.1, 123), shape=shape, corder=corder).todense()
         tagents = (brainstate.random.random(),)

--- a/brainevent/_jit_uniform/main_test.py
+++ b/brainevent/_jit_uniform/main_test.py
@@ -28,6 +28,11 @@ import brainevent
 from brainevent._test_util import allclose, gen_events
 from brainevent._typing import MatrixShape
 
+# Every test in this module dispatches to the native ``numba`` backend (the only backend for
+# JIT-connectivity kernels), which compiles per test and dominates wall-clock. Mark the whole
+# module ``slow`` so the default ``pytest`` run skips it; CI runs it via ``pytest -m ""``.
+pytestmark = pytest.mark.slow
+
 platform = jax.default_backend()
 
 if platform == 'cpu':
@@ -303,10 +308,14 @@ class Test_JITC_To_Dense:
         assert allclose(out1, out4)
         jax.block_until_ready((out1, out2, out3, out4))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wlow', [-1., 0.])
-    @pytest.mark.parametrize('whigh', [1., 2.])
+    # Covering set: every value of shape/corder/wlow/whigh appears at least once (4 rows
+    # instead of the full 2x2x2x2 = 16 product; gradient correctness is value-independent).
+    @pytest.mark.parametrize('shape,corder,wlow,whigh', [
+        (shapes[0], True, -1., 1.),
+        (shapes[1], False, 0., 2.),
+        (shapes[0], False, -1., 2.),
+        (shapes[1], True, 0., 1.),
+    ])
     def test_vjp(self, shape, corder, wlow, whigh):
         base = brainevent.JITCUniformR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 
@@ -342,10 +351,12 @@ class Test_JITC_To_Dense:
              jitc_wlow_grad, jitc_whigh_grad)
         )
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wlow', [-1., 0.])
-    @pytest.mark.parametrize('whigh', [1., 2.])
+    @pytest.mark.parametrize('shape,corder,wlow,whigh', [
+        (shapes[0], True, -1., 1.),
+        (shapes[1], False, 0., 2.),
+        (shapes[0], False, -1., 2.),
+        (shapes[1], True, 0., 1.),
+    ])
     def test_jvp(self, shape, corder, wlow, whigh):
         base = brainevent.JITCUniformR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
         tagents = (brainstate.random.random(), brainstate.random.random())
@@ -363,11 +374,13 @@ class Test_JITC_To_Dense:
         assert allclose(true_grad, jitc_grad)
         jax.block_until_ready((base, tagents[0], tagents[1], primals1, true_grad, primals2, jitc_grad))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wlow', [-1., 0.])
-    @pytest.mark.parametrize('whigh', [1., 2.])
-    @pytest.mark.parametrize('dwlow', [1., 2.])
+    # Covering set over the 2x2x2x2x2 = 32 product (every value appears at least once).
+    @pytest.mark.parametrize('shape,corder,wlow,whigh,dwlow', [
+        (shapes[0], True, -1., 1., 1.),
+        (shapes[1], False, 0., 2., 2.),
+        (shapes[0], False, -1., 2., 2.),
+        (shapes[1], True, 0., 1., 1.),
+    ])
     def test_jvp_wlow(self, shape, corder, wlow, whigh, dwlow):
         base = brainevent.JITCUniformR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 
@@ -387,11 +400,12 @@ class Test_JITC_To_Dense:
         assert allclose(true_grad, jitc_grad)
         jax.block_until_ready((base, primals1, true_grad, expected_grad, primals2, jitc_grad))
 
-    @pytest.mark.parametrize('shape', shapes)
-    @pytest.mark.parametrize('corder', [True, False])
-    @pytest.mark.parametrize('wlow', [-1., 0.])
-    @pytest.mark.parametrize('whigh', [1., 2.])
-    @pytest.mark.parametrize('dw_high', [1., 2.])
+    @pytest.mark.parametrize('shape,corder,wlow,whigh,dw_high', [
+        (shapes[0], True, -1., 1., 1.),
+        (shapes[1], False, 0., 2., 2.),
+        (shapes[0], False, -1., 2., 2.),
+        (shapes[1], True, 0., 1., 1.),
+    ])
     def test_jvp_whigh(self, shape, corder, wlow, whigh, dw_high):
         base = brainevent.JITCUniformR((0.0, 1.0, 0.1, 123), shape=shape, corder=corder).todense()
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,59 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Pytest configuration shared by the whole test suite.
+
+The bulk of the suite parametrizes on a compute backend (the ``implementation`` or
+``backend`` test parameter).  The native backends — ``numba`` and friends — compile their
+kernels on first use, costing seconds per test and *not* caching across tests, so they
+dominate the wall-clock of a full run.
+
+To keep the default ``pytest`` invocation fast, this hook automatically tags every test
+variant that exercises a compilation-heavy backend with the ``slow`` marker.  Combined with
+``addopts = "-m 'not slow'"`` in ``pyproject.toml`` the default run skips those variants and
+exercises only the cheap backends (e.g. ``jax_raw``) plus backend-agnostic tests.
+
+Run the full suite (CI does this) with ``pytest -m ""``; run only the heavy variants with
+``pytest -m slow``.
+"""
+
+import pytest
+
+#: Backends whose kernels are JIT/AOT compiled on first use. The compile cost is paid per
+#: test (it is not cached across the session), so these variants are the slow ones.
+COMPILATION_HEAVY_BACKENDS = frozenset({'numba', 'numba_cuda', 'pallas', 'warp', 'taichi'})
+
+#: Test-parameter names that carry a backend identifier across the suite.
+_BACKEND_PARAM_NAMES = ('implementation', 'backend')
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark parametrized variants that run a compilation-heavy backend as ``slow``.
+
+    Parameters
+    ----------
+    config : pytest.Config
+        The active pytest configuration (unused, required by the hook signature).
+    items : list of pytest.Item
+        Collected test items, mutated in place to attach the ``slow`` marker.
+    """
+    slow = pytest.mark.slow
+    for item in items:
+        callspec = getattr(item, 'callspec', None)
+        if callspec is None:
+            continue
+        params = callspec.params
+        if any(params.get(name) in COMPILATION_HEAVY_BACKENDS for name in _BACKEND_PARAM_NAMES):
+            item.add_marker(slow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,21 @@ tpu = ['jax[tpu]>=0.7.2']
 testing = ['pytest']
 
 
+[tool.pytest.ini_options]
+# Local runs skip the `slow` marker by default. `slow` covers compilation-heavy backend
+# variants (numba / native kernels) that recompile per test and dominate wall-clock. The
+# marker is applied automatically by the root conftest.py based on the backend parameter.
+#
+# Run the FULL suite (including slow variants) with:   pytest -m ""
+# Run ONLY the slow variants with:                     pytest -m slow
+# CI runs the full suite (see .github/workflows/CI.yml).
+testpaths = ["brainevent"]
+addopts = "-m 'not slow'"
+markers = [
+    "slow: compilation-heavy backend variants (numba/native); deselected by default, run in CI via `pytest -m ''`",
+]
+
+
 [tool.mypy]
 # Configuration for the mypy CI ratchet (see .github/workflows/CI.yml `type_check`).
 #


### PR DESCRIPTION
## Why

`pytest` was very slow (~25 min). Nearly every backend-parametrized test exercised the
compilation-heavy `numba` backend — its kernels recompile per test and are **not** cached
across the session (measured: ~1–3.6 s per numba test, vs milliseconds for `jax_raw`) — and
several gradient tests used large parametrization cross-products (up to 32 combos each).

## What

- **Auto slow/fast split (no test edits):** a root `conftest.py` marks every collected
  variant whose backend parameter (`implementation`/`backend`) is compilation-heavy
  (`numba`/native) as `slow`.
- **pytest config** (`pyproject.toml`): registers the `slow` marker, sets `testpaths`, and
  defaults to `addopts = -m 'not slow'` so local runs skip the heavy variants.
- **Module-level `slow`** on the numba-by-default integration modules (`_csr/main`,
  `_csr/binary`, `_fcn/main`, `_jit_{normal,uniform,scalar}/main`). Their kernel correctness
  is still covered on the cheap `jax_raw` backend by the `float_test` modules in the default run.
- **Trimmed cross-products:** the heaviest gradient tests (16–32 combos) collapse to 4-row
  covering sets that still exercise **every parameter value at least once** (moderate trim).
- **CI runs the full suite** (`pytest -m ""`) in `CI.yml` and `CI-daily.yml`, so the
  numba/native backends keep full coverage.

## Results (CPU)

| Run | Before | After |
| --- | --- | --- |
| Default `pytest brainevent/` | ~25 min, 2615 tests | **3:52, 824 run (1490 slow deselected)** |
| Full `pytest brainevent/ -m ""` (CI) | ~25–30 min | **2314 passed, 129 skipped, 0 failed** |

## How to run

- Fast local loop (default): `pytest brainevent/`
- Full suite (what CI runs): `pytest brainevent/ -m ""`
- Only the heavy variants: `pytest brainevent/ -m slow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split compilation-heavy backend test variants into a separate slow group and adjust pytest/CI configuration to run them selectively while keeping default local test runs fast.

Build:
- Configure pytest in pyproject.toml with testpaths, a default exclusion of slow tests, and registration of the slow marker.

CI:
- Update CI and daily workflows to run the full pytest suite, including slow-marked tests, via an explicit marker selection.

Tests:
- Mark numba/native-backed test modules and parametrized backend variants as slow, reducing default test runtime without losing coverage.
- Collapse large gradient test parameter cross-products into smaller covering sets that still exercise all parameter values at least once.

Chores:
- Add a root conftest.py that automatically tags compilation-heavy backend configurations as slow during test collection.