### PR TITLE
ci: run CI once per commit (pull_request only, not push)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,9 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches:
-      - '**'        # matches every branch
+  # Trigger on pull requests only. A PR-branch push already fires the
+  # `pull_request` (synchronize) event, so also listening on `push` would
+  # start a second, redundant run for the same commit — one event, one run.
   pull_request:
     branches:
       - '**'        # matches every branch


### PR DESCRIPTION
The CI workflow listened on **both** `push` (every branch) and `pull_request`
(every branch). A push to a PR branch fires the `pull_request` *synchronize*
event as well, so every commit started two identical runs — and because the
two events carry different `github.ref` values (`refs/heads/<branch>` vs
`refs/pull/<n>/merge`) they land in separate concurrency groups, so neither
cancels the other.

Drop the `push` trigger and keep `pull_request`, so each commit runs CI exactly
once. PR gating (and auto-merge) is unaffected — it already relied on the
`pull_request` run.

## Summary by Sourcery

CI:
- Remove the push trigger from the CI workflow so that only pull_request events start CI runs.