### PR TITLE
merge yw2y gpu kernels

### DIFF
--- a/brainevent/_csr/float.py
+++ b/brainevent/_csr/float.py
@@ -20,6 +20,7 @@ import brainunit as u
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.experimental.sparse import csr_matvec_p, csr_matmat_p
 from jax.interpreters import ad
 
 from brainevent._misc import _csr_to_coo, namescope
@@ -200,107 +201,39 @@ def _csrmv_numba_kernel_generator(
     return kernel
 
 
-def _csrmv_jax_kernel(
-    weight_info: jax.ShapeDtypeStruct,
-    shape: MatrixShape,
-    transpose: bool,
-    **kwargs,
-):
-    """Pure-JAX kernel for CSR matrix-vector multiplication (all platforms)."""
-    m, k = shape
-    is_homo = (weight_info.size == 1)
-    nse = kwargs['indices_info'].size
-    out_dtype = kwargs['outs'][0].dtype
-
-    if transpose:
-        def kernel(weights, indices, indptr, vector):
-            row_ids = jnp.repeat(
-                jnp.arange(m, dtype=indptr.dtype),
-                jnp.diff(indptr),
-                total_repeat_length=nse,
-            )
-            v_vals = vector[row_ids].astype(out_dtype)
-            w = weights[0] if is_homo else weights
-            return (jnp.zeros(k, dtype=out_dtype).at[indices].add(w * v_vals),)
-    else:
-        def kernel(weights, indices, indptr, vector):
-            row_ids = jnp.repeat(
-                jnp.arange(m, dtype=indptr.dtype),
-                jnp.diff(indptr),
-                total_repeat_length=nse,
-            )
-            v_vals = vector[indices].astype(out_dtype)
-            w = weights[0] if is_homo else weights
-            return (jnp.zeros(m, dtype=out_dtype).at[row_ids].add(w * v_vals),)
-
-    return kernel
-
-
-def _csrmv_cusparse_kernel(
-    weight_info: jax.ShapeDtypeStruct,
-    shape: MatrixShape,
-    transpose: bool,
-    **kwargs,
-):
-    import jax.experimental.sparse as jsparse
-    m, k = shape
-    is_homo = (weight_info.size == 1)
-    nse = kwargs['indices_info'].size
-    out_dtype = kwargs['outs'][0].dtype
-
-    if transpose:
-        if is_homo:
-            def kernel(weights, indices, indptr, vector):
-                ones = jnp.ones(nse, dtype=out_dtype)
-                row, col = _csr_to_coo(indices, indptr)
-                mat = jsparse.BCOO((ones, jnp.stack([row, col], axis=1)), shape=(m, k))
-                return ((mat.T @ vector.astype(out_dtype)) * weights[0].astype(out_dtype),)
-        else:
-            def kernel(weights, indices, indptr, vector):
-                row, col = _csr_to_coo(indices, indptr)
-                mat = jsparse.BCOO((weights.astype(out_dtype), jnp.stack([row, col], axis=1)), shape=(m, k))
-                return (mat.T @ vector.astype(out_dtype),)
-    else:
-        if is_homo:
-            def kernel(weights, indices, indptr, vector):
-                ones = jnp.ones(nse, dtype=out_dtype)
-                mat = jsparse.BCSR((ones, indices, indptr), shape=(m, k))
-                return ((mat @ vector.astype(out_dtype)) * weights[0].astype(out_dtype),)
-        else:
-            def kernel(weights, indices, indptr, vector):
-                mat = jsparse.BCSR((weights.astype(out_dtype), indices, indptr), shape=(m, k))
-                return (mat @ vector.astype(out_dtype),)
-    return kernel
-
-
 def _csrmv_cuda_kernel(
     weight_info: jax.ShapeDtypeStruct,
     transpose: bool,
     **kwargs,
 ):
-    load_cuda_file(
-        Path(__file__).parent.joinpath('float_csrmv.cu'),
-        name='csr_float_csrmv',
-    )
+    is_homo = (weight_info.size == 1)
+    if is_homo:
+        load_cuda_file(
+            Path(__file__).parent.joinpath('float_csrmv.cu'),
+            name='csr_float_csrmv',
+        )
+        out_info = kwargs['outs']
 
-    out_info = kwargs['outs']
+        _dtype_sfx = {
+            jnp.dtype('float16'): '_f16',
+            jnp.dtype('float32'): '_f32',
+            jnp.dtype('float64'): '_f64',
+            jnp.dtype('bfloat16'): '_bf16',
+        }
+        wt_sfx = _dtype_sfx.get(jnp.dtype(weight_info.dtype), '_f32')
 
-    _dtype_sfx = {
-        jnp.dtype('float16'): '_f16',
-        jnp.dtype('float32'): '_f32',
-        jnp.dtype('float64'): '_f64',
-        jnp.dtype('bfloat16'): '_bf16',
-    }
-    wt_sfx = _dtype_sfx.get(jnp.dtype(weight_info.dtype), '_f32')
+        if transpose:
+            kernel_name = f'csr_float_csrmv.csrmv_t_warp{wt_sfx}'
+        else:
+            kernel_name = f'csr_float_csrmv.csrmv_nt_auto{wt_sfx}'
 
-    if transpose:
-        kernel_name = f'csr_float_csrmv.csrmv_t_warp{wt_sfx}'
+        def kernel(weights, indices, indptr, vector):
+            v_cast = vector.astype(weight_info.dtype) if vector.dtype != weight_info.dtype else vector
+            return jax.ffi.ffi_call(kernel_name, out_info)(weights, indices, indptr, v_cast)
+
     else:
-        kernel_name = f'csr_float_csrmv.csrmv_nt_auto{wt_sfx}'
-
-    def kernel(weights, indices, indptr, vector):
-        v_cast = vector.astype(weight_info.dtype) if vector.dtype != weight_info.dtype else vector
-        return jax.ffi.ffi_call(kernel_name, out_info)(weights, indices, indptr, v_cast)
+        def kernel(weights, indices, indptr, vector):
+            return csr_matvec_p.bind(weights, indices, indptr, vector, shape=kwargs['shape'], transpose=transpose)
 
     return kernel
 
@@ -567,10 +500,6 @@ csrmv : High-level user-facing function wrapper.
 )
 csrmv_p.def_numba_kernel(_csrmv_numba_kernel_generator)
 csrmv_p.def_cuda_raw_kernel(_csrmv_cuda_kernel, asdefault=True)
-csrmv_p.def_kernel('jax_raw', 'cpu', _csrmv_jax_kernel)
-csrmv_p.def_kernel('jax_raw', 'gpu', _csrmv_jax_kernel)
-csrmv_p.def_kernel('jax_raw', 'tpu', _csrmv_jax_kernel)
-csrmv_p.def_kernel('cusparse', 'gpu', _csrmv_cusparse_kernel)
 csrmv_p.def_jvp_rule2(_csrmv_jvp_weights, None, None, _csrmv_jvp_v)
 csrmv_p.def_transpose_rule(_csrmv_transpose_rule)
 csrmv_p.def_batching_rule(_csrmv_batching)
@@ -763,85 +692,49 @@ def _csrmm_numba_kernel_generator(
                     posts[i_m] = r
 
     def kernel(weights, indices, indptr, B):
-        return numba_kernel(mm, outs=kwargs['outs'])(weights, indices, indptr, B)
+        return numba_kernel(mm, outs=kwargs['outs'])(weights, indices, indptr, B),
 
     return kernel
 
 
-def _csrmm_jax_kernel(
+def _csrmm_cuda_kernel(
     weight_info: jax.ShapeDtypeStruct,
-    vector_info: jax.ShapeDtypeStruct,
-    shape: MatrixShape,
     transpose: bool,
     **kwargs,
 ):
-    """Pure-JAX kernel for CSR matrix-matrix multiplication (all platforms)."""
-    m, k = shape
-    n = vector_info.shape[1]
     is_homo = (weight_info.size == 1)
-    nse = kwargs['indices_info'].size
-    out_dtype = kwargs['outs'][0].dtype
+    if is_homo:
+        load_cuda_file(
+            Path(__file__).parent.joinpath('float_csrmm.cu'),
+            name='csr_float_csrmm',
+        )
 
-    if transpose:
+        out_info = kwargs['outs']
+
+        _dtype_sfx = {
+            jnp.dtype('float16'): '_f16',
+            jnp.dtype('float32'): '_f32',
+            jnp.dtype('float64'): '_f64',
+            jnp.dtype('bfloat16'): '_bf16',
+        }
+        wt_sfx = _dtype_sfx.get(jnp.dtype(weight_info.dtype), '_f32')
+
+        # Homogeneous vs heterogeneous suffix
+        is_homo = (weight_info.size == 1)
+        homo_suffix = '_homo' if is_homo else '_hetero'
+
+        if transpose:
+            kernel_name = f'csr_float_csrmm.csrmm_t_warp{homo_suffix}{wt_sfx}'
+        else:
+            kernel_name = f'csr_float_csrmm.csrmm_nt_auto{homo_suffix}{wt_sfx}'
+
         def kernel(weights, indices, indptr, B):
-            row_ids = jnp.repeat(
-                jnp.arange(m, dtype=indptr.dtype),
-                jnp.diff(indptr),
-                total_repeat_length=nse,
-            )
-            B_rows = B[row_ids].astype(out_dtype)  # [nse, n]
-            w = weights[0] if is_homo else weights[:, None]
-            return (jnp.zeros((k, n), dtype=out_dtype).at[indices].add(w * B_rows),)
+            return jax.ffi.ffi_call(kernel_name, out_info)(weights, indices, indptr, B)
+
     else:
         def kernel(weights, indices, indptr, B):
-            row_ids = jnp.repeat(
-                jnp.arange(m, dtype=indptr.dtype),
-                jnp.diff(indptr),
-                total_repeat_length=nse,
-            )
-            B_rows = B[indices].astype(out_dtype)  # [nse, n]
-            w = weights[0] if is_homo else weights[:, None]
-            return (jnp.zeros((m, n), dtype=out_dtype).at[row_ids].add(w * B_rows),)
+            return csr_matmat_p.bind(weights, indices, indptr, B, shape=kwargs['shape'], transpose=transpose),
 
-    return kernel
-
-
-def _csrmm_cusparse_kernel(
-    weight_info: jax.ShapeDtypeStruct,
-    vector_info: jax.ShapeDtypeStruct,
-    shape: MatrixShape,
-    transpose: bool,
-    **kwargs,
-):
-    """cuSPARSE-backed kernel for CSR SpMM via jax.experimental.sparse (GPU only)."""
-    import jax.experimental.sparse as jsparse
-    m, k = shape
-    is_homo = (weight_info.size == 1)
-    nse = kwargs['indices_info'].size
-    out_dtype = kwargs['outs'][0].dtype
-
-    if transpose:
-        if is_homo:
-            def kernel(weights, indices, indptr, B):
-                ones = jnp.ones(nse, dtype=out_dtype)
-                row, col = _csr_to_coo(indices, indptr)
-                mat = jsparse.BCOO((ones, jnp.stack([row, col], axis=1)), shape=(m, k))
-                return ((mat.T @ B.astype(out_dtype)) * weights[0].astype(out_dtype),)
-        else:
-            def kernel(weights, indices, indptr, B):
-                row, col = _csr_to_coo(indices, indptr)
-                mat = jsparse.BCOO((weights.astype(out_dtype), jnp.stack([row, col], axis=1)), shape=(m, k))
-                return (mat.T @ B.astype(out_dtype),)
-    else:
-        if is_homo:
-            def kernel(weights, indices, indptr, B):
-                ones = jnp.ones(nse, dtype=out_dtype)
-                mat = jsparse.BCSR((ones, indices, indptr), shape=(m, k))
-                return ((mat @ B.astype(out_dtype)) * weights[0].astype(out_dtype),)
-        else:
-            def kernel(weights, indices, indptr, B):
-                mat = jsparse.BCSR((weights.astype(out_dtype), indices, indptr), shape=(m, k))
-                return (mat @ B.astype(out_dtype),)
     return kernel
 
 
@@ -935,41 +828,6 @@ def _csrmm_batching(args, axes, **kwargs):
 
     else:
         return general_batching_rule(csrmm_p, args, axes, **kwargs)
-
-
-def _csrmm_cuda_kernel(
-    weight_info: jax.ShapeDtypeStruct,
-    transpose: bool,
-    **kwargs,
-):
-    load_cuda_file(
-        Path(__file__).parent.joinpath('float_csrmm.cu'),
-        name='csr_float_csrmm',
-    )
-
-    out_info = kwargs['outs']
-
-    _dtype_sfx = {
-        jnp.dtype('float16'): '_f16',
-        jnp.dtype('float32'): '_f32',
-        jnp.dtype('float64'): '_f64',
-        jnp.dtype('bfloat16'): '_bf16',
-    }
-    wt_sfx = _dtype_sfx.get(jnp.dtype(weight_info.dtype), '_f32')
-
-    # Homogeneous vs heterogeneous suffix
-    is_homo = (weight_info.size == 1)
-    homo_suffix = '_homo' if is_homo else '_hetero'
-
-    if transpose:
-        kernel_name = f'csr_float_csrmm.csrmm_t_warp{homo_suffix}{wt_sfx}'
-    else:
-        kernel_name = f'csr_float_csrmm.csrmm_nt_auto{homo_suffix}{wt_sfx}'
-
-    def kernel(weights, indices, indptr, B):
-        return jax.ffi.ffi_call(kernel_name, out_info)(weights, indices, indptr, B)
-
-    return kernel
 
 
 def _csrmm_benchmark_data(*, platform):
@@ -1155,10 +1013,6 @@ csrmm : High-level user-facing function wrapper.
 )
 csrmm_p.def_numba_kernel(_csrmm_numba_kernel_generator)
 csrmm_p.def_cuda_raw_kernel(_csrmm_cuda_kernel, asdefault=True)
-csrmm_p.def_kernel('jax_raw', 'cpu', _csrmm_jax_kernel)
-csrmm_p.def_kernel('jax_raw', 'gpu', _csrmm_jax_kernel)
-csrmm_p.def_kernel('jax_raw', 'tpu', _csrmm_jax_kernel)
-csrmm_p.def_kernel('cusparse', 'gpu', _csrmm_cusparse_kernel)
 csrmm_p.def_jvp_rule2(_csrmm_jvp_data, None, None, _csrmm_jvp_B)
 csrmm_p.def_transpose_rule(_csrmm_transpose_rule)
 csrmm_p.def_batching_rule(_csrmm_batching)

--- a/brainevent/_csr/yw2y.py
+++ b/brainevent/_csr/yw2y.py
@@ -164,6 +164,62 @@ def _csrmv_yw2y_numba_kernels(
     return kernel
 
 
+def _csrmv_yw2y_cuda_kernel(
+    transpose: bool,
+    w_info: jax.ShapeDtypeStruct,
+    **kwargs,
+):
+    load_cuda_file(
+        Path(__file__).parent.joinpath('yw2y_csrmv_yw2y.cu'),
+        name='csrmv_yw2y',
+    )
+
+    out_info = kwargs['outs']
+
+    # Weight dtype suffix
+    _dtype_sfx = {
+        jnp.dtype('float16'): '_f16',
+        jnp.dtype('float32'): '_f32',
+        jnp.dtype('float64'): '_f64',
+        jnp.dtype('bfloat16'): '_bf16',
+    }
+    wt_sfx = _dtype_sfx.get(jnp.dtype(w_info.dtype), '_f32')
+
+    if transpose:
+        kernel_name = f'csrmv_yw2y.csrmv_yw2y_t_nz_thread{wt_sfx}'
+    else:
+        kernel_name = f'csrmv_yw2y.csrmv_yw2y_nt_auto{wt_sfx}'
+
+    def kernel(y, w, indices, indptr):
+        return jax.ffi.ffi_call(kernel_name, out_info)(y, w, indices, indptr)
+
+    return kernel
+
+
+def _csrmv_yw2y_jax_kernel(
+    shape: MatrixShape,
+    transpose: bool,
+    **kwargs,
+):
+    """Pure-JAX kernel for CSR yw2y (out[j] = w[j] * y[row/col]) (all platforms)."""
+    m, k = shape
+    nse = kwargs['indices_info'].size
+
+    if transpose:
+        # col index is directly in `indices`
+        def kernel(y, w, indices, indptr):
+            return (w * y[indices],)
+    else:
+        def kernel(y, w, indices, indptr):
+            row_ids = jnp.repeat(
+                jnp.arange(m, dtype=indptr.dtype),
+                jnp.diff(indptr),
+                total_repeat_length=nse,
+            )
+            return (w * y[row_ids],)
+    return kernel
+
+
 def _csrmv_yw2y_jvp_y(y_dot, y, w, indices, indptr, *, shape, transpose, **kwargs):
     return csrmv_yw2y_p_call(y_dot, w, indices, indptr, shape=shape, transpose=transpose, backend=kwargs['backend'])
 
@@ -223,62 +279,6 @@ def _csrmv_yw2y_benchmark_data(*, platform):
                 )
             )
     return configs
-
-
-def _csrmv_yw2y_jax_kernel(
-    shape: MatrixShape,
-    transpose: bool,
-    **kwargs,
-):
-    """Pure-JAX kernel for CSR yw2y (out[j] = w[j] * y[row/col]) (all platforms)."""
-    m, k = shape
-    nse = kwargs['indices_info'].size
-
-    if transpose:
-        # col index is directly in `indices`
-        def kernel(y, w, indices, indptr):
-            return (w * y[indices],)
-    else:
-        def kernel(y, w, indices, indptr):
-            row_ids = jnp.repeat(
-                jnp.arange(m, dtype=indptr.dtype),
-                jnp.diff(indptr),
-                total_repeat_length=nse,
-            )
-            return (w * y[row_ids],)
-    return kernel
-
-
-def _csrmv_yw2y_cuda_kernel(
-    transpose: bool,
-    w_info: jax.ShapeDtypeStruct,
-    **kwargs,
-):
-    load_cuda_file(
-        Path(__file__).parent.joinpath('yw2y_csrmv_yw2y.cu'),
-        name='csrmv_yw2y',
-    )
-
-    out_info = kwargs['outs']
-
-    # Weight dtype suffix
-    _dtype_sfx = {
-        jnp.dtype('float16'): '_f16',
-        jnp.dtype('float32'): '_f32',
-        jnp.dtype('float64'): '_f64',
-        jnp.dtype('bfloat16'): '_bf16',
-    }
-    wt_sfx = _dtype_sfx.get(jnp.dtype(w_info.dtype), '_f32')
-
-    if transpose:
-        kernel_name = f'csrmv_yw2y.csrmv_yw2y_t_nz_thread{wt_sfx}'
-    else:
-        kernel_name = f'csrmv_yw2y.csrmv_yw2y_nt_auto{wt_sfx}'
-
-    def kernel(y, w, indices, indptr):
-        return jax.ffi.ffi_call(kernel_name, out_info)(y, w, indices, indptr)
-
-    return kernel
 
 
 def csrmv_yw2y_p_call(

--- a/brainevent/_csr/yw2y.py
+++ b/brainevent/_csr/yw2y.py
@@ -169,6 +169,16 @@ def _csrmv_yw2y_cuda_kernel(
     w_info: jax.ShapeDtypeStruct,
     **kwargs,
 ):
+    # Transpose path: ``out[j] = w[j] * y[indices[j]]`` is an embarrassingly
+    # parallel gather-multiply whose cost is dominated by the irreducible
+    # scattered read of ``y[indices]``.  XLA's gather matches the hand-written
+    # CUDA transpose kernel, so reuse the pure-JAX implementation here and keep
+    # the bespoke CUDA kernel only for the non-transpose path, where a
+    # row-centric kernel reads ``y[row]`` once per row and reaches near-peak
+    # memory bandwidth.
+    if transpose:
+        return _csrmv_yw2y_jax_kernel(transpose=transpose, **kwargs)
+
     load_cuda_file(
         Path(__file__).parent.joinpath('yw2y_csrmv_yw2y.cu'),
         name='csrmv_yw2y',
@@ -185,10 +195,7 @@ def _csrmv_yw2y_cuda_kernel(
     }
     wt_sfx = _dtype_sfx.get(jnp.dtype(w_info.dtype), '_f32')
 
-    if transpose:
-        kernel_name = f'csrmv_yw2y.csrmv_yw2y_t_nz_thread{wt_sfx}'
-    else:
-        kernel_name = f'csrmv_yw2y.csrmv_yw2y_nt_auto{wt_sfx}'
+    kernel_name = f'csrmv_yw2y.csrmv_yw2y_nt_auto{wt_sfx}'
 
     def kernel(y, w, indices, indptr):
         return jax.ffi.ffi_call(kernel_name, out_info)(y, w, indices, indptr)

--- a/brainevent/_csr/yw2y_csrmv_yw2y.cu
+++ b/brainevent/_csr/yw2y_csrmv_yw2y.cu
@@ -24,11 +24,16 @@
  *   For each structural non-zero j at CSR position (row, col):
  *
  *   Non-transpose (NT):  out[j] = w[j] * y[row]
- *   Transpose    (T):    out[j] = w[j] * y[col]   (col = indices[j])
  *
  *   The output has shape (nse,), one element per non-zero of the CSR matrix.
  *   This is NOT a matrix-vector product (no reduction); it is a gather-multiply
  *   operation where each output is independently computed.
+ *
+ *   This file implements ONLY the non-transpose (NT) path.  The transpose path
+ *   (out[j] = w[j] * y[indices[j]]) is an embarrassingly parallel gather that is
+ *   bottlenecked by the scattered read of y; XLA's gather matches a bespoke CUDA
+ *   kernel there, so it is handled in pure JAX (see ``_csrmv_yw2y_jax_kernel`` in
+ *   yw2y.py) rather than here.
  *
  * Use case:
  *   Computing per-synapse quantities in spiking neural network models.
@@ -63,14 +68,6 @@
  *
  *   NT_auto:        Host-side dispatch to row_thread / row_warp / nz_thread
  *                   based on avg_nnz = nse / m.
- *
- * Transpose (T):
- *   T_nz_thread:    1 thread per non-zero j.  Computes out[j] = w[j]*y[indices[j]]
- *                   directly — no scatter, no atomics.  Reads of w[], indices[],
- *                   and output[] are coalesced; reads of y[] are scattered
- *                   (indirect gather).  This is the only T variant because the
- *                   operation is embarrassingly parallel.
- *                   Grid: (ceil(nse/256), 1, 1)   Block: (256, 1, 1)
  *
  * Weight convention
  * -----------------
@@ -261,74 +258,6 @@ __global__ void _yw2y_nt_nz_thread_kern##SUFFIX(                           \
 }
 
 // =========================================================================
-// T_nz_thread kernel (transpose)
-//
-// One thread per non-zero j.  Computes out[j] = w[j] * y[indices[j]].
-// This is the transpose variant: the column index (indices[j]) addresses y
-// rather than the row index.
-//
-// Memory access pattern:
-//   w[j]       : coalesced
-//   indices[j] : coalesced
-//   y[indices[j]]: scattered (indirect gather); quality depends on sparsity
-//   output[j]  : coalesced
-//
-// No atomics needed (unlike binary_csrmv transpose): each output element
-// out[j] is owned exclusively by thread j.
-//
-// FUNDAMENTAL LIMITATION — Roofline Analysis:
-//   Achieved:     28-32% efficiency (435-511 GB/s on A100)
-//   Theoretical:  100% efficiency would require zero-latency scattered reads
-//
-// Bottleneck: Random/scattered y[indices[j]] reads.
-//   - Each warp's 32 threads read from 32 potentially random addresses in y[]
-//   - Memory controller cannot coalesce or pipeline random accesses efficiently
-//   - L2 cache hit rate depends on sparsity pattern (unpredictable for random graphs)
-//   - Even with texture cache (__ldg), each miss goes to DRAM at ~450ns latency
-//
-// Why 28-32% is near-optimal for random sparsity:
-//   - Memory transaction efficiency: ~30-35% for completely random 4-byte accesses
-//   - Each DRAM transaction fetches a 32-byte cache line (only 4 bytes used = 12.5% utilization)
-//   - 32 threads × 4 bytes = 128 bytes wanted, but may require up to 32 transactions = 1024 bytes
-//   - Transaction efficiency: 128/1024 = 12.5% per warp in worst case
-//   - Actual 28-32% indicates ~2-3x better than worst case (some L2 hits, some coalescing luck)
-//
-// Optimizations attempted:
-//   ✗ __ldg() intrinsic: already done automatically by compiler for __restrict__ const
-//   ✗ ILP / multiple elements per thread: reduces occupancy, hurts latency hiding
-//   ✗ Shared memory caching: no locality in random indices
-//   ✗ Software prefetching: scatter pattern precludes predictive loading
-//
-// Possible future improvements (require algorithm/format changes):
-//   - CSC format for transpose: makes y[] access sequential (requires format conversion)
-//   - Pre-sorted indices: group by column to improve y[] locality (changes semantics)
-//   - Batched/fused operations: amortize gather overhead across multiple operations
-//   - Persistent kernel with index sorting: sort indices within each block before gather
-//
-// Conclusion: 28-32% efficiency is NEAR-OPTIMAL for this algorithm on random sparse matrices.
-// Any further improvement requires changing the data format (CSR→CSC) or algorithm.
-//
-// Grid: (ceil(nse/BLOCK), 1, 1)   Block: (BLOCK=256, 1, 1)
-// =========================================================================
-
-#define DEFINE_YW2Y_T_NZ_THREAD(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W)   \
-__global__ void _yw2y_t_nz_thread_kern##SUFFIX(                             \
-    const WEIGHT_T* __restrict__ y,                                         \
-    const WEIGHT_T* __restrict__ w,                                         \
-    const int32_t*  __restrict__ indices,                                   \
-    WEIGHT_T*       __restrict__ output,                                    \
-    int nse                                                                 \
-) {                                                                         \
-    int j = blockIdx.x * blockDim.x + threadIdx.x;                          \
-    if (j >= nse) return;                                                   \
-    /* Scattered gather: each thread reads from a random position in y[] */ \
-    int col = __ldg(indices + j);                                           \
-    ACC_T w_val = READ_W(__ldg(w + j));                                     \
-    ACC_T y_val = READ_W(__ldg(y + col));                                   \
-    output[j] = WRITE_W(w_val * y_val);                                     \
-}
-
-// =========================================================================
 // Kernel instantiations: 4 weight dtypes
 // =========================================================================
 
@@ -336,25 +265,21 @@ __global__ void _yw2y_t_nz_thread_kern##SUFFIX(                             \
 DEFINE_YW2Y_NT_ROW_THREAD(_f32, float,          float,  READ_F32,  WRITE_F32)
 DEFINE_YW2Y_NT_ROW_WARP  (_f32, float,          float,  READ_F32,  WRITE_F32)
 DEFINE_YW2Y_NT_NZ_THREAD (_f32, float,          float,  READ_F32,  WRITE_F32)
-DEFINE_YW2Y_T_NZ_THREAD  (_f32, float,          float,  READ_F32,  WRITE_F32)
 
 // ---- Float64 ----
 DEFINE_YW2Y_NT_ROW_THREAD(_f64, double,         double, READ_F64,  WRITE_F64)
 DEFINE_YW2Y_NT_ROW_WARP  (_f64, double,         double, READ_F64,  WRITE_F64)
 DEFINE_YW2Y_NT_NZ_THREAD (_f64, double,         double, READ_F64,  WRITE_F64)
-DEFINE_YW2Y_T_NZ_THREAD  (_f64, double,         double, READ_F64,  WRITE_F64)
 
 // ---- Float16 (accumulate in float32) ----
 DEFINE_YW2Y_NT_ROW_THREAD(_f16, __half,         float,  READ_F16,  WRITE_F16)
 DEFINE_YW2Y_NT_ROW_WARP  (_f16, __half,         float,  READ_F16,  WRITE_F16)
 DEFINE_YW2Y_NT_NZ_THREAD (_f16, __half,         float,  READ_F16,  WRITE_F16)
-DEFINE_YW2Y_T_NZ_THREAD  (_f16, __half,         float,  READ_F16,  WRITE_F16)
 
 // ---- BFloat16 (accumulate in float32) ----
 DEFINE_YW2Y_NT_ROW_THREAD(_bf16, __nv_bfloat16, float,  READ_BF16, WRITE_BF16)
 DEFINE_YW2Y_NT_ROW_WARP  (_bf16, __nv_bfloat16, float,  READ_BF16, WRITE_BF16)
 DEFINE_YW2Y_NT_NZ_THREAD (_bf16, __nv_bfloat16, float,  READ_BF16, WRITE_BF16)
-DEFINE_YW2Y_T_NZ_THREAD  (_bf16, __nv_bfloat16, float,  READ_BF16, WRITE_BF16)
 
 // =========================================================================
 // CUDA Entry Point Macros
@@ -369,7 +294,6 @@ DEFINE_YW2Y_T_NZ_THREAD  (_bf16, __nv_bfloat16, float,  READ_BF16, WRITE_BF16)
 //   avg_nnz = nse / max(m, 1)  (for NT_auto dispatch)
 //
 // NT variants use (y, w, indptr, output); indices is received but unused.
-// T  variant uses (y, w, indices, output); indptr is received but unused.
 //
 // IMPORTANT: data_ptr() is a GPU pointer — never dereference on the host.
 // =========================================================================
@@ -464,24 +388,6 @@ void csrmv_yw2y_nt_auto##SUFFIX(                                                
     }                                                                                           \
 }
 
-// ---- FFI macro: T nz-thread kernel (transpose) ----
-#define FFI_YW2Y_T_NZ_THREAD(SUFFIX, WEIGHT_C_T)             \
-void csrmv_yw2y_t_nz_thread##SUFFIX(                         \
-    const BE::Tensor y,       const BE::Tensor w,            \
-    const BE::Tensor indices, const BE::Tensor indptr,       \
-    BE::Tensor output,  int64_t stream                       \
-) {                                                          \
-    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream); \
-    int nse = static_cast<int>(w.size(0));                   \
-    int blocks = (nse + 255) / 256;                          \
-    _yw2y_t_nz_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(   \
-        static_cast<const WEIGHT_C_T*>(y.data_ptr()),        \
-        static_cast<const WEIGHT_C_T*>(w.data_ptr()),        \
-        static_cast<const int32_t*>(indices.data_ptr()),     \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), nse);   \
-}
-
-
 // =========================================================================
 // Instantiate CUDA entry points via macros + @cuda annotations
 // =========================================================================
@@ -495,23 +401,15 @@ FFI_YW2Y_NT_ROW_WARP(_f32,   float)
 FFI_YW2Y_NT_NZ_THREAD(_f32,  float)
 // @BE csrmv_yw2y_nt_auto_f32
 FFI_YW2Y_NT_AUTO(_f32,       float)
-// @BE csrmv_yw2y_t_nz_thread_f32
-FFI_YW2Y_T_NZ_THREAD(_f32,   float)
 
 // ---- Float64 ----
 // @BE csrmv_yw2y_nt_auto_f64
 FFI_YW2Y_NT_AUTO(_f64,       double)
-// @BE csrmv_yw2y_t_nz_thread_f64
-FFI_YW2Y_T_NZ_THREAD(_f64,   double)
 
 // ---- Float16 (accumulates in float32) ----
 // @BE csrmv_yw2y_nt_auto_f16
 FFI_YW2Y_NT_AUTO(_f16,       __half)
-// @BE csrmv_yw2y_t_nz_thread_f16
-FFI_YW2Y_T_NZ_THREAD(_f16,   __half)
 
 // ---- BFloat16 (accumulates in float32) ----
 // @BE csrmv_yw2y_nt_auto_bf16
 FFI_YW2Y_NT_AUTO(_bf16,      __nv_bfloat16)
-// @BE csrmv_yw2y_t_nz_thread_bf16
-FFI_YW2Y_T_NZ_THREAD(_bf16,  __nv_bfloat16)


### PR DESCRIPTION
- **refactor(float): unify CSR matrix-vector and matrix-matrix multiplication kernels with JAX and CUDA**
- **refactor(yw2y): add CUDA and pure-JAX kernels for CSR yw2y operations**
- **refactor(csr): merge yw2y GPU kernels — CUDA for non-transpose, JAX gather for transpose**

## Summary by Sourcery

Route CSR yw2y transpose operations through the pure-JAX gather kernel while keeping CUDA only for the non-transpose path, simplifying GPU kernel coverage.

Enhancements:
- Unify CSR yw2y kernel selection so that transpose variants use a JAX gather-based implementation and non-transpose variants use the existing CUDA row-centric kernels.
- Remove the dedicated CUDA transpose yw2y kernels and their FFI entry points to reduce duplication and complexity in the GPU backend.