### PR TITLE
feat(fcn): add fcnmv_yw2y per-synapse operator and yw_to_w methods

### DIFF
--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -72,7 +72,7 @@ from ._fcn import (
     csc_binary_matvec, csc_binary_matvec_p,
     csc_binary_matmat, csc_binary_matmat_p,
     binary_fcnmm, ell_binary_matmat_p,
-    fcnmv, fcnmm,
+    fcnmv, fcnmm, fcnmv_yw2y,
 )
 from ._jit_normal import (
     JITCNormalR, JITCNormalC,
@@ -195,6 +195,7 @@ __all__ = [
     'binary_fcnmm', 'ell_binary_matmat_p',
     'fcnmv',
     'fcnmm',
+    'fcnmv_yw2y',
 
     # --- operator customization routines --- #
     'XLACustomKernel', 'KernelEntry',

--- a/brainevent/_fcn/__init__.py
+++ b/brainevent/_fcn/__init__.py
@@ -23,7 +23,7 @@ from .binary import (
     binary_fcnmm,
     ell_binary_matmat_p,
 )
-from .float import fcnmv, fcnmm
+from .float import fcnmv, fcnmm, fcnmv_yw2y
 from .main import FixedNumConn, FixedPreNumConn, FixedPostNumConn
 
 __all__ = [
@@ -32,5 +32,5 @@ __all__ = [
     'csc_binary_matvec', 'csc_binary_matvec_p',
     'csc_binary_matmat', 'csc_binary_matmat_p',
     'binary_fcnmm', 'ell_binary_matmat_p',
-    'fcnmv', 'fcnmm',
+    'fcnmv', 'fcnmm', 'fcnmv_yw2y',
 ]

--- a/brainevent/_fcn/float.py
+++ b/brainevent/_fcn/float.py
@@ -26,6 +26,7 @@ from brainevent._misc import check_fixed_conn_num_shape, namescope
 __all__ = [
     'fcnmv',
     'fcnmm',
+    'fcnmv_yw2y',
 ]
 
 
@@ -249,3 +250,110 @@ def fcnmm(
         else:
             r = jax.vmap(lambda w, ind: jnp.sum(w[:, None] * matrix[ind], axis=0))(weights, indices)
     return u.maybe_decimal(r * m_unit * w_unit)
+
+
+@namescope(static_argnames=['shape', 'transpose'])
+def fcnmv_yw2y(
+    weights: Union[jax.Array, u.Quantity],
+    indices: jax.Array,
+    y: Union[jax.Array, u.Quantity],
+    *,
+    shape: Tuple[int, int],
+    transpose: bool,
+) -> Union[jax.Array, u.Quantity]:
+    """
+    Per-synapse element-wise product of a vector and fixed-connection weights.
+
+    For each stored connection slot ``(i, k)`` of the fixed-connection-number
+    (ELL) structure, computes ``out[i, k] = weights[i, k] * y[i]`` when
+    ``transpose=False`` or ``out[i, k] = weights[i, k] * y[indices[i, k]]`` when
+    ``transpose=True``.  The result has the same shape as ``indices`` (one value
+    per structural non-zero).
+
+    This is the fixed-connection-number analog of :func:`brainevent.csrmv_yw2y`
+    and follows the **same** ``transpose`` convention as that operator: the flag
+    selects whether ``y`` is indexed by the leading (row) axis or by the stored
+    ``indices`` (column) axis.  Note this is the opposite sense of the
+    ``transpose`` flag in :func:`fcnmv` / :func:`fcnmm`.
+
+    Parameters
+    ----------
+    weights : jax.Array or brainunit.Quantity
+        Per-synapse weights.  Either a scalar / size-1 array (homogeneous) or a
+        ``(rows, n_conn)`` array matching ``indices``.  Must be floating dtype.
+    indices : jax.Array
+        Integer ELL index array of shape ``(rows, n_conn)``.
+    y : jax.Array or brainunit.Quantity
+        Dense 1-D vector.  Sized ``shape[0]`` when ``transpose=False`` or
+        ``shape[1]`` when ``transpose=True``.
+    shape : tuple of int
+        Two-element ``(rows_dim, cols_dim)`` logical shape of the ELL operand.
+    transpose : bool
+        If ``False``, index ``y`` by the leading axis (broadcast).  If ``True``,
+        index ``y`` by ``indices`` (gather).
+
+    Returns
+    -------
+    out : jax.Array or brainunit.Quantity
+        Per-synapse result of shape ``indices.shape``.  Output unit is
+        ``unit(weights) * unit(y)``.
+
+    Raises
+    ------
+    ValueError
+        If ``indices`` is not 2-D, ``shape`` is not length-2, ``weights`` is
+        neither size-1 nor shaped like ``indices``, ``weights`` is not floating,
+        or ``y`` is not 1-D with the length required by ``transpose``.
+
+    See Also
+    --------
+    csrmv_yw2y : CSR equivalent of this operator.
+    fcnmv : Fixed-connection sparse matrix--vector product.
+
+    Notes
+    -----
+    Unlike :func:`csrmv_yw2y` (which drops ``y``'s physical unit), this operator
+    keeps both units, consistent with the :func:`fcnmv` sibling and with the
+    mathematics of a product.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> from brainevent import fcnmv_yw2y
+        >>> weights = jnp.array([[0.5, 1.0], [1.5, 2.0]])
+        >>> indices = jnp.array([[0, 1], [1, 2]])
+        >>> y = jnp.array([10.0, 20.0])
+        >>> fcnmv_yw2y(weights, indices, y, shape=(2, 3), transpose=False)
+        Array([[ 5., 10.],
+               [30., 40.]], dtype=float32)
+    """
+    if indices.ndim != 2:
+        raise ValueError(f"indices must be 2D, got {indices.ndim}D.")
+    if len(shape) != 2:
+        raise ValueError(f"shape must be length-2, got {shape!r}.")
+
+    weights, w_unit = u.split_mantissa_unit(weights)
+    y, y_unit = u.split_mantissa_unit(y)
+
+    if not jnp.issubdtype(weights.dtype, jnp.floating):
+        raise ValueError(f"weights must be a floating-point type, got {weights.dtype}.")
+    if jnp.size(weights) != 1 and weights.shape != indices.shape:
+        raise ValueError(
+            f"weights must be size-1 or match indices shape {indices.shape}, "
+            f"got {weights.shape}."
+        )
+    if y.ndim != 1:
+        raise ValueError(f"y must be 1D, got {y.ndim}D.")
+    expected_y = shape[1] if transpose else shape[0]
+    if y.shape[0] != expected_y:
+        raise ValueError(
+            f"y length {y.shape[0]} does not match expected {expected_y} for "
+            f"transpose={transpose} and shape={tuple(shape)}."
+        )
+
+    yv = y[indices] if transpose else y[:, None]
+    res = jnp.broadcast_to(weights * yv, indices.shape)
+    return u.maybe_decimal(res * w_unit * y_unit)

--- a/brainevent/_fcn/float_test.py
+++ b/brainevent/_fcn/float_test.py
@@ -15,9 +15,12 @@
 
 # -*- coding: utf-8 -*-
 
+import jax
 import jax.numpy as jnp
 import pytest
 
+import brainunit as u
+from brainevent import fcnmv_yw2y  # top-level export (exercises N1)
 from brainevent._fcn.float import fcnmv, fcnmm
 from brainevent._test_util import (
     generate_fixed_conn_num_indices,
@@ -64,3 +67,98 @@ def test_fcnmm(homo_w, transpose):
         y = fcnmm(w, indices, x, shape=shape, transpose=False)
         y_ref = fcn_matrix(x, w, indices, shape)
     assert allclose(y, y_ref, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize('homo_w', [True, False])
+@pytest.mark.parametrize('transpose', [True, False])
+def test_fcnmv_yw2y(homo_w, transpose):
+    m, n = shape  # (20, 40)
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    if homo_w:
+        w = jnp.asarray(1.5, dtype=jnp.float32)
+    else:
+        w = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+    y = jnp.arange(1, (m if not transpose else n) + 1, dtype=jnp.float32)
+
+    out = fcnmv_yw2y(w, indices, y, shape=shape, transpose=transpose)
+
+    assert out.shape == indices.shape
+    w_full = jnp.broadcast_to(w, indices.shape)
+    yv = y[:, None] if not transpose else y[indices]
+    expected = w_full * yv
+    assert allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_fcnmv_yw2y_units():
+    m, n = shape
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    w_mant = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+    y_mant = jnp.arange(1, m + 1, dtype=jnp.float32)
+    w = w_mant * u.siemens
+    y = y_mant * u.mV
+
+    out = fcnmv_yw2y(w, indices, y, shape=shape, transpose=False)
+
+    expected = (w_mant * y_mant[:, None]) * (u.siemens * u.mV)
+    assert u.math.allclose(out, expected)
+
+
+@pytest.mark.parametrize('transpose', [True, False])
+def test_fcnmv_yw2y_grad(transpose):
+    m, n = shape
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    w = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+    y = jnp.arange(1, (m if not transpose else n) + 1, dtype=jnp.float32)
+
+    def loss(w_, y_):
+        return jnp.sum(fcnmv_yw2y(w_, indices, y_, shape=shape, transpose=transpose) ** 2)
+
+    def ref(w_, y_):
+        yv = y_[:, None] if not transpose else y_[indices]
+        return jnp.sum((w_ * yv) ** 2)
+
+    gw, gy = jax.grad(loss, argnums=(0, 1))(w, y)
+    rgw, rgy = jax.grad(ref, argnums=(0, 1))(w, y)
+    assert allclose(gw, rgw, rtol=1e-4, atol=1e-4)
+    assert allclose(gy, rgy, rtol=1e-4, atol=1e-4)
+
+
+def test_fcnmv_yw2y_jit():
+    m, n = shape
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    w = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+    y = jnp.arange(1, m + 1, dtype=jnp.float32)
+
+    fn = jax.jit(lambda w_, y_: fcnmv_yw2y(w_, indices, y_, shape=shape, transpose=False))
+    out = fn(w, y)
+    assert allclose(out, w * y[:, None], rtol=1e-5, atol=1e-5)
+
+
+def test_fcnmv_yw2y_vmap():
+    m, n = shape
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    w = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+    Y = jnp.arange(1, 3 * m + 1, dtype=jnp.float32).reshape(3, m)  # batch of 3
+
+    out = jax.vmap(lambda y_: fcnmv_yw2y(w, indices, y_, shape=shape, transpose=False))(Y)
+    assert out.shape == (3, *indices.shape)
+    expected = w[None] * Y[:, :, None]
+    assert allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_fcnmv_yw2y_validation():
+    m, n = shape
+    indices = generate_fixed_conn_num_indices(m, n, n_conn, replace=True)
+    w = jnp.ones(indices.shape, dtype=jnp.float32)
+
+    # wrong y length for transpose=False (expects shape[0]=m)
+    with pytest.raises(ValueError):
+        fcnmv_yw2y(w, indices, jnp.ones(m + 3, dtype=jnp.float32), shape=shape, transpose=False)
+    # weight shape mismatch (and not size-1)
+    with pytest.raises(ValueError):
+        fcnmv_yw2y(jnp.ones((m, n_conn + 1), dtype=jnp.float32), indices,
+                   jnp.ones(m, dtype=jnp.float32), shape=shape, transpose=False)
+    # non-floating weights
+    with pytest.raises(ValueError):
+        fcnmv_yw2y(jnp.ones(indices.shape, dtype=jnp.int32), indices,
+                   jnp.ones(m, dtype=jnp.float32), shape=shape, transpose=False)

--- a/brainevent/_fcn/main.py
+++ b/brainevent/_fcn/main.py
@@ -27,7 +27,7 @@ from brainevent._event.binary import BinaryArray
 from brainevent._misc import _coo_todense, COOInfo, fixed_conn_num_csc_structure
 from brainevent._typing import Data, MatrixShape, Index
 from .binary import binary_fcnmv, binary_fcnmm, csc_binary_matvec, csc_binary_matmat
-from .float import fcnmv, fcnmm
+from .float import fcnmv, fcnmm, fcnmv_yw2y
 
 __all__ = [
     'FixedNumConn',
@@ -199,6 +199,67 @@ class FixedNumConn(DataRepresentation):
     def _float_matmat(self, matrix, transpose_W: bool, data):
         a_shape, ell_transpose = self._ell_plan(transpose_W)
         return fcnmm(data, self.indices, matrix, shape=a_shape, transpose=ell_transpose)
+
+    # ------------------------------------------------------------------ #
+    # Per-synapse y * w product (yw2y), parity with CSR / CSC
+    # ------------------------------------------------------------------ #
+
+    def yw_to_w(self, y_dim_arr, w_dim_arr=None):
+        """Per-synapse ``w * y`` with ``y`` indexed by the row (pre) of ``W``.
+
+        For every stored connection, returns ``w * y[row]`` where ``row`` is the
+        pre-synaptic index of that connection, regardless of storage axis.  This
+        is the fixed-connection analog of :meth:`brainevent.CSR.yw_to_w` and
+        implements the ``yw_to_w`` protocol of :class:`brainunit.sparse.SparseMatrix`.
+
+        Parameters
+        ----------
+        y_dim_arr : jax.Array or brainunit.Quantity
+            Pre-synaptic (row) vector, sized ``shape[0]``.
+        w_dim_arr : jax.Array or brainunit.Quantity, optional
+            Per-synapse weights of shape ``indices.shape`` (or size-1).  Defaults
+            to ``self.data``.
+
+        Returns
+        -------
+        jax.Array or brainunit.Quantity
+            Per-synapse result of shape ``self.indices.shape``.
+
+        See Also
+        --------
+        yw_to_w_transposed : ``y`` indexed by the column (post) of ``W``.
+        """
+        w = self.data if w_dim_arr is None else w_dim_arr
+        a_shape = tuple(self.shape) if self.axis == 0 else tuple(self.shape)[::-1]
+        return fcnmv_yw2y(w, self.indices, y_dim_arr, shape=a_shape, transpose=(self.axis == 1))
+
+    def yw_to_w_transposed(self, y_dim_arr, w_dim_arr=None):
+        """Per-synapse ``w * y`` with ``y`` indexed by the column (post) of ``W``.
+
+        Adjoint counterpart of :meth:`yw_to_w`: for every stored connection,
+        returns ``w * y[col]`` where ``col`` is the post-synaptic index of that
+        connection, regardless of storage axis.
+
+        Parameters
+        ----------
+        y_dim_arr : jax.Array or brainunit.Quantity
+            Post-synaptic (column) vector, sized ``shape[1]``.
+        w_dim_arr : jax.Array or brainunit.Quantity, optional
+            Per-synapse weights of shape ``indices.shape`` (or size-1).  Defaults
+            to ``self.data``.
+
+        Returns
+        -------
+        jax.Array or brainunit.Quantity
+            Per-synapse result of shape ``self.indices.shape``.
+
+        See Also
+        --------
+        yw_to_w : ``y`` indexed by the row (pre) of ``W``.
+        """
+        w = self.data if w_dim_arr is None else w_dim_arr
+        a_shape = tuple(self.shape) if self.axis == 0 else tuple(self.shape)[::-1]
+        return fcnmv_yw2y(w, self.indices, y_dim_arr, shape=a_shape, transpose=(self.axis == 0))
 
     def _dispatch(self, other, transpose_W: bool):
         if isinstance(other, u.sparse.SparseMatrix):

--- a/brainevent/_fcn/main_test.py
+++ b/brainevent/_fcn/main_test.py
@@ -783,3 +783,61 @@ class TestMatrix:
             assert allclose(y1, y_true, rtol=1e-3, atol=1e-3)
             assert allclose(y2, y_true, rtol=1e-3, atol=1e-3)
         jax.block_until_ready((indices, xs, y1, y2, y_true))
+
+
+class Test_Yw2y:
+    def test_fixed_post(self):
+        m, n, k = 5, 7, 3
+        indices = generate_fixed_conn_num_indices(m, n, k, replace=True)
+        data = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+        conn = brainevent.FixedPostNumConn((data, indices), shape=(m, n))
+        y_pre = jnp.arange(1, m + 1, dtype=jnp.float32)
+        y_post = jnp.arange(1, n + 1, dtype=jnp.float32)
+
+        # yw_to_w: y indexed by row=pre -> broadcast
+        assert allclose(conn.yw_to_w(y_pre), data * y_pre[:, None])
+        # yw_to_w_transposed: y indexed by col=post -> gather
+        assert allclose(conn.yw_to_w_transposed(y_post), data * y_post[indices])
+
+    def test_fixed_pre(self):
+        num_pre, num_post, k = 7, 5, 3
+        # indices: (num_post, k) with values in [0, num_pre)
+        indices = generate_fixed_conn_num_indices(num_post, num_pre, k, replace=True)
+        data = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+        conn = brainevent.FixedPreNumConn((data, indices), shape=(num_pre, num_post))
+        y_pre = jnp.arange(1, num_pre + 1, dtype=jnp.float32)
+        y_post = jnp.arange(1, num_post + 1, dtype=jnp.float32)
+
+        # yw_to_w: y indexed by row=pre -> gather (indices are pre ids)
+        assert allclose(conn.yw_to_w(y_pre), data * y_pre[indices])
+        # yw_to_w_transposed: y indexed by col=post=leading -> broadcast
+        assert allclose(conn.yw_to_w_transposed(y_post), data * y_post[:, None])
+
+    def test_default_w_uses_self_data(self):
+        m, n, k = 5, 7, 3
+        indices = generate_fixed_conn_num_indices(m, n, k, replace=True)
+        data = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+        conn = brainevent.FixedPostNumConn((data, indices), shape=(m, n))
+        y_pre = jnp.arange(1, m + 1, dtype=jnp.float32)
+        y_post = jnp.arange(1, n + 1, dtype=jnp.float32)
+        assert allclose(conn.yw_to_w(y_pre), conn.yw_to_w(y_pre, data))
+        assert allclose(conn.yw_to_w_transposed(y_post),
+                        conn.yw_to_w_transposed(y_post, data))
+
+    def test_golden_parity_csr(self):
+        m, n, k = 5, 7, 3
+        indices = generate_fixed_conn_num_indices(m, n, k, replace=True)
+        data = jnp.arange(1, indices.size + 1, dtype=jnp.float32).reshape(indices.shape)
+        conn = brainevent.FixedPostNumConn((data, indices), shape=(m, n))
+
+        indptr = jnp.arange(m + 1, dtype=jnp.int32) * k
+        csr = brainevent.CSR(
+            (data.flatten(), indices.flatten().astype(jnp.int32), indptr), shape=(m, n)
+        )
+        y_pre = jnp.arange(1, m + 1, dtype=jnp.float32)
+        y_post = jnp.arange(1, n + 1, dtype=jnp.float32)
+
+        assert allclose(conn.yw_to_w(y_pre).flatten(),
+                        csr.yw_to_w(y_pre, data.flatten()))
+        assert allclose(conn.yw_to_w_transposed(y_post).flatten(),
+                        csr.yw_to_w_transposed(y_post, data.flatten()))


### PR DESCRIPTION
Add an FCN-native per-synapse product (out = w * y[row|col]) mirroring the
CSR csrmv_yw2y operator:

- fcnmv_yw2y in _fcn/float.py: pure-JAX, unit-aware, supports homogeneous and
  heterogeneous weights; same transpose convention as csrmv_yw2y. Exported from
  brainevent._fcn and the top-level package.
- FixedNumConn.yw_to_w / yw_to_w_transposed: per-synapse w*y indexed by the
  row (pre) / column (post) of W, axis-agnostic; w defaults to self.data.
  yw_to_w fulfils the SparseMatrix.yw_to_w protocol for both FCN orientations.
- Tests: standalone correctness, units, autodiff, jit, vmap, validation; class
  methods for both classes/directions, default-weight, and CSR golden parity.

## Summary by Sourcery

Introduce a fixed-connection-number per-synapse y·w operator and wire it into the FCN API and FixedNumConn helpers.

New Features:
- Add fcnmv_yw2y, a JAX-based per-synapse y·w operator for fixed-connection (ELL) structures with unit support and CSR csrmv_yw2y parity.
- Expose yw_to_w and yw_to_w_transposed methods on FixedNumConn variants to compute per-synapse products indexed by pre- or post-synaptic dimensions, defaulting weights to the connection data.

Enhancements:
- Export fcnmv_yw2y from the internal FCN module and top-level brainevent package for external use.

Tests:
- Add unit, autodiff, JIT, vmap, and validation tests for fcnmv_yw2y, and protocol/golden-parity tests for the new FixedNumConn yw_to_w helpers.