### PR TITLE
refactor(csr): rename plasticity_binary -> plasticity_binary_csr

### DIFF
--- a/brainevent/_csr/__init__.py
+++ b/brainevent/_csr/__init__.py
@@ -18,7 +18,7 @@ from .binary import binary_csrmv, binary_csrmv_p, binary_csrmm, binary_csrmm_p
 from .binary_indexed import binary_csrmv_indexed, binary_csrmv_indexed_p
 from .float import csrmv, csrmv_p, csrmm, csrmm_p
 from .main import CSR, CSC
-from .plasticity_binary import (
+from .plasticity_binary_csr import (
     update_csr_on_binary_pre, update_csr_on_binary_pre_p,
     update_csr_on_binary_post, update_csr_on_binary_post_p,
 )

--- a/brainevent/_csr/main.py
+++ b/brainevent/_csr/main.py
@@ -30,7 +30,7 @@ from .binary import binary_csrmv, binary_csrmm
 from .binary_indexed import binary_csrmv_indexed
 from .diag_add import csr_diag_position, csr_diag_add
 from .float import csrmv, csrmm
-from .plasticity_binary import update_csr_on_binary_pre, update_csr_on_binary_post
+from .plasticity_binary_csr import update_csr_on_binary_pre, update_csr_on_binary_post
 from .slice import csr_slice_rows
 from .spsolve import csr_solve
 from .yw2y import csrmv_yw2y

--- a/brainevent/_csr/plasticity_binary_csc.py
+++ b/brainevent/_csr/plasticity_binary_csc.py
@@ -42,7 +42,7 @@ import numpy as np
 
 from brainevent._misc import csc_to_csr_index
 from brainevent._typing import MatrixShape
-from .plasticity_binary import update_csr_on_binary_pre, update_csr_on_binary_post
+from .plasticity_binary_csr import update_csr_on_binary_pre, update_csr_on_binary_post
 
 __all__ = [
     'update_csc_on_binary_pre',

--- a/brainevent/_csr/plasticity_binary_csr.py
+++ b/brainevent/_csr/plasticity_binary_csr.py
@@ -142,7 +142,7 @@ def update_csr_on_binary_pre(
     .. code-block:: python
 
         >>> import jax.numpy as jnp
-        >>> from brainevent._csr.plasticity_binary import update_csr_on_binary_pre
+        >>> from brainevent._csr.plasticity_binary_csr import update_csr_on_binary_pre
         >>> weight = jnp.array([0.5, 0.3, 0.8, 0.2], dtype=jnp.float32)
         >>> indices = jnp.array([0, 1, 0, 2], dtype=jnp.int32)
         >>> indptr = jnp.array([0, 2, 4], dtype=jnp.int32)
@@ -408,7 +408,7 @@ def csr_on_pre_prim_call(weight, indices, indptr, pre_spike, post_trace, *, shap
     .. code-block:: python
 
         >>> import jax.numpy as jnp
-        >>> from brainevent._csr.plasticity_binary import csr_on_pre_prim_call
+        >>> from brainevent._csr.plasticity_binary_csr import csr_on_pre_prim_call
         >>> weight = jnp.array([0.5, 0.3, 0.8, 0.2], dtype=jnp.float32)
         >>> indices = jnp.array([0, 1, 0, 2], dtype=jnp.int32)
         >>> indptr = jnp.array([0, 2, 4], dtype=jnp.int32)
@@ -592,7 +592,7 @@ def update_csr_on_binary_post(
     .. code-block:: python
 
         >>> import jax.numpy as jnp
-        >>> from brainevent._csr.plasticity_binary import update_csr_on_binary_post
+        >>> from brainevent._csr.plasticity_binary_csr import update_csr_on_binary_post
         >>> weight = jnp.array([0.5, 0.3, 0.8, 0.2], dtype=jnp.float32)
         >>> indices = jnp.array([0, 1, 0, 1], dtype=jnp.int32)
         >>> indptr = jnp.array([0, 2, 4], dtype=jnp.int32)
@@ -875,7 +875,7 @@ def csr2csc_on_post_prim_call(weight, indices, indptr, weight_indices, pre_trace
     .. code-block:: python
 
         >>> import jax.numpy as jnp
-        >>> from brainevent._csr.plasticity_binary import csr2csc_on_post_prim_call
+        >>> from brainevent._csr.plasticity_binary_csr import csr2csc_on_post_prim_call
         >>> weight = jnp.array([0.5, 0.3, 0.8, 0.2], dtype=jnp.float32)
         >>> indices = jnp.array([0, 1, 0, 1], dtype=jnp.int32)
         >>> indptr = jnp.array([0, 2, 4], dtype=jnp.int32)

--- a/brainevent/_csr/plasticity_binary_csr_test.py
+++ b/brainevent/_csr/plasticity_binary_csr_test.py
@@ -23,7 +23,7 @@ import pytest
 import scipy.sparse as sp
 
 import brainevent
-from brainevent._csr.plasticity_binary import (
+from brainevent._csr.plasticity_binary_csr import (
     update_csr_on_binary_pre,
     update_csr_on_binary_post,
     update_csr_on_binary_pre_p,


### PR DESCRIPTION
Renames the CSR binary-plasticity module to disambiguate it from the dense counterpart (`_dense/plasticity_binary.py`) and to align with the `_csc` naming (`plasticity_binary_csc.py`).

- `_csr/plasticity_binary.py` → `_csr/plasticity_binary_csr.py` (via `git mv`, history preserved)
- `_csr/plasticity_binary_test.py` → `_csr/plasticity_binary_csr_test.py`
- Update intra-package imports: `_csr/__init__.py`, `_csr/main.py`, `_csr/plasticity_binary_csc.py`, and the in-module docstring examples.

Pure rename + import update; no behavioral change. Verified: `import brainevent` works, and `plasticity_binary_csr_test.py` (108 passed) and `plasticity_binary_csc_test.py` (5 passed) are green.

## Summary by Sourcery

Rename the CSR binary plasticity module and its tests to a CSR-specific name and update all internal references accordingly.

Enhancements:
- Disambiguate the CSR binary plasticity module by renaming it to a CSR-specific name aligned with existing CSC naming.
- Update intra-package imports and docstring examples to reference the renamed CSR binary plasticity module.