### PR TITLE
ci: also run CI on push to main (keep PR runs deduped)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,13 @@
 name: Continuous Integration
 
 on:
-  # Trigger on pull requests only. A PR-branch push already fires the
-  # `pull_request` (synchronize) event, so also listening on `push` would
-  # start a second, redundant run for the same commit — one event, one run.
+  # Run on direct pushes/merges to `main`, plus every pull request.
+  # `push` is scoped to `main` only so that pushing a PR branch fires just the
+  # `pull_request` (synchronize) event — one event, one run, no duplicates.
+  # Merging/pushing to `main` is not a PR-head update, so it fires only `push`.
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - '**'        # matches every branch


### PR DESCRIPTION
## What

Scope the `push` trigger to `main` only, restoring CI on direct pushes/merges to `main` while keeping PR runs deduplicated.

```yaml
on:
  push:
    branches:
      - main
  pull_request:
    branches:
      - '**'
```

## Why

Commit #147 dropped `push` entirely to kill duplicate runs, but that also meant **nothing ran on merge/push to `main`**. Scoping `push` to `main` gives the best of both:

| Event | Runs |
|-------|------|
| Push/merge to `main` | once, via `push` |
| PR opened/updated (any branch) | once, via `pull_request` |
| Push a PR branch with an open PR | once — `push` ignores non-`main` branches, no duplicate |

`concurrency`, `permissions`, and all jobs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope CI workflow triggers to run on pushes to main and on all pull requests while avoiding duplicate runs for PR branch updates.

CI:
- Restore CI runs on direct pushes and merges to the main branch by adding a push trigger scoped to main.
- Keep PR branch updates deduplicated by relying on the pull_request event for non-main branches.