### PR TITLE
fix(types): restore mypy ratchet (baseline _fcn/main.py union-attr)

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -67,6 +67,8 @@ brainevent/pararnn/_fused.py:0: note: Use https://github.com/hauntsaninja/no_imp
 brainevent/_jit_normal/main.py:0: error: Item "Number" of "Any | Number" has no attribute "T"  [union-attr]
 brainevent/_jit_normal/main.py:0: error: Item "Number" of "Any | Number" has no attribute "T"  [union-attr]
 brainevent/_fcn/main.py:0: error: Missing return statement  [return]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "reshape"  [union-attr]
+brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Number" has no attribute "size"  [union-attr]
 brainevent/_fcn/main.py:0: error: Incompatible types in assignment (expression has type "CscLayout", variable has type "None")  [assignment]
 brainevent/_fcn/main.py:0: error: Incompatible return value type (got "None", expected "CscLayout")  [return-value]
 brainevent/_fcn/main.py:0: error: Item "Number" of "Any | Any | Any | Number" has no attribute "shape"  [union-attr]


### PR DESCRIPTION
## Problem

CI `type_check` (the mypy-baseline ratchet) has been red since #127. #127 added the CSC weight-permutation path in `FixedNumConn._binary_matvec` (`brainevent/_fcn/main.py:169`):

```python
data = self.data
weights = data.reshape(1) if data.size == 1 else data.reshape(-1)[perm]
```

`Data = Union[jax.Array, np.ndarray, u.Quantity, numbers.Number]`. Under the ratchet's `ignore_missing_imports`, the array members collapse to `Any` but `numbers.Number` stays typed and has no `.reshape` / `.size`, producing two new `union-attr` errors not present in the baseline.

These are false positives — `__init__` always coerces `data` via `u.math.asarray` — and they match the `Any | Number` union-attr entries already baselined for this file (`.shape`, `.dtype`, etc.).

## Fix

Add the two entries to `mypy-baseline.txt`. Verified locally with the pinned tooling (mypy==2.1.0, mypy-baseline==0.7.4): `mypy-baseline filter --allow-unsynced` now exits 0.

## Summary by Sourcery

Bug Fixes:
- Adjust mypy-baseline entries to account for new union-attribute type warnings so CI type checking passes again.