### PR TITLE
feat(fcn): add to_csr/to_csc/to_dense conversions to FixedNumConn

### DIFF
--- a/brainevent/_fcn/conversion_test.py
+++ b/brainevent/_fcn/conversion_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+"""Tests for the :class:`FixedNumConn` format conversions.
+
+These exercise :meth:`to_dense`, :meth:`to_csr`, and :meth:`to_csc`.  All
+correctness checks route through the dense round-trip, which uses the pure-JAX
+``jax.experimental.sparse`` primitives (``coo_todense`` / ``csr_todense``) and
+therefore needs no compilation-heavy backend -- so this module is *not* marked
+``slow`` and runs in the default ``pytest`` lane.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainunit as u
+
+from brainevent import CSC, CSR, FixedNumPerPost, FixedNumPerPre
+from brainevent._test_util import allclose, generate_fixed_conn_num_indices
+
+# Duplicate columns within a row exercise the accumulation semantics shared by
+# ``todense`` and the matmul kernels: row 0 has column ``2`` twice; row 1 has
+# columns ``3`` and ``1`` twice.
+DUP_INDICES = jnp.array([[0, 1, 2, 2], [1, 3, 3, 1], [2, 0, 3, 1]], dtype=jnp.int32)
+DUP_DATA = jnp.array([[1., 9., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]], dtype=jnp.float32)
+
+
+def _make(cls, homo, shape, n_conn, seed=0):
+    """Build a connection of ``cls`` with random structure and values."""
+    pre = shape[0] if cls is FixedNumPerPre else shape[1]
+    n_post = shape[1] if cls is FixedNumPerPre else shape[0]
+    # ``replace=True`` keeps the cheap ``randint`` path (no ``for_loop``); the
+    # duplicate connections it may produce are themselves useful coverage.
+    indices = generate_fixed_conn_num_indices(pre, n_post, n_conn, replace=True)
+    if homo:
+        data = jnp.asarray(1.5, dtype=jnp.float32)
+    else:
+        rng = np.random.default_rng(seed)
+        data = jnp.asarray(rng.standard_normal(indices.shape), dtype=jnp.float32)
+    return cls((data, indices), shape=shape)
+
+
+CLASSES = [FixedNumPerPre, FixedNumPerPost]
+SHAPES = [(6, 8), (10, 5)]
+
+
+class TestToDense:
+    @pytest.mark.parametrize('cls', CLASSES)
+    @pytest.mark.parametrize('shape', SHAPES)
+    @pytest.mark.parametrize('homo', [True, False])
+    def test_to_dense_matches_todense(self, cls, shape, homo):
+        conn = _make(cls, homo, shape, n_conn=3)
+        assert allclose(conn.to_dense(), conn.todense())
+        assert conn.to_dense().shape == shape
+
+
+class TestToCsr:
+    @pytest.mark.parametrize('cls', CLASSES)
+    @pytest.mark.parametrize('shape', SHAPES)
+    @pytest.mark.parametrize('homo', [True, False])
+    def test_roundtrip_matches_dense(self, cls, shape, homo):
+        conn = _make(cls, homo, shape, n_conn=4)
+        csr = conn.to_csr()
+        assert isinstance(csr, CSR)
+        assert csr.shape == shape
+        assert allclose(csr.todense(), conn.todense())
+
+    @pytest.mark.parametrize('cls', CLASSES)
+    def test_metadata(self, cls):
+        shape = (6, 8)
+        conn = _make(cls, homo=False, shape=shape, n_conn=3)
+        csr = conn.to_csr()
+        assert csr.nse == conn.indices.size
+        assert csr.dtype == conn.dtype
+        assert csr.indptr.shape == (shape[0] + 1,)
+
+    @pytest.mark.parametrize('cls', CLASSES)
+    def test_homogeneous_weight_is_kept_compact(self, cls):
+        conn = _make(cls, homo=True, shape=(6, 8), n_conn=3)
+        csr = conn.to_csr()
+        # A single shared value is preserved rather than materialised per entry.
+        assert csr.data.size == 1
+        assert allclose(csr.todense(), conn.todense())
+
+    @pytest.mark.parametrize('cls', CLASSES)
+    def test_num_conn_one(self, cls):
+        conn = _make(cls, homo=False, shape=(5, 7), n_conn=1)
+        assert allclose(conn.to_csr().todense(), conn.todense())
+
+    def test_duplicates_preserved_pre(self):
+        conn = FixedNumPerPre((DUP_DATA, DUP_INDICES), shape=(3, 4))
+        assert allclose(conn.to_csr().todense(), conn.todense())
+
+    def test_duplicates_preserved_post(self):
+        conn = FixedNumPerPost((DUP_DATA, DUP_INDICES), shape=(4, 3))
+        assert allclose(conn.to_csr().todense(), conn.todense())
+
+    def test_units_preserved(self):
+        conn = FixedNumPerPre((DUP_DATA * u.mS, DUP_INDICES), shape=(3, 4))
+        csr = conn.to_csr()
+        assert u.get_unit(csr.data) == u.mS
+        assert u.get_unit(csr.todense()) == u.mS
+        assert allclose(u.get_mantissa(csr.todense()), u.get_mantissa(conn.todense()))
+
+    def test_backend_propagated(self):
+        conn = FixedNumPerPre((DUP_DATA, DUP_INDICES), shape=(3, 4), backend='numba')
+        assert conn.to_csr().backend == 'numba'
+
+    def test_requires_outside_jit(self):
+        conn = FixedNumPerPre((DUP_DATA, DUP_INDICES), shape=(3, 4))
+        with pytest.raises(RuntimeError, match='outside'):
+            jax.jit(lambda m: m.to_csr())(conn)
+
+
+class TestToCsc:
+    @pytest.mark.parametrize('cls', CLASSES)
+    @pytest.mark.parametrize('shape', SHAPES)
+    @pytest.mark.parametrize('homo', [True, False])
+    def test_roundtrip_matches_dense(self, cls, shape, homo):
+        conn = _make(cls, homo, shape, n_conn=4)
+        csc = conn.to_csc()
+        assert isinstance(csc, CSC)
+        assert csc.shape == shape
+        assert allclose(csc.todense(), conn.todense())
+
+    def test_duplicates_preserved_pre(self):
+        conn = FixedNumPerPre((DUP_DATA, DUP_INDICES), shape=(3, 4))
+        assert allclose(conn.to_csc().todense(), conn.todense())
+
+    def test_duplicates_preserved_post(self):
+        conn = FixedNumPerPost((DUP_DATA, DUP_INDICES), shape=(4, 3))
+        assert allclose(conn.to_csc().todense(), conn.todense())
+
+    def test_units_preserved(self):
+        conn = FixedNumPerPost((DUP_DATA * u.mV, DUP_INDICES), shape=(4, 3))
+        csc = conn.to_csc()
+        assert u.get_unit(csc.data) == u.mV
+        assert u.get_unit(csc.todense()) == u.mV
+        assert allclose(u.get_mantissa(csc.todense()), u.get_mantissa(conn.todense()))
+
+
+class TestCrossFormatConsistency:
+    @pytest.mark.parametrize('cls', CLASSES)
+    @pytest.mark.parametrize('homo', [True, False])
+    def test_csr_csc_dense_agree(self, cls, homo):
+        conn = _make(cls, homo, (7, 9), n_conn=3)
+        dense = conn.todense()
+        assert allclose(conn.to_csr().todense(), dense)
+        assert allclose(conn.to_csc().todense(), dense)
+        # Transpose equivalence: CSR of W^T equals CSC of W, array-for-array.
+        assert allclose(conn.to_csr().todense().T, conn.transpose().to_csr().todense())
+        jax.block_until_ready((dense,))

--- a/brainevent/_fcn/main.py
+++ b/brainevent/_fcn/main.py
@@ -24,7 +24,7 @@ import jax
 from brainevent._compatible_import import Tracer
 from brainevent._data import DataRepresentation
 from brainevent._event.binary import BinaryArray
-from brainevent._misc import _coo_todense, COOInfo, fixed_conn_num_csc_structure
+from brainevent._misc import _coo_todense, COOInfo, coo2csr, fixed_conn_num_csc_structure
 from brainevent._typing import Data, MatrixShape, Index
 from .binary import binary_fcnmv, binary_fcnmm, csc_binary_matvec, csc_binary_matmat
 from .float import fcnmv, fcnmm
@@ -301,6 +301,120 @@ class FixedNumConn(DataRepresentation):
     def __rmatmul__(self, other):
         """Reflected matrix multiplication ``other @ self`` (logical ``W^T @ other``)."""
         return self._dispatch(other, transpose_W=True)
+
+    # ------------------------------------------------------------------ #
+    # Format conversions
+    # ------------------------------------------------------------------ #
+
+    def _to_coo(self):
+        """Return ``(pre_ids, post_ids, COOInfo)`` for the logical matrix ``W``.
+
+        Dispatches on :attr:`axis` so both orientations describe the *same*
+        logical matrix of shape ``(num_pre, num_post)``: ``pre_ids`` are row
+        (pre-synaptic) indices and ``post_ids`` are column (post-synaptic)
+        indices, each of length ``self.indices.size``.
+        """
+        if self.axis == 0:
+            return fixed_post_num_to_coo(self)
+        return fixed_pre_num_to_coo(self)
+
+    def to_dense(self):
+        """Convert to a dense ``(num_pre, num_post)`` matrix.
+
+        Alias of :meth:`todense` provided for naming parity with
+        :meth:`to_csr` and :meth:`to_csc`.
+
+        Returns
+        -------
+        jax.Array or brainunit.Quantity
+            Dense matrix of shape ``self.shape``.  Stored entries that share a
+            ``(row, column)`` coordinate (duplicate connections) are summed,
+            matching :meth:`todense` and the event-driven matmul kernels.
+
+        See Also
+        --------
+        todense : Underlying implementation.
+        to_csr : Convert to Compressed Sparse Row format.
+        to_csc : Convert to Compressed Sparse Column format.
+        """
+        return self.todense()
+
+    def to_csr(self):
+        """Convert to a :class:`brainevent.CSR` matrix of the logical matrix ``W``.
+
+        The result is a Compressed Sparse Row view of the same logical weight
+        matrix ``W`` of shape ``(num_pre, num_post)``, irrespective of the
+        storage orientation (:class:`FixedNumPerPre` or
+        :class:`FixedNumPerPost`).  Duplicate connections are preserved as
+        repeated entries within a row (CSR matmul / :meth:`CSR.todense` sum
+        them, matching :meth:`todense`).  Homogeneous (size-1) weights are kept
+        as a single shared value.
+
+        Returns
+        -------
+        CSR
+            Equivalent matrix in CSR format with the same ``shape``, ``dtype``,
+            unit, and ``backend`` as ``self``.
+
+        Notes
+        -----
+        Building the CSR layout reorders the stored connections by row, which
+        requires concrete indices.  Like the lazy CSC mirror, it must therefore
+        run outside ``jax.jit`` / ``brainstate.transform.jit``; construct the
+        connection and call this method before entering a jitted function.
+
+        See Also
+        --------
+        to_csc : Convert to Compressed Sparse Column format.
+        to_dense : Convert to a dense matrix.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            >>> import jax.numpy as jnp
+            >>> from brainevent import FixedNumPerPre
+            >>>
+            >>> data = jnp.array([[1., 2.], [3., 4.]])
+            >>> indices = jnp.array([[0, 1], [1, 2]])
+            >>> mat = FixedNumPerPre((data, indices), shape=(2, 3))
+            >>> csr = mat.to_csr()
+            >>> bool((csr.todense() == mat.todense()).all())
+            True
+        """
+        from brainevent._csr import CSR  # local import avoids an import cycle
+
+        _ensure_fixed_conn_initialized_outside_jit(self.indices, kind=type(self).__name__)
+        pre_ids, post_ids, _ = self._to_coo()
+        indptr, indices, order = coo2csr(pre_ids, post_ids, shape=self.shape)
+        if self.data.size == 1:
+            # Homogeneous weight: keep the single shared value.
+            data = self.data.reshape(1)
+        else:
+            data = self.data.reshape(-1)[order]
+        return CSR((data, indices, indptr), shape=self.shape, backend=self.backend)
+
+    def to_csc(self):
+        """Convert to a :class:`brainevent.CSC` matrix of the logical matrix ``W``.
+
+        The result is a Compressed Sparse Column view of the same logical
+        weight matrix ``W`` of shape ``(num_pre, num_post)``.  It is built by
+        transposing to the opposite orientation, taking the CSR view of ``W^T``,
+        and reinterpreting it as the (array-identical) CSC view of ``W`` -- so
+        the same outside-``jit`` requirement as :meth:`to_csr` applies.
+
+        Returns
+        -------
+        CSC
+            Equivalent matrix in CSC format with the same ``shape``, ``dtype``,
+            unit, and ``backend`` as ``self``.
+
+        See Also
+        --------
+        to_csr : Convert to Compressed Sparse Row format.
+        to_dense : Convert to a dense matrix.
+        """
+        return self.transpose().to_csr().transpose()
 
     # ------------------------------------------------------------------ #
     # Event-driven plasticity (STDP) updates


### PR DESCRIPTION
Add format-conversion methods to the FixedNumConn base class so both
FixedNumPerPre and FixedNumPerPost can be converted to other sparse
representations of the same logical weight matrix W:

- to_csr()  -> brainevent.CSR
- to_csc()  -> brainevent.CSC
- to_dense() (alias of todense, for naming parity)

Conversions go through a shared COO view (_to_coo) and reuse coo2csr, so
duplicate connections are preserved (CSR/CSC matmul and todense sum them)
and homogeneous size-1 weights stay compact. Like the lazy CSC mirror,
to_csr/to_csc reorder by row and must run outside jax.jit.

Add brainevent/_fcn/conversion_test.py covering both orientations,
homogeneous/heterogeneous weights, duplicate indices, units, backend
propagation, metadata, and the outside-jit guard.
