### PR TITLE
release: bump version to 0.1.0; drop brainstate from core import path

### DIFF
--- a/brainevent/_misc.py
+++ b/brainevent/_misc.py
@@ -17,7 +17,6 @@ import inspect
 from functools import partial
 from typing import Tuple, NamedTuple, Sequence, Union, Callable, Optional
 
-import brainstate.environ
 import brainunit as u
 import jax
 import jax.numpy as jnp
@@ -1001,31 +1000,34 @@ def coo_to_csc_index(
         ... )
     """
     n_post = shape[1]
+    # int32 is brainevent's canonical index dtype (cf. ``CSR`` / ``index_dtype``).
+    # Defined locally so this helper stays free of an external precision provider.
+    index_dtype = jnp.int32
     if isinstance(indices, np.ndarray) and isinstance(pre_ids, np.ndarray):
         # to maintain the original order of the elements with the same value
         new_post_position = np.argsort(indices, kind='stable')
-        pre_ids_new = np.asarray(pre_ids[new_post_position], dtype=brainstate.environ.ditype())
+        pre_ids_new = np.asarray(pre_ids[new_post_position], dtype=index_dtype)
 
         unique_post_ids, count = np.unique(indices, return_counts=True)
-        post_count = np.zeros(n_post, dtype=brainstate.environ.ditype())
+        post_count = np.zeros(n_post, dtype=index_dtype)
         post_count[unique_post_ids] = count
 
         indptr_new = np.insert(post_count.cumsum(), 0, 0)
-        indptr_new = np.asarray(indptr_new, dtype=brainstate.environ.ditype())
+        indptr_new = np.asarray(indptr_new, dtype=index_dtype)
 
     else:
         # to maintain the original order of the elements with the same value
 
         with jax.ensure_compile_time_eval():
             new_post_position = jnp.argsort(indices, stable=True)
-            pre_ids_new = jnp.asarray(pre_ids[new_post_position], dtype=brainstate.environ.ditype())
+            pre_ids_new = jnp.asarray(pre_ids[new_post_position], dtype=index_dtype)
 
             unique_post_ids, count = jnp.unique(indices, return_counts=True)
-            post_count = jnp.zeros(n_post, dtype=brainstate.environ.ditype())
+            post_count = jnp.zeros(n_post, dtype=index_dtype)
             post_count = post_count.at[unique_post_ids].set(count)
 
             indptr_new = jnp.insert(post_count.cumsum(), 0, 0)
-            indptr_new = jnp.asarray(indptr_new, dtype=brainstate.environ.ditype())
+            indptr_new = jnp.asarray(indptr_new, dtype=index_dtype)
 
     return indptr_new, pre_ids_new, new_post_position
 
@@ -1098,30 +1100,33 @@ def coo2csr(
         [0 2 1 3 0]
     """
     n_pre = shape[0]
+    # int32 is brainevent's canonical index dtype (cf. ``CSR`` / ``index_dtype``).
+    # Defined locally so this helper stays free of an external precision provider.
+    index_dtype = jnp.int32
     if isinstance(row_ids, np.ndarray) and isinstance(col_ids, np.ndarray):
         # stable sort keeps the original order of entries within each row
         order = np.argsort(row_ids, kind='stable')
-        csr_indices = np.asarray(col_ids[order], dtype=brainstate.environ.ditype())
+        csr_indices = np.asarray(col_ids[order], dtype=index_dtype)
 
         unique_row_ids, count = np.unique(row_ids, return_counts=True)
-        row_count = np.zeros(n_pre, dtype=brainstate.environ.ditype())
+        row_count = np.zeros(n_pre, dtype=index_dtype)
         row_count[unique_row_ids] = count
 
         csr_indptr = np.insert(row_count.cumsum(), 0, 0)
-        csr_indptr = np.asarray(csr_indptr, dtype=brainstate.environ.ditype())
+        csr_indptr = np.asarray(csr_indptr, dtype=index_dtype)
 
     else:
         with jax.ensure_compile_time_eval():
             # stable sort keeps the original order of entries within each row
             order = jnp.argsort(row_ids, stable=True)
-            csr_indices = jnp.asarray(col_ids[order], dtype=brainstate.environ.ditype())
+            csr_indices = jnp.asarray(col_ids[order], dtype=index_dtype)
 
             unique_row_ids, count = jnp.unique(row_ids, return_counts=True)
-            row_count = jnp.zeros(n_pre, dtype=brainstate.environ.ditype())
+            row_count = jnp.zeros(n_pre, dtype=index_dtype)
             row_count = row_count.at[unique_row_ids].set(count)
 
             csr_indptr = jnp.insert(row_count.cumsum(), 0, 0)
-            csr_indptr = jnp.asarray(csr_indptr, dtype=brainstate.environ.ditype())
+            csr_indptr = jnp.asarray(csr_indptr, dtype=index_dtype)
 
     return csr_indptr, csr_indices, order
 

--- a/brainevent/_misc_test.py
+++ b/brainevent/_misc_test.py
@@ -183,3 +183,97 @@ class TestCooToCscIndex(unittest.TestCase):
         csc_indptr = np.asarray(csc_indptr)
         # column 2 spans [csc_indptr[2], csc_indptr[3]) and must be empty.
         self.assertEqual(int(csc_indptr[2]), int(csc_indptr[3]))
+
+
+class TestIndexDtypeContract(unittest.TestCase):
+    """The public index helpers emit ``int32`` index arrays.
+
+    ``int32`` is brainevent's canonical index dtype (see ``CSR`` /
+    ``index_dtype=jnp.int32``). These assertions lock that contract so the
+    removal of the historical ``brainstate.environ.ditype()`` cast (which also
+    resolved to ``int32``) stays behaviour-preserving.
+    """
+
+    def test_coo2csr_emits_int32_numpy(self):
+        indptr, indices, _ = coo2csr(np.array([0, 2, 1, 0, 2]),
+                                     np.array([0, 3, 1, 2, 0]), shape=(3, 4))
+        self.assertEqual(np.asarray(indptr).dtype, np.int32)
+        self.assertEqual(np.asarray(indices).dtype, np.int32)
+
+    def test_coo2csr_emits_int32_even_for_int64_inputs(self):
+        # NumPy's default integer dtype is int64 on Linux/macOS; the output must
+        # still be the canonical int32, independent of the input index dtype.
+        row_ids = np.array([0, 2, 1, 0, 2], dtype=np.int64)
+        col_ids = np.array([0, 3, 1, 2, 0], dtype=np.int64)
+        indptr, indices, _ = coo2csr(row_ids, col_ids, shape=(3, 4))
+        self.assertEqual(np.asarray(indptr).dtype, np.int32)
+        self.assertEqual(np.asarray(indices).dtype, np.int32)
+
+    def test_coo2csr_emits_int32_jax(self):
+        import jax.numpy as jnp
+        indptr, indices, _ = coo2csr(jnp.array([0, 2, 1, 0, 2]),
+                                     jnp.array([0, 3, 1, 2, 0]), shape=(3, 4))
+        self.assertEqual(jnp.asarray(indices).dtype, jnp.int32)
+        self.assertEqual(jnp.asarray(indptr).dtype, jnp.int32)
+
+    def test_coo_to_csc_index_emits_int32(self):
+        from brainevent._misc import coo_to_csc_index
+        csc_indptr, csc_rows, _ = coo_to_csc_index(np.array([0, 0, 1, 2, 2]),
+                                                   np.array([0, 2, 1, 0, 3]), shape=(3, 4))
+        self.assertEqual(np.asarray(csc_indptr).dtype, np.int32)
+        self.assertEqual(np.asarray(csc_rows).dtype, np.int32)
+
+
+class TestNoBrainstateRuntimeDependency(unittest.TestCase):
+    """``import brainevent`` must not require the optional ``brainstate`` package.
+
+    ``brainstate`` is *not* a declared dependency of brainevent, so a clean
+    ``pip install brainevent`` does not provide it. This regression test pins
+    that the import graph reachable from ``import brainevent`` -- including the
+    index helpers in :mod:`brainevent._misc` -- stays free of a hard
+    ``brainstate`` import. Run in a subprocess with ``brainstate`` blocked so the
+    parent process's already-imported modules cannot mask the dependency.
+    """
+
+    def test_import_brainevent_and_index_helpers_without_brainstate(self):
+        import os
+        import sys
+        import subprocess
+        import textwrap
+        import brainevent._misc as _misc
+
+        pkg_parent = os.path.dirname(os.path.dirname(os.path.abspath(_misc.__file__)))
+        code = textwrap.dedent(
+            """
+            import sys, builtins
+            sys.path.insert(0, %r)
+            _real_import = builtins.__import__
+            def _blocked(name, *args, **kwargs):
+                if name == 'brainstate' or name.startswith('brainstate.'):
+                    raise ImportError('brainstate blocked (simulating a clean install)')
+                return _real_import(name, *args, **kwargs)
+            builtins.__import__ = _blocked
+
+            import numpy as np
+            import brainevent  # must not pull in brainstate
+            from brainevent._misc import coo2csr, coo_to_csc_index
+
+            indptr, indices, _ = coo2csr(
+                np.array([0, 2, 1, 0, 2]), np.array([0, 3, 1, 2, 0]), shape=(3, 4))
+            assert np.asarray(indices).dtype == np.int32, np.asarray(indices).dtype
+            assert list(np.asarray(indptr)) == [0, 2, 3, 5], list(np.asarray(indptr))
+
+            csc_indptr, _, _ = coo_to_csc_index(
+                np.array([0, 0, 1, 2, 2]), np.array([0, 2, 1, 0, 3]), shape=(3, 4))
+            assert np.asarray(csc_indptr).dtype == np.int32, np.asarray(csc_indptr).dtype
+
+            assert 'brainstate' not in sys.modules, 'brainstate was imported by brainevent'
+            print('OK')
+            """ % pkg_parent
+        )
+        proc = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
+        self.assertEqual(
+            proc.returncode, 0,
+            msg=f"subprocess failed.\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
+        self.assertIn('OK', proc.stdout)

--- a/brainevent/_version.py
+++ b/brainevent/_version.py
@@ -17,5 +17,5 @@
 
 __all__ = ["__version__", "__version_info__"]
 
-__version__ = "0.0.7"
+__version__ = "0.1.0"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-07
+
 ### Added
 
 - **Sparse row slicing** for `CSR`, `CSC`, `FixedNumPerPre`, and `FixedNumPerPost`:
@@ -156,7 +158,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSR solve test tolerances for numerical stability (#37)
 - CI configuration to use development requirements for CPU installation
 
-## [0.1.0] - 2025-05-02
+## [V0.1.0] - 2025-05-02 — GitHub tag only, never published to PyPI
+
+> **Historical note:** The `V0.1.0` git tag was published on GitHub on 2025-05-02
+> but was **never released to PyPI**. The PyPI distribution line continued as
+> `0.0.1.postN` → `0.0.2` … `0.0.7`; the first `0.1.0` published to PyPI is the
+> entry dated 2026-06-07 at the top of this file. This section is retained for
+> historical accuracy.
 
 ### Added
 - Just-In-Time Connectivity (JITC) matrix operators for CSR format (#18)
@@ -221,8 +229,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version Comparison Links
 
+- [0.1.0](https://github.com/chaobrain/brainevent/compare/v0.0.7...v0.1.0)
 - [0.0.7](https://github.com/chaobrain/brainevent/compare/v0.0.6...v0.0.7)
 - [0.0.6](https://github.com/chaobrain/brainevent/compare/v0.0.5...v0.0.6)
 - [0.0.5](https://github.com/chaobrain/brainevent/compare/V0.0.4...v0.0.5)
 - [0.0.4](https://github.com/chaobrain/brainevent/compare/V0.1.0...V0.0.4)
-- [0.1.0](https://github.com/chaobrain/brainevent/releases/tag/V0.1.0)
+- [V0.1.0 — GitHub tag, 2025-05-02, never published to PyPI](https://github.com/chaobrain/brainevent/releases/tag/V0.1.0)


### PR DESCRIPTION
- Bump __version__ 0.0.7 -> 0.1.0 (single source in brainevent/_version.py)
- Remove unguarded 'import brainstate.environ' from _misc.py; cast CSR/CSC
  index arrays with a locally-defined int32 dtype (brainevent's canonical
  index dtype) so 'import brainevent' no longer needs the undeclared
  brainstate dependency
- Add regression test (import works without brainstate) and dtype-contract
  tests for coo2csr / coo_to_csc_index
- changelog: promote [Unreleased] -> [0.1.0] (2026-06-07); relabel historical
  V0.1.0 entry as GitHub-tag-only (never published to PyPI)

## Summary by Sourcery

Release version 0.1.0 and decouple sparse index helpers from the optional brainstate dependency while enforcing their int32 index contract.

Bug Fixes:
- Ensure coo2csr and coo_to_csc_index consistently emit int32 index arrays for NumPy and JAX inputs, independent of input dtypes.
- Remove the implicit runtime dependency on the undeclared brainstate package from brainevent._misc index helpers.

Enhancements:
- Document and enforce the canonical int32 index dtype contract for sparse index helper functions.

Build:
- Bump the package version from 0.0.7 to 0.1.0 in the single source of truth.

Documentation:
- Update the changelog for the 0.1.0 release, clarify the historical V0.1.0 GitHub-only tag, and add a comparison link for the new version.

Tests:
- Add regression tests ensuring import brainevent works without brainstate present and validating int32 outputs from coo2csr and coo_to_csc_index across backends.