### PR TITLE
compat: keep v0.0.7 public API importable in 0.1.0 via deprecation shim

### DIFF
--- a/brainevent/__init__.py
+++ b/brainevent/__init__.py
@@ -251,3 +251,99 @@ __all__ = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Backward-compatibility shim for public names retired between v0.0.7 and 0.1.0.
+#
+# Retired names stay *resolvable* so v0.0.7 code keeps importing:
+#   * renamed names return their replacement and emit a ``DeprecationWarning``;
+#   * names whose underlying functionality was removed raise an
+#     ``AttributeError`` stating the concrete migration path.
+# These names are intentionally NOT part of ``__all__`` -- they are hidden,
+# deprecated aliases surfaced only on explicit access (PEP 562).
+# ---------------------------------------------------------------------------
+
+#: old public name -> (replacement object, replacement display name)
+_DEPRECATED_RENAMES = {
+    'EventArray': (BinaryArray, 'BinaryArray'),
+    'csr_on_pre': (update_csr_on_binary_pre, 'update_csr_on_binary_pre'),
+    'csr2csc_on_post': (update_csr_on_binary_post, 'update_csr_on_binary_post'),
+    'dense_on_pre': (update_dense_on_binary_pre, 'update_dense_on_binary_pre'),
+    'dense_on_post': (update_dense_on_binary_post, 'update_dense_on_binary_post'),
+    'JITCHomoR': (JITCScalarR, 'JITCScalarR'),
+    'JITCHomoC': (JITCScalarC, 'JITCScalarC'),
+    'FixedPostNumConn': (FixedNumPerPre, 'FixedNumPerPre'),
+    'FixedPreNumConn': (FixedNumPerPost, 'FixedNumPerPost'),
+}
+
+_COO_MIGRATION = (
+    'The COO sparse format was removed in brainevent 0.1.0. Use CSR / CSC '
+    'instead (brainevent.CSR / brainevent.CSC); convert indices with '
+    'brainevent.coo2csr or the *_index helpers (csr_to_coo_index, '
+    'coo_to_csc_index, csr_to_csc_index, csc_to_csr_index).'
+)
+_FCN_PACK_MIGRATION = (
+    'The explicit bitpack_/compact_ FCN kernels were removed in brainevent '
+    '0.1.0; they were unified into fcnmv / fcnmm, which dispatch on the input '
+    'event type. Wrap spikes with brainevent.BitPackedBinary or '
+    'brainevent.CompactBinary and call brainevent.fcnmv / brainevent.fcnmm.'
+)
+_LAYOUT_MIGRATION = (
+    'The fixed-number-connection layout abstraction was removed. Use '
+    'FixedNumPerPost / FixedNumPerPre directly (favorable/unfavorable dispatch '
+    'is now internal).'
+)
+
+#: old public name -> migration message (functionality removed, no drop-in)
+_DEPRECATED_REMOVED = {}
+_DEPRECATED_REMOVED.update({
+    name: _COO_MIGRATION for name in (
+        'COO',
+        'binary_coomv', 'binary_coomv_p',
+        'binary_coomm', 'binary_coomm_p',
+        'coomv', 'coomv_p',
+        'coomm', 'coomm_p',
+        'update_coo_on_binary_pre', 'update_coo_on_binary_post',
+        'update_coo_on_binary_pre_p', 'update_coo_on_binary_post_p',
+    )
+})
+_DEPRECATED_REMOVED.update({
+    name: _FCN_PACK_MIGRATION for name in (
+        'bitpack_binary_fcnmv', 'bitpack_binary_fcnmv_p',
+        'bitpack_binary_fcnmm', 'bitpack_binary_fcnmm_p',
+        'compact_binary_fcnmv', 'compact_binary_fcnmv_p',
+        'compact_binary_fcnmm', 'compact_binary_fcnmm_p',
+    )
+})
+_DEPRECATED_REMOVED.update({
+    'EllLayout': _LAYOUT_MIGRATION,
+    'CscLayout': _LAYOUT_MIGRATION,
+})
+
+
+def __getattr__(name):
+    """Resolve retired v0.0.7 public names (PEP 562 module-level hook)."""
+    import warnings
+    if name in _DEPRECATED_RENAMES:
+        replacement, new_name = _DEPRECATED_RENAMES[name]
+        warnings.warn(
+            f'brainevent.{name} is deprecated and will be removed in a future '
+            f'release; use brainevent.{new_name} instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return replacement
+    if name in _DEPRECATED_REMOVED:
+        raise AttributeError(
+            f'brainevent.{name} was removed in 0.1.0. {_DEPRECATED_REMOVED[name]}'
+        )
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+
+def __dir__():
+    return sorted(
+        set(globals())
+        | set(_DEPRECATED_RENAMES)
+        | set(_DEPRECATED_REMOVED)
+    )
+
+

--- a/brainevent/deprecation_test.py
+++ b/brainevent/deprecation_test.py
@@ -15,52 +15,89 @@
 
 # -*- coding: utf-8 -*-
 
-"""Tests pinning the removal of the module-level back-compat shim.
+"""Tests for the v0.0.7 -> v0.1.0 backward-compatibility shim.
 
-The package previously exposed a ``__getattr__`` deprecation layer that
-forwarded retired public names to their replacements. That layer has been
-removed (breaking change), so every retired name must now raise a plain
-:class:`AttributeError`, and the curated ``__all__`` must stay importable.
+Public names retired between v0.0.7 and v0.1.0 must stay *resolvable*:
+renamed names warn and return their replacement; names whose functionality was
+removed raise an :class:`AttributeError` naming the migration path. Normal
+``import brainevent`` must remain warning-free, and ``__all__`` must be unchanged.
 """
 
+import subprocess
+import sys
 import warnings
 
 import pytest
 
 import brainevent
 
+# old name -> attribute name of the replacement on the brainevent module.
+_RENAMES = {
+    "EventArray": "BinaryArray",
+    "csr_on_pre": "update_csr_on_binary_pre",
+    "csr2csc_on_post": "update_csr_on_binary_post",
+    "dense_on_pre": "update_dense_on_binary_pre",
+    "dense_on_post": "update_dense_on_binary_post",
+    "JITCHomoR": "JITCScalarR",
+    "JITCHomoC": "JITCScalarC",
+    "FixedPostNumConn": "FixedNumPerPre",
+    "FixedPreNumConn": "FixedNumPerPost",
+}
 
-# Names that used to warn-and-forward, plus the already-removed layout names.
-# All must now be plain attribute misses -- no shim, no forwarding.
-_REMOVED_NAMES = [
-    "EventArray",
-    "csr_on_pre",
-    "csr2csc_on_post",
-    "dense_on_pre",
-    "dense_on_post",
-    "JITCHomoC",
-    "JITCHomoR",
-    "FixedPostNumConn",
-    "FixedPreNumConn",
-    "EllLayout",
-    "CscLayout",
-]
+# old name -> a token that MUST appear in the AttributeError migration message.
+_REMOVED = {
+    # COO family -> CSR / CSC + coo2csr
+    "COO": "CSR",
+    "binary_coomv": "CSR", "binary_coomv_p": "CSR",
+    "binary_coomm": "CSR", "binary_coomm_p": "CSR",
+    "coomv": "CSR", "coomv_p": "CSR",
+    "coomm": "CSR", "coomm_p": "CSR",
+    "update_coo_on_binary_pre": "CSR", "update_coo_on_binary_post": "CSR",
+    "update_coo_on_binary_pre_p": "CSR", "update_coo_on_binary_post_p": "CSR",
+    # bitpack / compact FCN -> fcnmv / fcnmm
+    "bitpack_binary_fcnmv": "fcnmv", "bitpack_binary_fcnmv_p": "fcnmv",
+    "bitpack_binary_fcnmm": "fcnmv", "bitpack_binary_fcnmm_p": "fcnmv",
+    "compact_binary_fcnmv": "fcnmv", "compact_binary_fcnmv_p": "fcnmv",
+    "compact_binary_fcnmm": "fcnmv", "compact_binary_fcnmm_p": "fcnmv",
+    # layout objects
+    "EllLayout": "FixedNumPer", "CscLayout": "FixedNumPer",
+}
+
+# The 23 names exported by brainevent 0.0.7 ``__all__`` that are absent from 0.1.0.
+_V007_REMOVED_FROM_ALL = {
+    "COO", "binary_coomv", "binary_coomv_p", "binary_coomm", "binary_coomm_p",
+    "coomv", "coomv_p", "coomm", "coomm_p",
+    "update_coo_on_binary_pre", "update_coo_on_binary_post",
+    "update_coo_on_binary_pre_p", "update_coo_on_binary_post_p",
+    "FixedPreNumConn", "FixedPostNumConn",
+    "bitpack_binary_fcnmv", "bitpack_binary_fcnmv_p",
+    "bitpack_binary_fcnmm", "bitpack_binary_fcnmm_p",
+    "compact_binary_fcnmv", "compact_binary_fcnmv_p",
+    "compact_binary_fcnmm", "compact_binary_fcnmm_p",
+}
 
 
-@pytest.mark.parametrize("name", _REMOVED_NAMES)
-def test_removed_name_raises_attributeerror(name):
-    with pytest.raises(AttributeError):
-        getattr(brainevent, name)
+@pytest.mark.parametrize("old, new", list(_RENAMES.items()))
+def test_renamed_name_warns_and_forwards(old, new):
+    with pytest.warns(DeprecationWarning):
+        obj = getattr(brainevent, old)
+    assert obj is getattr(brainevent, new)
 
 
-@pytest.mark.parametrize("name", _REMOVED_NAMES)
-def test_removed_name_does_not_warn(name):
-    # The shim is gone, so accessing a retired name must not emit a deprecation
-    # warning -- it is simply absent.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        with pytest.raises(AttributeError):
-            getattr(brainevent, name)
+@pytest.mark.parametrize("old", list(_RENAMES))
+def test_renamed_name_importable_via_from(old):
+    # PEP 562 module __getattr__ also powers ``from brainevent import <old>``.
+    with pytest.warns(DeprecationWarning):
+        module = __import__("brainevent", fromlist=[old])
+        assert getattr(module, old) is not None
+
+
+@pytest.mark.parametrize("old, token", list(_REMOVED.items()))
+def test_removed_name_raises_with_migration(old, token):
+    with pytest.raises(AttributeError) as excinfo:
+        getattr(brainevent, old)
+    message = str(excinfo.value)
+    assert token in message, f"{old}: expected {token!r} in message: {message}"
 
 
 def test_unknown_attribute_raises_plain_attributeerror():
@@ -68,8 +105,28 @@ def test_unknown_attribute_raises_plain_attributeerror():
         _ = brainevent.this_symbol_does_not_exist
 
 
-def test_dir_lists_public_exports():
-    # The curated __all__ should be a subset of the importable names, so a
-    # plain ``import brainevent; brainevent.<name>`` works for every export.
+def test_fresh_import_emits_no_warning():
+    # A clean interpreter importing brainevent with warnings-as-errors must
+    # succeed: deprecation warnings fire only on deprecated-name access.
+    code = "import warnings; warnings.simplefilter('error'); import brainevent"
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_all_exports_resolve_and_are_stable():
+    assert len(brainevent.__all__) == 154
     for name in brainevent.__all__:
         assert hasattr(brainevent, name), name
+
+
+def test_all_v007_removed_names_have_backcompat():
+    covered = set(_RENAMES) | set(_REMOVED)
+    missing = _V007_REMOVED_FROM_ALL - covered
+    assert not missing, f"v0.0.7 names without backward-compat: {missing}"
+    # A name must not be both a rename and a removed-with-error entry.
+    assert not (set(_RENAMES) & set(_REMOVED))
+    # Deprecated names stay hidden from the curated public surface.
+    for name in covered:
+        assert name not in brainevent.__all__

--- a/changelog.md
+++ b/changelog.md
@@ -7,50 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+## [0.1.0] - 2026-06-07
+
+First stable feature release of `BrainEvent` on PyPI. It consolidates the
+event-driven data structures (binary / bit-packed / compact events; `CSR` / `CSC`,
+fixed-number connectivity, and just-in-time connectivity matrices) behind a
+single, uniform API, ships inline type information, and retires the legacy names
+accumulated during the `0.0.x` series.
+
+> **Not to be confused with the historical `V0.1.0` git tag** (2025-05-02), which
+> was tagged on GitHub but never published to PyPI. The PyPI line ran
+> `0.0.1.postN` → … → `0.0.7`; this `0.1.0` is the first `0.1.0` distributed on
+> PyPI. See the `[V0.1.0]` section below for the historical note.
+
+**Requirements:** Python ≥ 3.11, `jax` ≥ 0.5.0, `brainunit` ≥ 0.0.8, `numpy`,
+`absl-py`.
+
+### ⚠️ Breaking changes & migration
+
+This release standardizes naming, but **retains a backward-compatibility shim** so
+every public name exported by v0.0.7 stays importable (see _Deprecated_ below).
+Renamed symbols forward to their replacement with a `DeprecationWarning`; names
+whose underlying functionality was removed raise an `AttributeError` that names the
+replacement. Recommended updates:
+
+| Deprecated / changed name | Replacement / migration |
+| --- | --- |
+| `EventArray` | `BinaryArray` |
+| `JITCHomoR` / `JITCHomoC` | `JITCScalarR` / `JITCScalarC` |
+| `FixedPostNumConn` / `FixedPreNumConn` | `FixedNumPerPre` / `FixedNumPerPost` |
+| `FixedNumConn.to_csr` / `to_csc` / `to_dense` | `tocsr` / `tocsc` / `todense` |
+| `csr_on_pre`, `csr2csc_on_post`, `dense_on_pre`, `dense_on_post` | `update_csr_on_binary_pre`, `update_csc_on_binary_post`, `update_dense_on_binary_pre`, `update_dense_on_binary_post` |
+| `EllLayout` / `CscLayout` | (removed — use the canonical representations) |
+| `COO` sparse class & operators | `CSR` / `CSC` (+ `coo2csr` and the `*_index` helpers) |
+| `CSC.__getitem__(i)` → column `i` | now returns **row** `i`; use `csc.transpose()[i]` or `csc.todense()[:, i]` for the old result |
+| `JITCScalar*` / `JITCNormal*` / `JITCUniform*` `.fromdense` / `yw_to_w` / `update_on_*` | materialize with `.tocsr()` first, then operate |
+
+`import brainevent` no longer pulls in `brainstate`.
+
 ### Added
 
-- **Common-API contract on `DataRepresentation`**: every concrete data
-  representation now exposes (or deliberately refuses) a uniform conversion and
+- **Uniform common-API contract on `DataRepresentation`**: every concrete data
+  representation now exposes (or deliberately refuses) a single conversion and
   neural-plasticity surface — `fromdense`, `todense`, `tocoo`, `tocsr`, `tocsc`,
   `yw_to_w`, `yw_to_w_transposed`, `update_on_pre`, `update_on_post`. The base
-  class declares stubs so missing overrides fail loudly rather than silently
-  inheriting an unrelated implementation.
-- **`UnsupportedOperationError`** (subclass of `BrainEventError`): raised when an
-  operation is structurally meaningless for a representation, distinct from
-  `NotImplementedError`. The JIT-connectivity matrices (`JITCScalar*`,
-  `JITCNormal*`, `JITCUniform*`) raise it for `fromdense`, `yw_to_w`,
-  `yw_to_w_transposed`, `update_on_pre`, and `update_on_post`, pointing callers
-  to `.tocsr()` for a materialized, plastic representation.
+  class declares stubs so a missing override fails loudly rather than silently
+  inheriting an unrelated implementation (#161).
+- **Format conversions** `tocsr` / `tocsc` / `tocoo` for `CSR`, `CSC`,
+  `FixedNumPerPre`, `FixedNumPerPost`, and the JIT-connectivity matrices (the
+  latter materialize eagerly via `tocsr` and delegate the rest). CSR/CSC
+  conversions are `jax.jit`-safe (#153, #161).
 - **`FixedNumPerPre.fromdense` / `FixedNumPerPost.fromdense`**: build a
   fixed-num-connection matrix from a dense array. With `num_conn=None` the dense
   matrix must have a uniform per-row (per-column) non-zero count; passing
   `num_conn` pads short rows with in-range zero-weight sentinels and raises
-  `ValueError` on overflow. Units are preserved.
-- **Format conversions** `tocsr` / `tocsc` / `tocoo` for `CSR`, `CSC`,
-  `FixedNumPerPre`, `FixedNumPerPost`, and the JIT-connectivity matrices (the
-  latter materialize eagerly via `tocsr` and delegate the rest). CSR/CSC
-  conversions are `jax.jit`-safe.
-
-### Changed
-
-- **`FixedNumConn` conversion methods renamed to the no-underscore canonical
-  form** (scipy/saiunit convention): `to_csr` → `tocsr`, `to_csc` → `tocsc`,
-  `to_dense` → `todense`. **Breaking** — no aliases are kept (see Removed).
-
-### Removed
-
-- **Breaking: `FixedNumConn.to_csr` / `to_csc` / `to_dense` aliases removed.**
-  Use `tocsr` / `tocsc` / `todense`.
-- **Breaking: the module-level `__getattr__` deprecation shim removed.** The
-  retired names it forwarded (`EventArray`, `csr_on_pre`, `csr2csc_on_post`,
-  `dense_on_pre`, `dense_on_post`, `JITCHomoC`, `JITCHomoR`, `FixedPostNumConn`,
-  `FixedPreNumConn`, `EllLayout`, `CscLayout`) now raise a plain
-  `AttributeError` with no deprecation warning.
-
-## [0.1.0] - 2026-06-07
-
-### Added
-
+  `ValueError` on overflow. Physical units are preserved (#161).
 - **Sparse row slicing** for `CSR`, `CSC`, `FixedNumPerPre`, and `FixedNumPerPost`:
   a dense `__getitem__` returning row(s) of the logical matrix `W` with full NumPy
   index semantics (`int` / `list` / `tuple` / `array` / Python `slice`, negative-index
@@ -58,13 +71,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `slice_rows(index)` returning `W[rows, :]`
   (`CSR`→`CSR`, `CSC`→`CSC`, `FixedNumPerPre`→`FixedNumPerPre`, `FixedNumPerPost`→`CSR`).
   `FixedNumPerPre.slice_rows` is `jax.jit`-safe; the other `slice_rows` paths have a
-  data-dependent number of non-zeros and must run outside `jax.jit`.
+  data-dependent number of non-zeros and must run outside `jax.jit` (#145).
+- **`UnsupportedOperationError`** (subclass of `BrainEventError`): raised when an
+  operation is structurally meaningless for a representation, distinct from
+  `NotImplementedError`. The JIT-connectivity matrices (`JITCScalar*`,
+  `JITCNormal*`, `JITCUniform*`) raise it for `fromdense`, `yw_to_w`,
+  `yw_to_w_transposed`, `update_on_pre`, and `update_on_post`, pointing callers
+  to `.tocsr()` for a materialized, plastic representation (#161).
+- **PEP 561 inline type information**: ships a `py.typed` marker so downstream
+  type checkers consume `brainevent`'s annotations. Public-API type hints and
+  NumPy-style docstrings were completed across the package, guarded by a mypy
+  CI ratchet (#151).
 
 ### Changed
 
-- **`CSC.__getitem__` now returns row `i` of `W`** (NumPy semantics) instead of column
-  `i`. This is a breaking change for code relying on the previous column-indexing
-  behavior; use `csc.transpose()[i]` or `csc.todense()[:, i]` for the old result.
+- **`FixedNumConn` conversion methods renamed to the no-underscore canonical
+  form** (scipy / `saiunit` convention): `to_csr` → `tocsr`, `to_csc` → `tocsc`,
+  `to_dense` → `todense`. **Breaking** — no aliases are kept (#148, #161).
+- **`CSC.__getitem__` now returns row `i` of `W`** (NumPy semantics) instead of
+  column `i`. **Breaking** for code relying on the previous column-indexing
+  behavior (#145).
+- **`brainstate` dropped from the core import path**: importing `brainevent` no
+  longer imports `brainstate`, removing it as an implicit runtime dependency of
+  the core package (#159).
+- **Documentation reorganized into the Diátaxis structure** (tutorials / how-to /
+  reference / explanation); the README was updated to match the current public
+  API (#149, #152, #155).
+- **Internal CSR / JIT kernel layout**: `_jit_conn_csr` split into per-distribution
+  submodules, with JIT-matrix `.tocsr()` backed by dedicated CPU / CUDA operators
+  (#153, #160).
+
+### Deprecated
+
+- **Backward-compatibility shim for every v0.0.7 public name.** A module-level
+  `__getattr__` keeps the entire v0.0.7 import surface resolvable. Renamed symbols
+  emit a `DeprecationWarning` and forward to their replacement (slated for removal
+  in a future major release):
+  `EventArray` → `BinaryArray`;
+  `JITCHomoR` / `JITCHomoC` → `JITCScalarR` / `JITCScalarC`;
+  `FixedPostNumConn` / `FixedPreNumConn` → `FixedNumPerPre` / `FixedNumPerPost`;
+  `csr_on_pre` / `csr2csc_on_post` / `dense_on_pre` / `dense_on_post` → the
+  corresponding `update_*_on_binary_*` functions. Names whose functionality was
+  removed — the `COO` class & operators, the `bitpack_` / `compact_` FCN kernels,
+  and `EllLayout` / `CscLayout` — raise an `AttributeError` that names the
+  replacement instead of failing silently.
+
+### Removed
+
+- **`COO` sparse format class and its operators** removed; accessing them now
+  raises a guided `AttributeError`. Use `CSR` / `CSC` together with the `coo2csr`
+  helper and the `*_index` conversion utilities (`csr_to_coo_index`,
+  `coo_to_csc_index`, `csr_to_csc_index`, `csc_to_csr_index`) for index
+  manipulation (#124).
+- **Explicit `bitpack_` / `compact_` FCN kernels** removed; they were unified into
+  `fcnmv` / `fcnmm`, which dispatch on the input event type. Wrap spikes with
+  `BitPackedBinary` / `CompactBinary` and call `fcnmv` / `fcnmm`.
+- **`FixedNumConn.to_csr` / `to_csc` / `to_dense`** (added and renamed within the
+  0.1.0 cycle, never shipped in a release) standardized to `tocsr` / `tocsc` /
+  `todense` (#148, #161).
+- **cuSPARSE-based CSR SpMV / SpMM kernel implementations** removed in favor of
+  the native CUDA / JAX kernel paths (internal; no public-API change).
 
 ## [0.0.7] - 2026-03-12
 


### PR DESCRIPTION
Re-introduce a module-level __getattr__ (PEP 562) so every public name exported
by brainevent v0.0.7 remains resolvable in 0.1.0:

- Renamed names (EventArray, JITCHomoR/C, FixedPostNumConn/FixedPreNumConn,
  csr_on_pre/csr2csc_on_post/dense_on_pre/dense_on_post) emit a
  DeprecationWarning and forward to their replacement.
- Names whose functionality was removed (COO class & operators, bitpack_/compact_
  FCN kernels, EllLayout/CscLayout) raise an AttributeError that names the
  migration path instead of failing silently.

__all__ is unchanged (154 names); deprecated names stay hidden. Rewrites
deprecation_test.py to pin the new behavior and updates the changelog.

## Summary by Sourcery

Reintroduce a module-level deprecation shim so all public names from v0.0.7 remain importable in 0.1.0, with renamed symbols warning-and-forwarding and removed functionality raising migration-guiding errors, and update tests and changelog to document and enforce this behavior.

Bug Fixes:
- Restore backward-compatibility for v0.0.7 public API symbols that were unintentionally made unavailable in 0.1.0.

Enhancements:
- Add a PEP 562-based module-level __getattr__ and __dir__ to provide deprecation-backed aliases for renamed and removed public symbols.
- Refine changelog entries to describe 0.1.0 breaking changes, deprecations, and migration paths more clearly and accurately.
- Expand and rewrite deprecation tests to cover renamed symbols, removed symbols with guided AttributeErrors, stable __all__ exports, and warning-free imports.