### PR TITLE
docs: update README to match current public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,25 @@ Brain is characterized by the discrete spiking events, which are the fundamental
 **CPUs**, **GPUs**, **TPUs**, and maybe more, which can be used to model the brain dynamics in an
 efficient and biologically plausible way.
 
-Particularly, it provides the following class to represent binary events in the brain:
+Particularly, it provides the following classes to represent binary (spiking) events in the brain:
 
-- ``BinaryArray``: representing array with a vector/matrix of events.
+- ``BinaryArray``: an array wrapping a vector/matrix of binary events (spikes).
+- ``BitPackedBinary``: a memory-efficient representation that packs binary events into bits
+  (see also the ``bitpack`` helper).
+- ``CompactBinary``: a compact representation that stores only the indices of the active (non-zero) events.
 
 Furthermore, it implements the following commonly used data structures for event-driven computation
-of the above class:
+of the above classes. Most structures come in row-oriented (``R``) and column-oriented (``C``) variants:
 
-- ``COO``: a sparse matrix in COO format for sparse and event-driven computation.
-- ``CSR``: a sparse matrix in CSR format for sparse and event-driven computation.
-- ``CSC``: a sparse matrix in CSC format for sparse and event-driven computation.
-- ``JITCHomoR``: a just-in-time connectivity matrix with homogenous weight for sparse and event-driven computation.
-- ``JITCNormalR``: a just-in-time connectivity matrix with normal distribution weight for sparse and event-driven
-  computation.
-- ``JITCUniformR``: a just-in-time connectivity matrix with uniform distribution weight for sparse and event-driven
-  computation.
-- ``FixedPreNumConn``: a fixed number of pre-synaptic connections for sparse and event-driven computation.
-- ``FixedPostNumConn``: a fixed number of post-synaptic connections for sparse and event-driven computation.
+- ``CSR`` / ``CSC``: sparse matrices in CSR / CSC format for sparse and event-driven computation.
+- ``JITCScalarR`` / ``JITCScalarC``: a just-in-time connectivity matrix with homogeneous (scalar)
+  weight for sparse and event-driven computation.
+- ``JITCNormalR`` / ``JITCNormalC``: a just-in-time connectivity matrix with normal-distribution
+  weights for sparse and event-driven computation.
+- ``JITCUniformR`` / ``JITCUniformC``: a just-in-time connectivity matrix with uniform-distribution
+  weights for sparse and event-driven computation.
+- ``FixedNumConn`` / ``FixedNumPerPre`` / ``FixedNumPerPost``: fixed-number connectivity matrices,
+  where each neuron has a fixed number of synaptic connections.
 - ...
 
 `BrainEvent` is fully compatible with physical units and unit-aware computations provided
@@ -62,8 +64,8 @@ will take advantage of event-driven computations:
 
 - Sparse data structures provided by ``brainevent``, like:
     - ``brainevent.CSR``
-    - ``brainevent.JITCHomoR``
-    - ``brainevent.FixedPostNumConn``
+    - ``brainevent.JITCScalarR``
+    - ``brainevent.FixedNumPerPre``
     - ...
 - Dense data structures provided by JAX/NumPy, like:
     - ``jax.numpy.ndarray``
@@ -73,7 +75,7 @@ will take advantage of event-driven computations:
 data = jax.random.rand(...)  # normal dense array
 data = brainevent.CSR(...)  # CSR structure
 data = brainevent.JITCScalarR(...)  # JIT connectivity
-data = brainevent.FixedPostNumConn(...)  # fixed number of post-synaptic connections
+data = brainevent.FixedNumPerPre(...)  # fixed number of post-synaptic connections per pre-neuron
 
 # event-driven matrix multiplication
 r = event_array @ data

--- a/brainevent/_csr/slice_test.py
+++ b/brainevent/_csr/slice_test.py
@@ -134,7 +134,7 @@ class TestCSRSliceRows:
 
 def _make_homo_csr_and_dense(m, n, prob=0.3):
     """Create a homogeneous-weight CSR matrix and its dense equivalent."""
-    indptr, indices = get_csr(m, n, prob, replace=False)
+    indptr, indices = _csr_index_arrays(m, n, prob)
     data = jnp.array([1.5], dtype=jnp.float32)
     dense = np.zeros((m, n), dtype=np.float32)
     indptr_np = np.asarray(indptr)
@@ -499,31 +499,34 @@ class TestCSRSliceBatching:
     reason=f'No csr_slice_rows implementation on platform={platform}',
 )
 class TestCSCGetitem:
+    # ``CSC.__getitem__`` indexes *rows* of the logical matrix ``W`` (NumPy
+    # semantics), matching ``CSR``; previously it indexed columns. See PR #145
+    # / changelog.md ("CSC.__getitem__ now returns row i of W").
 
-    def test_single_col(self):
+    def test_single_int_index(self):
         m, n = 10, 15
         dense = np.random.randn(m, n).astype(np.float32)
         csc = CSC.fromdense(jnp.asarray(dense))
         result = csc[3]
-        expected = dense[:, 3]
-        assert result.shape == (m,)
+        expected = dense[3]
+        assert result.shape == (n,)
         assert jnp.allclose(result, jnp.asarray(expected), atol=1e-5)
 
-    def test_multi_col(self):
+    def test_tuple_index(self):
         m, n = 10, 15
         dense = np.random.randn(m, n).astype(np.float32)
         csc = CSC.fromdense(jnp.asarray(dense))
         result = csc[(0, 3, 7)]
-        expected = dense[:, [0, 3, 7]]
-        assert result.shape == (m, 3)
+        expected = dense[np.array([0, 3, 7])]
+        assert result.shape == (3, n)
         assert jnp.allclose(result, jnp.asarray(expected), atol=1e-5)
 
-    def test_array_col(self):
+    def test_array_index(self):
         m, n = 10, 15
         dense = np.random.randn(m, n).astype(np.float32)
         csc = CSC.fromdense(jnp.asarray(dense))
         idx = jnp.array([1, 5, 9], dtype=jnp.int32)
         result = csc[idx]
-        expected = dense[:, [1, 5, 9]]
-        assert result.shape == (m, 3)
+        expected = dense[np.array([1, 5, 9])]
+        assert result.shape == (3, n)
         assert jnp.allclose(result, jnp.asarray(expected), atol=1e-5)


### PR DESCRIPTION
Refresh the README class listings so they reflect the actual public API:
- Add the new binary-event representations BitPackedBinary (bitpack) and
  CompactBinary alongside BinaryArray.
- Drop COO (no longer a public class), rename JITCHomoR -> JITCScalarR, and
  FixedPre/PostNumConn -> FixedNumPerPost / FixedNumPerPre / FixedNumConn.
  Note the row- (R) / column-oriented (C) variants.

Also fix two stale tests in _csr/slice_test.py left behind by earlier
refactors so the suite passes:
- _make_homo_csr_and_dense referenced the un-imported get_csr (removed in
  c21e111); use the file-local _csr_index_arrays helper.
- TestCSCGetitem still asserted column semantics, but CSC.__getitem__ was
  changed to row indexing in #145 (see changelog.md); align it with the
  documented NumPy row semantics, mirroring TestCSRGetitem.
