### PR TITLE
docs(typing): complete type hints and NumPy-style docstrings for public API

### DIFF
--- a/brainevent/_event/bitpack_binary.py
+++ b/brainevent/_event/bitpack_binary.py
@@ -15,6 +15,7 @@
 
 # -*- coding: utf-8 -*-
 
+import jax
 import jax.numpy as jnp
 from jax.tree_util import register_pytree_node_class
 
@@ -28,7 +29,7 @@ __all__ = [
 ]
 
 
-def bitpack(arr, axis):
+def bitpack(arr: jax.Array, axis: int) -> jax.Array:
     """Pack a boolean array into uint32 words along the given axis.
 
     Each uint32 word stores 32 binary values.  Bit ``b`` of word ``w``

--- a/brainevent/_op/benchmark.py
+++ b/brainevent/_op/benchmark.py
@@ -22,7 +22,7 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import jax
 import numpy as np
@@ -1512,7 +1512,7 @@ def _json_safe(v: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 def benchmark_function(
-    fn,
+    fn: Callable,
     n_warmup: int,
     n_runs: int,
     n_batch_per_run: int = 1,
@@ -1523,7 +1523,8 @@ def benchmark_function(
     Parameters
     ----------
     fn : callable
-        A callable that takes no arguments and returns the result.
+        The callable to benchmark.  It is invoked as ``fn(*data)`` and its
+        result is used to seed the timing loop's carry.
     n_warmup : int
         Number of warmup runs (not timed).
     n_runs : int
@@ -1536,6 +1537,9 @@ def benchmark_function(
         which is useful for measuring throughput on asynchronous
         GPU/TPU execution.  The reported times are always **per-call**
         (i.e. the interval time divided by *n_batch_per_run*).
+    data : tuple, optional
+        Positional arguments forwarded to ``fn`` on every call.  Default
+        is the empty tuple ``()`` (``fn`` is called with no arguments).
 
     Returns
     -------

--- a/brainevent/_op/numba_cuda_ffi.py
+++ b/brainevent/_op/numba_cuda_ffi.py
@@ -560,7 +560,7 @@ def _register_numba_cuda_ffi_target(
 
 
 def numba_cuda_kernel(
-    kernel,
+    kernel: Callable,
     outs: OutType,
     *,
     grid: Union[int, Tuple[int, ...], None] = None,
@@ -570,7 +570,7 @@ def numba_cuda_kernel(
     shared_mem: int = 0,
     vmap_method: str | None = None,
     input_output_aliases: dict[int, int] | None = None,
-):
+) -> Callable:
     """Create a JAX-callable function from a single Numba CUDA kernel.
 
     Wraps a Numba CUDA kernel (decorated with ``@cuda.jit``) so that it
@@ -993,7 +993,7 @@ def numba_cuda_callable(
     *,
     vmap_method: str | None = None,
     input_output_aliases: dict[int, int] | None = None,
-):
+) -> Callable:
     """Create a JAX-callable from a Python function that launches Numba CUDA kernels.
 
     Unlike :func:`numba_cuda_kernel` (which wraps a single

--- a/brainevent/_op/numba_ffi.py
+++ b/brainevent/_op/numba_ffi.py
@@ -19,7 +19,7 @@ import importlib.util
 import threading
 import traceback
 from ctypes import c_void_p, c_int, c_int64, c_uint32, c_size_t, POINTER, Structure, CFUNCTYPE
-from typing import Dict, Sequence, Tuple
+from typing import Callable, Dict, Sequence, Tuple
 
 import jax
 import numpy as np
@@ -321,12 +321,12 @@ def _register_numba_cpu_ffi_target(
 
 
 def numba_kernel(
-    kernel,
+    kernel: Callable,
     outs: OutType,
     *,
     vmap_method: str | None = None,
     input_output_aliases: dict[int, int] | None = None,
-):
+) -> Callable:
     """Create a JAX-callable function from a Numba CPU kernel.
 
     Wraps a Numba JIT-compiled CPU kernel (decorated with ``@numba.njit``)
@@ -353,6 +353,21 @@ def numba_kernel(
         A function that takes JAX arrays as inputs and returns JAX
         arrays as outputs.  Compatible with ``jax.jit`` and other
         transformations.
+
+    Raises
+    ------
+    ImportError
+        If Numba is not installed.
+    AssertionError
+        If *kernel* is not a Numba CPU dispatcher.
+
+    Notes
+    -----
+    The Numba kernel function should:
+
+    - Accept input arrays followed by output arrays as arguments.
+    - Write results directly to the output arrays.
+    - Not return any values (outputs are written in-place).
 
     Examples
     --------
@@ -402,16 +417,6 @@ def numba_kernel(
         ... def parallel_add_kernel(x, y, out):
         ...     for i in numba.prange(out.size):
         ...         out[i] = x[i] + y[i]
-
-    Raises:
-        ImportError: If Numba is not installed.
-        AssertionError: If kernel is not a Numba CPU dispatcher.
-
-    Note:
-        The Numba kernel function should:
-        - Accept input arrays followed by output arrays as arguments
-        - Write results directly to the output arrays
-        - Not return any values (outputs are written in-place)
     """
     if not numba_installed:
         raise ImportError('Numba is required to compile the CPU kernel for the custom operator.')

--- a/brainevent/_op/util.py
+++ b/brainevent/_op/util.py
@@ -17,7 +17,7 @@
 
 import functools
 import importlib.util
-from typing import Protocol, Union, Tuple, Sequence
+from typing import Any, Callable, Optional, Protocol, Sequence, Tuple, TYPE_CHECKING, Union
 
 import jax
 import numpy as np
@@ -25,6 +25,9 @@ from jax import tree_util
 from jax.interpreters import ad
 
 from brainevent._compatible_import import Primitive, init_zero
+
+if TYPE_CHECKING:
+    from .main import XLACustomKernel
 
 warp_installed = importlib.util.find_spec('warp') is not None
 
@@ -123,7 +126,7 @@ def check_warp_installed():
         raise RuntimeError(_WARP_INSTALL_ERROR_MESSAGE) from exc
 
 
-def defjvp(primitive, *jvp_rules):
+def defjvp(primitive: Union[Primitive, 'XLACustomKernel'], *jvp_rules: Optional[Callable]) -> None:
     """Define per-input JVP rules for a JAX primitive.
 
     This function allows defining Jacobian-vector product (JVP) rules
@@ -266,7 +269,12 @@ def _add_tangents(xs, ys):
     return tree_util.tree_map(ad.add_tangents, xs, ys, is_leaf=lambda a: isinstance(a, ad.Zero))
 
 
-def general_batching_rule(prim, args, axes, **kwargs):
+def general_batching_rule(
+    prim: Primitive,
+    args: Sequence,
+    axes: Sequence[Optional[int]],
+    **kwargs
+) -> Tuple[Any, Any]:
     """General-purpose batching rule for custom JAX primitives.
 
     Implements batching by separating batched and non-batched arguments,
@@ -329,15 +337,20 @@ def general_batching_rule(prim, args, axes, **kwargs):
             batch_axes.append(ax_i)
 
     def f(_, x):
-        """
-        Internal function for jax.lax.scan that applies the primitive to a single batch element.
+        """Apply the primitive to a single batch element for ``jax.lax.scan``.
 
-        Args:
-            _: Carry value (unused).
-            x: Dictionary containing the current batch slice for each batched argument.
+        Parameters
+        ----------
+        _ : int
+            Scan carry value (unused).
+        x : dict
+            The current batch slice for each batched argument.
 
-        Returns:
-            tuple: (carry value, primitive output)
+        Returns
+        -------
+        tuple
+            A pair ``(carry, primitive_output)`` where *carry* is the
+            unchanged scan carry (``0``).
         """
         pars = tuple(
             [(x[f'ax{i}'] if i in batch_axes else non_batch_args[f'ax{i}'])
@@ -472,7 +485,7 @@ def abstract_arguments(outs):
     return outs, tree_def
 
 
-def jaxtype_to_warptype(dtype):
+def jaxtype_to_warptype(dtype: Union[np.dtype, type]) -> Any:
     """Convert a JAX / NumPy dtype to the corresponding Warp scalar type.
 
     Maps standard NumPy data types (which are also used by JAX) to their
@@ -560,7 +573,7 @@ def jaxtype_to_warptype(dtype):
         raise ValueError(f"Warp does not support computations with dtype: {dtype}")
 
 
-def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct):
+def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct) -> Any:
     """Convert a ``jax.ShapeDtypeStruct`` to a Warp array type descriptor.
 
     Takes a JAX shape-and-dtype specification and creates the

--- a/brainevent/_pallas_random.py
+++ b/brainevent/_pallas_random.py
@@ -1202,12 +1202,26 @@ _PALLAS_LFSR_CLASSES = {
 }
 
 
-def get_pallas_lfsr_rng_class():
-    """Return the Pallas RNG class for the current global LFSR algorithm."""
+def get_pallas_lfsr_rng_class() -> type[LFSRBase]:
+    """Return the Pallas RNG class for the current global LFSR algorithm.
+
+    The active algorithm is read from the global configuration via
+    :func:`brainevent.config.get_lfsr_algorithm`.
+
+    Returns
+    -------
+    type[LFSRBase]
+        The Pallas RNG class (a subclass of :class:`LFSRBase`) implementing
+        the currently configured LFSR algorithm.
+
+    See Also
+    --------
+    PallasLFSRRNG : Instantiate the configured RNG class directly.
+    """
     return _PALLAS_LFSR_CLASSES[get_lfsr_algorithm()]
 
 
-def PallasLFSRRNG(seed):
+def PallasLFSRRNG(seed: int) -> LFSRBase:
     """Factory: create a Pallas RNG instance using the globally configured algorithm.
 
     Parameters

--- a/brainevent/pararnn/_auto_cell.py
+++ b/brainevent/pararnn/_auto_cell.py
@@ -42,6 +42,8 @@ Three Jacobian structures are supported:
 - ``'auto'``: auto-detect from the cell function (default)
 """
 
+from typing import Callable, Optional
+
 import jax
 import jax.numpy as jnp
 
@@ -180,16 +182,25 @@ class AutoRNNCell(BaseRNNCell):
 
     The cell function operates on single vectors (no batch/time dims).
 
-    Args:
-        cell_fn: Recurrence function ``(h_prev, x_t, *params) -> h_new``.
-        jacobian_structure: ``'auto'``, ``'diagonal'``, ``'block_diagonal'``,
-            or ``'dense'``.
-        block_size: Block size K for ``'block_diagonal'`` structure.
-            Required when ``jacobian_structure='block_diagonal'``.
-            Ignored for other structures.
+    Parameters
+    ----------
+    cell_fn : callable
+        Recurrence function ``(h_prev, x_t, *params) -> h_new``.
+    jacobian_structure : str, optional
+        One of ``'auto'``, ``'diagonal'``, ``'block_diagonal'``, or
+        ``'dense'``.  Default is ``'auto'``.
+    block_size : int or None, optional
+        Block size ``K`` for the ``'block_diagonal'`` structure.  Required
+        when ``jacobian_structure='block_diagonal'``; ignored for other
+        structures.
     """
 
-    def __init__(self, cell_fn, jacobian_structure='auto', block_size=None):
+    def __init__(
+        self,
+        cell_fn: Callable,
+        jacobian_structure: str = 'auto',
+        block_size: Optional[int] = None,
+    ):
         self.cell_fn = cell_fn
         self._jac_structure = jacobian_structure
         self._block_size = block_size
@@ -495,15 +506,15 @@ def _apply_sequential_auto(cell, x, state_dim, params):
 
 
 def parallel_rnn(
-    cell_fn,
-    x,
+    cell_fn: Callable,
+    x: jax.Array,
     *params,
-    jacobian_structure='auto',
-    block_size=None,
-    state_dim=None,
-    newton_config=None,
-    mode='parallel',
-):
+    jacobian_structure: str = 'auto',
+    block_size: Optional[int] = None,
+    state_dim: Optional[int] = None,
+    newton_config: Optional[NewtonConfig] = None,
+    mode: str = 'parallel',
+) -> jax.Array:
     """Train any RNN cell in parallel via Newton + parallel scan.
 
     Given a cell function ``cell_fn(h_prev, x_t, *params) -> h_new``,
@@ -511,24 +522,42 @@ def parallel_rnn(
     for O(log T) parallel training.
 
     The cell function operates on **single vectors** (no batch/time dims):
+
     - ``h_prev``: shape ``(state_dim,)``
     - ``x_t``: shape ``(input_dim,)``
     - returns: ``h_new`` with shape ``(state_dim,)``
 
-    Args:
-        cell_fn: Recurrence function ``(h_prev, x_t, *params) -> h_new``.
-        x: Input sequence, shape ``(B, T, input_dim)``.
-        *params: Cell parameters (JAX arrays).
-        jacobian_structure: ``'auto'`` (default), ``'diagonal'``,
-            ``'block_diagonal'``, or ``'dense'``.
-        block_size: Block size K for ``'block_diagonal'`` structure.
-        state_dim: Hidden state dimension. If ``None``, inferred from
-            ``cell_fn`` and ``params``.
-        newton_config: Newton solver configuration.
-        mode: ``'sequential'`` or ``'parallel'`` (default).
+    Parameters
+    ----------
+    cell_fn : callable
+        Recurrence function ``(h_prev, x_t, *params) -> h_new``.
+    x : jax.Array
+        Input sequence, shape ``(B, T, input_dim)``.
+    *params : jax.Array
+        Cell parameters (JAX arrays).
+    jacobian_structure : str, optional
+        One of ``'auto'`` (default), ``'diagonal'``, ``'block_diagonal'``,
+        or ``'dense'``.
+    block_size : int or None, optional
+        Block size ``K`` for the ``'block_diagonal'`` structure.
+    state_dim : int or None, optional
+        Hidden state dimension.  If ``None``, inferred from ``cell_fn`` and
+        ``params``.
+    newton_config : NewtonConfig or None, optional
+        Newton solver configuration.  If ``None``, a default
+        :class:`NewtonConfig` is used.
+    mode : str, optional
+        Either ``'sequential'`` or ``'parallel'`` (default).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Hidden states, shape ``(B, T, state_dim)``.
+
+    Raises
+    ------
+    ValueError
+        If *mode* is not ``'sequential'`` or ``'parallel'``.
     """
     if newton_config is None:
         newton_config = NewtonConfig()

--- a/brainevent/pararnn/_cell.py
+++ b/brainevent/pararnn/_cell.py
@@ -34,6 +34,7 @@ All params are split into array params (differentiable) and static params
 
 import abc
 from enum import Enum
+from typing import Any, Type
 
 import jax
 import jax.numpy as jnp
@@ -46,10 +47,15 @@ __all__ = ['BaseRNNCell', 'ApplicationMode', 'apply_rnn']
 class ApplicationMode(str, Enum):
     """Application modes for RNN cell evaluation.
 
-    - ``SEQUENTIAL``: O(T) sequential scan via ``jax.lax.scan``.
-    - ``PARALLEL``: O(log T) parallel via Newton + ``jax.lax.associative_scan``.
-    - ``FUSED``: Single CUDA kernel combining Newton + parallel reduction.
-      Requires CUDA and a GPU. Falls back to ``PARALLEL`` if unavailable.
+    Attributes
+    ----------
+    SEQUENTIAL : str
+        ``O(T)`` sequential scan via ``jax.lax.scan``.
+    PARALLEL : str
+        ``O(log T)`` parallel via Newton + ``jax.lax.associative_scan``.
+    FUSED : str
+        Single CUDA kernel combining Newton + parallel reduction.
+        Requires CUDA and a GPU. Falls back to ``PARALLEL`` if unavailable.
     """
     SEQUENTIAL = "sequential"
     PARALLEL = "parallel"
@@ -69,6 +75,12 @@ class BaseRNNCell(abc.ABC):
     Subclasses must set ``num_array_params`` to indicate how many of the
     leading ``*params`` arguments are JAX arrays (differentiable). The
     remaining params are treated as static (e.g., activation functions).
+
+    Attributes
+    ----------
+    num_array_params : int
+        Number of leading ``*params`` arguments that are JAX arrays
+        (differentiable). The remaining params are treated as static.
     """
 
     # Number of leading params that are JAX arrays
@@ -97,7 +109,11 @@ class BaseRNNCell(abc.ABC):
     def backprop_to_params(dl_dh, x, h, *params):
         """Compute gradients w.r.t. x and all params.
 
-        Returns: (grad_x, *grad_all_params) where grad for static params is None.
+        Returns
+        -------
+        tuple
+            ``(grad_x, *grad_all_params)`` where the gradient for static
+            params is ``None``.
         """
         ...
 
@@ -126,24 +142,45 @@ class BaseRNNCell(abc.ABC):
         return jnp.zeros((*x.shape[:-1], state_dim), dtype=x.dtype)
 
 
-def apply_rnn(cell_cls, x, state_dim, mode='parallel',
-              newton_config=NewtonConfig(), *params):
+def apply_rnn(
+    cell_cls: Type[BaseRNNCell],
+    x: jax.Array,
+    state_dim: int,
+    mode: str = 'parallel',
+    newton_config: NewtonConfig = NewtonConfig(),
+    *params: Any,
+) -> jax.Array:
     """Apply an RNN cell to an input sequence.
 
     Dispatches to sequential or parallel mode. In parallel mode, uses
     ``jax.custom_vjp`` with implicit differentiation for the backward pass.
 
-    Args:
-        cell_cls: The RNN cell class (subclass of BaseRNNCell).
-        x: Input sequence, shape ``(B, T, input_dim)``.
-        state_dim: Hidden state dimension.
-        mode: ``'sequential'`` or ``'parallel'``.
-        newton_config: Newton solver configuration (for parallel mode).
-        *params: Cell parameters. The first ``cell_cls.num_array_params``
-            are JAX arrays; the rest are static (e.g., activation functions).
+    Parameters
+    ----------
+    cell_cls : Type[BaseRNNCell]
+        The RNN cell class (subclass of ``BaseRNNCell``).
+    x : jax.Array
+        Input sequence, shape ``(B, T, input_dim)``.
+    state_dim : int
+        Hidden state dimension.
+    mode : str, default='parallel'
+        ``'sequential'``, ``'parallel'``, or ``'fused'``.
+    newton_config : NewtonConfig
+        Newton solver configuration (for parallel mode).
+    *params : Any
+        Cell parameters. The first ``cell_cls.num_array_params``
+        are JAX arrays; the rest are static (e.g., activation functions).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Output sequence, shape ``(B, T, output_dim)``.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not one of ``'sequential'``, ``'parallel'``, or
+        ``'fused'``.
     """
     n_arr = cell_cls.num_array_params
     array_params = params[:n_arr]

--- a/brainevent/pararnn/_fused.py
+++ b/brainevent/pararnn/_fused.py
@@ -33,6 +33,7 @@ Functions:
 """
 
 from pathlib import Path
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -485,19 +486,25 @@ def fused_gru_diag_forward(
     A: jax.Array,
     Bxpb: jax.Array,
     *,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Fused GRU forward pass.
 
     Runs the complete Newton-parallel-reduction solve. Input projection
-    (Bxpb = B @ x + b) must be precomputed.
+    (``Bxpb = B @ x + b``) must be precomputed.
 
-    Args:
-        A: Diagonal recurrence weights, shape ``(3, hidden_dim)``.
-        Bxpb: Precomputed input projection, shape ``(B, T, 3, hidden_dim)``.
-        backend: ``'cuda_raw'`` for CUDA, ``None`` for default (``jax_raw``).
+    Parameters
+    ----------
+    A : jax.Array
+        Diagonal recurrence weights, shape ``(3, hidden_dim)``.
+    Bxpb : jax.Array
+        Precomputed input projection, shape ``(B, T, 3, hidden_dim)``.
+    backend : str, optional
+        ``'cuda_raw'`` for CUDA, ``None`` for default (``jax_raw``).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Hidden states ``h``, shape ``(B, T, hidden_dim)``.
     """
     batch_size, seq_len = Bxpb.shape[0], Bxpb.shape[1]
@@ -601,21 +608,29 @@ def fused_gru_diag_backward(
     A: jax.Array,
     Bxpb: jax.Array,
     *,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Fused GRU backward pass (transposed system solve).
 
-    Solves the transposed bidiagonal system for dl/dh.
+    Solves the transposed bidiagonal system for ``dl/dh``.
 
-    Args:
-        grad_y: Gradient w.r.t. output, shape ``(B, T, hidden_dim)``.
-        h: Forward hidden states, shape ``(B, T, hidden_dim)``.
-        A: Diagonal recurrence weights, shape ``(3, hidden_dim)``.
-        Bxpb: Precomputed input projection, shape ``(B, T, 3, hidden_dim)``.
-        backend: ``'cuda_raw'`` for CUDA, ``None`` for default.
+    Parameters
+    ----------
+    grad_y : jax.Array
+        Gradient w.r.t. output, shape ``(B, T, hidden_dim)``.
+    h : jax.Array
+        Forward hidden states, shape ``(B, T, hidden_dim)``.
+    A : jax.Array
+        Diagonal recurrence weights, shape ``(3, hidden_dim)``.
+    Bxpb : jax.Array
+        Precomputed input projection, shape ``(B, T, 3, hidden_dim)``.
+    backend : str, optional
+        ``'cuda_raw'`` for CUDA, ``None`` for default.
 
-    Returns:
-        dl/dh with shape ``(B, T, hidden_dim)``.
+    Returns
+    -------
+    jax.Array
+        ``dl/dh`` with shape ``(B, T, hidden_dim)``.
     """
     return fused_gru_diag_bwd_p(
         grad_y, h, A, Bxpb,
@@ -796,20 +811,27 @@ def fused_lstm_cifg_diag_forward(
     Bxpb: jax.Array,
     C: jax.Array,
     *,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Fused LSTM-CIFG forward pass.
 
     Runs the complete Newton-parallel-reduction solve with 2x2 block-diagonal
     Jacobians.
 
-    Args:
-        A: Diagonal recurrence weights, shape ``(3, state_dim)``.
-        Bxpb: Precomputed input projection, shape ``(B, T, 3, state_dim)``.
-        C: Peephole connection weights, shape ``(2, state_dim)``.
-        backend: ``'cuda_raw'`` for CUDA, ``None`` for default (``jax_raw``).
+    Parameters
+    ----------
+    A : jax.Array
+        Diagonal recurrence weights, shape ``(3, state_dim)``.
+    Bxpb : jax.Array
+        Precomputed input projection, shape ``(B, T, 3, state_dim)``.
+    C : jax.Array
+        Peephole connection weights, shape ``(2, state_dim)``.
+    backend : str, optional
+        ``'cuda_raw'`` for CUDA, ``None`` for default (``jax_raw``).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Full state ``[c, h]``, shape ``(B, T, 2, state_dim)``.
     """
     batch_size, seq_len = Bxpb.shape[0], Bxpb.shape[1]
@@ -940,22 +962,31 @@ def fused_lstm_cifg_diag_backward(
     Bxpb: jax.Array,
     C: jax.Array,
     *,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Fused LSTM-CIFG backward pass.
 
-    Solves the transposed 2x2 block-diagonal system for dl/d[c,h].
+    Solves the transposed 2x2 block-diagonal system for ``dl/d[c, h]``.
 
-    Args:
-        grad_y: Gradient w.r.t. output h only, shape ``(B, T, state_dim)``.
-        full_state: Forward full state [c, h], shape ``(B, T, 2, state_dim)``.
-        A: Diagonal recurrence weights, shape ``(3, state_dim)``.
-        Bxpb: Precomputed input projection, shape ``(B, T, 3, state_dim)``.
-        C: Peephole connection weights, shape ``(2, state_dim)``.
-        backend: ``'cuda_raw'`` for CUDA, ``None`` for default.
+    Parameters
+    ----------
+    grad_y : jax.Array
+        Gradient w.r.t. output ``h`` only, shape ``(B, T, state_dim)``.
+    full_state : jax.Array
+        Forward full state ``[c, h]``, shape ``(B, T, 2, state_dim)``.
+    A : jax.Array
+        Diagonal recurrence weights, shape ``(3, state_dim)``.
+    Bxpb : jax.Array
+        Precomputed input projection, shape ``(B, T, 3, state_dim)``.
+    C : jax.Array
+        Peephole connection weights, shape ``(2, state_dim)``.
+    backend : str, optional
+        ``'cuda_raw'`` for CUDA, ``None`` for default.
 
-    Returns:
-        dl/d[c,h] with shape ``(B, T, 2, state_dim)``.
+    Returns
+    -------
+    jax.Array
+        ``dl/d[c, h]`` with shape ``(B, T, 2, state_dim)``.
     """
     batch_size, seq_len = grad_y.shape[0], grad_y.shape[1]
     state_dim = A.shape[1]

--- a/brainevent/pararnn/_gru.py
+++ b/brainevent/pararnn/_gru.py
@@ -228,22 +228,38 @@ class GRUDiagMH(brainstate.nn.Module):
     This module wraps the ``GRUDiagMHImpl`` cell with ``brainstate.nn.Module``
     for state management and provides a clean API for training.
 
-    Args:
-        input_dim: Input feature dimension.
-        state_dim: Hidden state dimension.
-        num_heads: Number of heads for input projection. Must divide both
-            ``input_dim`` and ``state_dim``.
-        mode: Application mode (``'sequential'`` or ``'parallel'``).
-        nonlin_update: Activation for update gate z (default: ``'sigmoid'``).
-        nonlin_reset: Activation for reset gate r (default: ``'sigmoid'``).
-        nonlin_state: Activation for candidate state (default: ``'tanh'``).
-        a_init: Initialization for A weights (default: ``'xlstm'``).
-        b_init: Initialization for bias b (default: ``'bias_minus_linspace'``).
-        w_init: Initialization for B weights (default: ``'xavier_uniform'``).
-        newton_config: Configuration for Newton solver.
-        seed: Random seed for initialization.
+    Parameters
+    ----------
+    input_dim : int
+        Input feature dimension.
+    state_dim : int
+        Hidden state dimension.
+    num_heads : int, default 2
+        Number of heads for input projection. Must divide both ``input_dim``
+        and ``state_dim``.
+    mode : str, default 'parallel'
+        Application mode (``'sequential'`` or ``'parallel'``).
+    nonlin_update : str, default 'sigmoid'
+        Activation for update gate z.
+    nonlin_reset : str, default 'sigmoid'
+        Activation for reset gate r.
+    nonlin_state : str, default 'tanh'
+        Activation for candidate state.
+    a_init : str, default 'xlstm'
+        Initialization for A weights.
+    b_init : str, default 'bias_minus_linspace'
+        Initialization for bias b.
+    w_init : str, default 'xavier_uniform'
+        Initialization for B weights.
+    newton_config : NewtonConfig, optional
+        Configuration for the Newton solver. If ``None``, a default
+        :class:`NewtonConfig` is used.
+    seed : int, default 0
+        Random seed for initialization.
 
-    Example::
+    Examples
+    --------
+    .. code-block:: python
 
         >>> import jax.numpy as jnp
         >>> import brainstate
@@ -310,10 +326,14 @@ class GRUDiagMH(brainstate.nn.Module):
     def __call__(self, x: jax.Array) -> jax.Array:
         """Run the GRU on an input sequence.
 
-        Args:
-            x: Input tensor, shape ``(B, T, input_dim)``.
+        Parameters
+        ----------
+        x : jax.Array
+            Input tensor, shape ``(B, T, input_dim)``.
 
-        Returns:
+        Returns
+        -------
+        jax.Array
             Hidden states, shape ``(B, T, state_dim)``.
         """
         if self.mode == 'fused':

--- a/brainevent/pararnn/_init.py
+++ b/brainevent/pararnn/_init.py
@@ -159,18 +159,28 @@ def initialize(name: str, key: jax.Array, shape: Tuple[int, ...],
                fan_in: int = 1, fan_out: Optional[int] = None) -> jax.Array:
     """Initialize a weight tensor using the named strategy.
 
-    Args:
-        name: Name of the initialization strategy.
-        key: JAX PRNG key.
-        shape: Shape of the tensor to initialize.
-        fan_in: Fan-in dimension (number of input features).
-        fan_out: Fan-out dimension (number of output features).
+    Parameters
+    ----------
+    name : str
+        Name of the initialization strategy.
+    key : jax.Array
+        JAX PRNG key.
+    shape : Tuple[int, ...]
+        Shape of the tensor to initialize.
+    fan_in : int, default=1
+        Fan-in dimension (number of input features).
+    fan_out : Optional[int], default=None
+        Fan-out dimension (number of output features).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Initialized JAX array.
 
-    Raises:
-        KeyError: If the name is not in the registry.
+    Raises
+    ------
+    KeyError
+        If the name is not in the registry.
     """
     if name not in INITIALIZERS:
         raise KeyError(

--- a/brainevent/pararnn/_lstm.py
+++ b/brainevent/pararnn/_lstm.py
@@ -325,22 +325,40 @@ class LSTMCIFGDiagMH(brainstate.nn.Module):
     dimension (``h``). Internally, the state is ``[c, h]`` with dimension
     ``2 * state_dim``.
 
-    Args:
-        input_dim: Input feature dimension.
-        state_dim: Hidden state dimension (output dimension ``h``).
-        num_heads: Number of heads for input projection.
-        mode: Application mode (``'sequential'`` or ``'parallel'``).
-        nonlin_f: Activation for forget gate (default: ``'sigmoid'``).
-        nonlin_o: Activation for output gate (default: ``'sigmoid'``).
-        nonlin_c: Activation for cell candidate (default: ``'tanh'``).
-        nonlin_state: Activation for cell state (default: ``'tanh'``).
-        a_init: Initialization for A weights (default: ``'xlstm'``).
-        w_init: Initialization for B weights (default: ``'xavier_uniform'``).
-        b_init: Initialization for bias b (default: ``'bias_minus_linspace'``).
-        newton_config: Configuration for Newton solver.
-        seed: Random seed for initialization.
+    Parameters
+    ----------
+    input_dim : int
+        Input feature dimension.
+    state_dim : int
+        Hidden state dimension (output dimension ``h``).
+    num_heads : int, default 2
+        Number of heads for input projection. Must divide both ``input_dim``
+        and ``state_dim``.
+    mode : str, default 'parallel'
+        Application mode (``'sequential'`` or ``'parallel'``).
+    nonlin_f : str, default 'sigmoid'
+        Activation for forget gate.
+    nonlin_o : str, default 'sigmoid'
+        Activation for output gate.
+    nonlin_c : str, default 'tanh'
+        Activation for cell candidate.
+    nonlin_state : str, default 'tanh'
+        Activation for cell state.
+    a_init : str, default 'xlstm'
+        Initialization for A weights.
+    w_init : str, default 'xavier_uniform'
+        Initialization for B weights.
+    b_init : str, default 'bias_minus_linspace'
+        Initialization for bias b.
+    newton_config : NewtonConfig, optional
+        Configuration for the Newton solver. If ``None``, a default
+        :class:`NewtonConfig` is used.
+    seed : int, default 0
+        Random seed for initialization.
 
-    Example::
+    Examples
+    --------
+    .. code-block:: python
 
         >>> import jax.numpy as jnp
         >>> import brainstate
@@ -412,12 +430,16 @@ class LSTMCIFGDiagMH(brainstate.nn.Module):
     def __call__(self, x: jax.Array) -> jax.Array:
         """Run the LSTM on an input sequence.
 
-        Args:
-            x: Input tensor, shape ``(B, T, input_dim)``.
+        Parameters
+        ----------
+        x : jax.Array
+            Input tensor, shape ``(B, T, input_dim)``.
 
-        Returns:
-            Hidden states ``h``, shape ``(B, T, state_dim)``.
-            (Cell states ``c`` are internal and not returned.)
+        Returns
+        -------
+        jax.Array
+            Hidden states ``h``, shape ``(B, T, state_dim)``. Cell states ``c``
+            are internal and not returned.
         """
         if self.mode == 'fused':
             return self._apply_fused(x)

--- a/brainevent/pararnn/_newton.py
+++ b/brainevent/pararnn/_newton.py
@@ -26,7 +26,7 @@ differentiation through Newton iterations.
 """
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 import jax
 
@@ -37,10 +37,13 @@ __all__ = ['NewtonConfig', 'newton_solve']
 class NewtonConfig:
     """Configuration for the Newton solver.
 
-    Attributes:
-        max_its: Maximum number of Newton iterations.
-        omega_sor: Successive-over-relaxation parameter.
-            < 1: stabilizing, = 1: vanilla Newton, > 1: accelerating.
+    Attributes
+    ----------
+    max_its : int
+        Maximum number of Newton iterations.
+    omega_sor : float
+        Successive-over-relaxation parameter.
+        ``< 1``: stabilizing, ``= 1``: vanilla Newton, ``> 1``: accelerating.
     """
     max_its: int = 3
     omega_sor: float = 1.0
@@ -48,29 +51,39 @@ class NewtonConfig:
 
 def newton_solve(
     h0: jax.Array,
-    compute_negative_residuals: Callable,
-    compute_jacobians: Callable,
-    linear_solve: Callable,
+    compute_negative_residuals: Callable[[jax.Array], jax.Array],
+    compute_jacobians: Callable[[jax.Array], Any],
+    linear_solve: Callable[[Any, jax.Array], jax.Array],
     newton_config: NewtonConfig = NewtonConfig(),
 ) -> jax.Array:
     """Solve F(h) = 0 via Newton iteration with parallel reduction.
 
     At each iteration:
-        1. Compute residuals: rhs = -(h - f(h_prev, x))
-        2. Compute Jacobians: J = -df/dh_prev
-        3. Solve bidiagonal system: dh = linear_solve(J, rhs)
-        4. Update: h = h + omega * dh
+
+    1. Compute residuals: ``rhs = -(h - f(h_prev, x))``
+    2. Compute Jacobians: ``J = -df/dh_prev``
+    3. Solve bidiagonal system: ``dh = linear_solve(J, rhs)``
+    4. Update: ``h = h + omega * dh``
 
     Uses ``jax.lax.fori_loop`` for JIT compatibility.
 
-    Args:
-        h0: Initial guess for hidden states, shape ``(B, T, N)``.
-        compute_negative_residuals: ``h -> rhs``, computes negative residuals.
-        compute_jacobians: ``h -> jac``, computes Jacobians.
-        linear_solve: ``(jac, rhs) -> dh``, solves the bidiagonal system.
-        newton_config: Solver configuration.
+    Parameters
+    ----------
+    h0 : jax.Array
+        Initial guess for hidden states, shape ``(B, T, N)``.
+    compute_negative_residuals : Callable[[jax.Array], jax.Array]
+        ``h -> rhs``, computes negative residuals.
+    compute_jacobians : Callable[[jax.Array], Any]
+        ``h -> jac``, computes Jacobians. The returned Jacobian structure
+        is cell-specific and consumed by ``linear_solve``.
+    linear_solve : Callable[[Any, jax.Array], jax.Array]
+        ``(jac, rhs) -> dh``, solves the bidiagonal system.
+    newton_config : NewtonConfig
+        Solver configuration.
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution ``h`` with shape ``(B, T, N)``.
     """
     omega = newton_config.omega_sor

--- a/brainevent/pararnn/_nonlinearities.py
+++ b/brainevent/pararnn/_nonlinearities.py
@@ -156,14 +156,20 @@ NONLINEARITIES: Dict[str, Tuple[Callable, Callable]] = {
 def get_nonlinearity(name: str) -> Tuple[Callable, Callable]:
     """Get (activation, derivative) pair by name.
 
-    Args:
-        name: Name of the nonlinearity.
+    Parameters
+    ----------
+    name : str
+        Name of the nonlinearity.
 
-    Returns:
-        Tuple of (activation_fn, derivative_fn).
+    Returns
+    -------
+    Tuple[Callable, Callable]
+        Tuple of ``(activation_fn, derivative_fn)``.
 
-    Raises:
-        KeyError: If the name is not in the registry.
+    Raises
+    ------
+    KeyError
+        If the name is not in the registry.
     """
     if name not in NONLINEARITIES:
         raise KeyError(

--- a/brainevent/pararnn/_parallel_reduce.py
+++ b/brainevent/pararnn/_parallel_reduce.py
@@ -36,6 +36,7 @@ Backends:
 """
 
 from pathlib import Path
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -389,7 +390,7 @@ parallel_reduce_dense_p.def_transpose_rule(_reduce_dense_transpose)
 def parallel_reduce_diag(
     jac: jax.Array,
     rhs: jax.Array,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Solve h[t] = jac[t]*h[t-1] + rhs[t] with diagonal Jacobians.
 
@@ -398,12 +399,18 @@ def parallel_reduce_diag(
     is specified, dispatches through ``XLACustomKernel`` to CUDA kernels
     (not differentiable — use inside ``jax.custom_vjp``).
 
-    Args:
-        jac: Jacobian diagonals, shape ``(B, T, N)``.
-        rhs: Right-hand side, shape ``(B, T, N)``.
-        backend: ``'cuda_raw'`` for GPU kernels, ``None`` for JAX native.
+    Parameters
+    ----------
+    jac : jax.Array
+        Jacobian diagonals, shape ``(B, T, N)``.
+    rhs : jax.Array
+        Right-hand side, shape ``(B, T, N)``.
+    backend : str, optional
+        ``'cuda_raw'`` for GPU kernels, ``None`` for JAX native.
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution ``h`` with shape ``(B, T, N)``.
     """
     if backend is not None and backend != 'jax_raw':
@@ -419,19 +426,25 @@ def parallel_reduce_diag(
 def parallel_reduce_diag_bwd(
     jac: jax.Array,
     rhs: jax.Array,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Backward (transposed) solve for diagonal Jacobians.
 
     The Jacobian for backward is already prepared (flipped and shifted) by
     ``compute_jacobians_bwd``, so this function just does a forward scan.
 
-    Args:
-        jac: Prepared backward Jacobians, shape ``(B, T, N)``.
-        rhs: Gradient right-hand side (flipped), shape ``(B, T, N)``.
-        backend: ``'cuda_raw'`` for GPU kernels, ``None`` for default.
+    Parameters
+    ----------
+    jac : jax.Array
+        Prepared backward Jacobians, shape ``(B, T, N)``.
+    rhs : jax.Array
+        Gradient right-hand side (flipped), shape ``(B, T, N)``.
+    backend : str, optional
+        ``'cuda_raw'`` for GPU kernels, ``None`` for default.
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution with shape ``(B, T, N)``.
     """
     return parallel_reduce_diag(jac, rhs, backend=backend)
@@ -440,7 +453,7 @@ def parallel_reduce_diag_bwd(
 def parallel_reduce_block_diag(
     jac: jax.Array,
     rhs: jax.Array,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Solve h[t] = jac[t] @ h[t-1] + rhs[t] with block-diagonal Jacobians.
 
@@ -448,14 +461,20 @@ def parallel_reduce_block_diag(
     When ``backend='cuda_raw'`` is specified, dispatches through
     ``XLACustomKernel`` to CUDA kernels (K=2 only).
 
-    Args:
-        jac: Block-diagonal Jacobians, shape ``(B, T, N, K, K)`` where K is
-            the block size (2 or 3).
-        rhs: Right-hand side, shape ``(B, T, N, K)``.
-        backend: ``'cuda_raw'`` for GPU kernels (K=2 only), ``None`` for
-            JAX native.
+    Parameters
+    ----------
+    jac : jax.Array
+        Block-diagonal Jacobians, shape ``(B, T, N, K, K)`` where K is
+        the block size (2 or 3).
+    rhs : jax.Array
+        Right-hand side, shape ``(B, T, N, K)``.
+    backend : str, optional
+        ``'cuda_raw'`` for GPU kernels (K=2 only), ``None`` for
+        JAX native.
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution ``h`` with shape ``(B, T, N, K)``.
     """
     if backend is not None and backend != 'jax_raw':
@@ -475,16 +494,22 @@ def parallel_reduce_block_diag(
 def parallel_reduce_block_diag_bwd(
     jac: jax.Array,
     rhs: jax.Array,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Backward (transposed) solve for block-diagonal Jacobians.
 
-    Args:
-        jac: Prepared backward Jacobians, shape ``(B, T, N, K, K)``.
-        rhs: Gradient right-hand side, shape ``(B, T, N, K)``.
-        backend: ``'cuda_raw'`` for GPU kernels, ``None`` for default.
+    Parameters
+    ----------
+    jac : jax.Array
+        Prepared backward Jacobians, shape ``(B, T, N, K, K)``.
+    rhs : jax.Array
+        Gradient right-hand side, shape ``(B, T, N, K)``.
+    backend : str, optional
+        ``'cuda_raw'`` for GPU kernels, ``None`` for default.
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution with shape ``(B, T, N, K)``.
     """
     return parallel_reduce_block_diag(jac, rhs, backend=backend)
@@ -493,19 +518,25 @@ def parallel_reduce_block_diag_bwd(
 def parallel_reduce_dense(
     jac: jax.Array,
     rhs: jax.Array,
-    backend: str = None,
+    backend: Optional[str] = None,
 ) -> jax.Array:
     """Solve h[t] = jac[t] @ h[t-1] + rhs[t] with dense N×N Jacobians.
 
     Uses ``jax.lax.associative_scan`` for O(log T) parallel depth with
     O(N^3) matrix multiply cost per step.
 
-    Args:
-        jac: Dense Jacobian matrices, shape ``(B, T, N, N)``.
-        rhs: Right-hand side, shape ``(B, T, N)``.
-        backend: ``None`` for JAX native (default).
+    Parameters
+    ----------
+    jac : jax.Array
+        Dense Jacobian matrices, shape ``(B, T, N, N)``.
+    rhs : jax.Array
+        Right-hand side, shape ``(B, T, N)``.
+    backend : str, optional
+        ``None`` for JAX native (default).
 
-    Returns:
+    Returns
+    -------
+    jax.Array
         Solution ``h`` with shape ``(B, T, N)``.
     """
     if backend is not None and backend != 'jax_raw':


### PR DESCRIPTION
Fill the remaining type-hint and docstring gaps across the public API and
fix docstring bugs, without changing any runtime behaviour.

Core (brainevent):
- Add type hints to bitpack, defjvp, general_batching_rule, jaxtype_to_warptype,
  jaxinfo_to_warpinfo, numba_kernel, numba_cuda_kernel, numba_cuda_callable,
  benchmark_function, PallasLFSRRNG, get_pallas_lfsr_rng_class.
- Docstring bug fixes: convert numba_kernel's Google-style Raises:/Note: to
  NumPy-doc (and move into canonical order); document benchmark_function's
  `data` parameter and correct the `fn` description; convert the nested helper
  docstring in general_batching_rule.

pararnn (brainevent.pararnn):
- Complete type hints for parallel_rnn, apply_rnn and AutoRNNCell.
- Convert all public docstrings (functions and classes) from Google style to
  NumPy-doc.
- Fix `backend: str = None` -> `Optional[str] = None` in the parallel_reduce_*
  and fused_* functions.
