### PR TITLE
fix(_op,include): harden JAX custom-op FFI bridges and C++/CUDA headers

### DIFF
--- a/brainevent/_compatible_import.py
+++ b/brainevent/_compatible_import.py
@@ -16,6 +16,7 @@
 __all__ = [
     'Primitive',
     'Tracer',
+    'apply_primitive',
     'init_zero',
     'pallas_triton_params',
     'pallas_mosaic_tpu_params',
@@ -23,6 +24,16 @@ __all__ = [
 
 import jax
 from jax.interpreters import ad
+
+# ``apply_primitive`` is the eager (impl) evaluator for a primitive.  It has
+# lived at ``jax.interpreters.xla.apply_primitive`` for a long time but that
+# module is a thinning legacy shim; newer jax exposes the same function from
+# ``jax._src.dispatch``.  Resolve it once here so a jax version bump only needs
+# a change in this file rather than at every ``def_impl`` call site (L3).
+try:
+    from jax.interpreters.xla import apply_primitive
+except (ImportError, AttributeError):  # pragma: no cover - version-dependent path
+    from jax._src.dispatch import apply_primitive
 
 
 def pallas_triton_params():

--- a/brainevent/_op/kernix_cache.py
+++ b/brainevent/_op/kernix_cache.py
@@ -27,12 +27,18 @@ from brainevent._version import __version__
 class CompilationCache:
     """Persistent, filesystem-backed compilation cache.
 
-    The cache key is a SHA-256 digest of:
-    - User CUDA source code
-    - jax-kernel-bridge version
-    - nvcc version string
+    The cache key is a SHA-256 digest, truncated to the first 16 hex digits
+    (64-bit collision domain), of:
+
+    - User CUDA / C++ source code
+    - ``brainevent`` version
+    - ``jaxlib`` version (the FFI ABI moves with jaxlib)
+    - nvcc / host-compiler version string
     - GPU architecture
     - Extra compiler / linker flags
+    - Extra include paths (``-I`` search dirs change which headers win)
+    - Byte hashes of the injected headers (``ffi_compat.h`` and jaxlib's
+      ``ffi.h``), so an editable header edit or a jaxlib ABI bump rebuilds.
 
     Cached artefacts are stored under
     ``<base_dir>/<name>_<key>/module.so``.
@@ -55,15 +61,81 @@ class CompilationCache:
         cxx_version: str = "",
         extra_cflags: list[str] | None = None,
         extra_ldflags: list[str] | None = None,
+        extra_include_paths: list[str] | None = None,
+        header_paths: list[str] | None = None,
+        jaxlib_version: str | None = None,
     ) -> str:
-        """Compute a deterministic cache key."""
+        """Compute a deterministic cache key for a compiled artefact.
+
+        Parameters
+        ----------
+        source : str
+            Preprocessed/user source code that will be compiled.
+        arch : str
+            Target architecture token(s) (e.g. ``"sm_86+sm_90"`` or ``"cpu"``).
+        cxx_version : str, optional
+            Host-compiler / nvcc version string.  Two compilers with different
+            versions must not share a cache entry.
+        extra_cflags, extra_ldflags : list of str, optional
+            Extra compiler / linker flags.  Hashed as a sorted JSON list.
+        extra_include_paths : list of str, optional
+            Additional ``-I`` header search paths.  These change which header a
+            given ``#include`` resolves to, so two otherwise-identical builds
+            with different include dirs must get **different** keys (a shadowing
+            header would otherwise yield a wrong cached ``.so``).  Hashed as a
+            sorted JSON list.
+        header_paths : list of str, optional
+            Filesystem paths of injected headers whose **byte contents** affect
+            the build (``brainevent``'s ``ffi_compat.h`` and jaxlib's
+            ``xla/ffi/api/ffi.h``).  Each file is SHA-256-hashed so an editable
+            header edit, or a jaxlib upgrade that rewrites ``ffi.h``, forces a
+            rebuild.  Missing/unreadable files contribute a sentinel rather than
+            raising, so key computation never fails on a transient read error.
+        jaxlib_version : str, optional
+            ``jaxlib.__version__``.  The FFI ABI moves with jaxlib, so a jaxlib
+            upgrade (same ``brainevent`` version, same source) must rebuild.
+            Imported lazily when ``None`` so the key always reflects the
+            installed jaxlib; pass an explicit value to override (e.g. tests).
+
+        Returns
+        -------
+        str
+            The first 16 hex digits (64-bit truncation) of the SHA-256 digest.
+            64 bits is ample for a per-machine on-disk cache; the truncation
+            keeps directory names short.  Collisions are astronomically
+            unlikely but theoretically possible within this 64-bit domain.
+
+        Notes
+        -----
+        New parameters are optional with backward-compatible defaults so legacy
+        callers keep working; an omitted input simply contributes its empty
+        sentinel to the digest.
+        """
+        if jaxlib_version is None:
+            try:
+                import jaxlib
+                jaxlib_version = jaxlib.__version__
+            except Exception:
+                jaxlib_version = ""
+
         h = hashlib.sha256()
         h.update(source.encode())
         h.update(arch.encode())
         h.update(cxx_version.encode())
         h.update(__version__.encode())
+        h.update(jaxlib_version.encode())
         h.update(json.dumps(extra_cflags or [], sort_keys=True).encode())
         h.update(json.dumps(extra_ldflags or [], sort_keys=True).encode())
+        h.update(json.dumps(extra_include_paths or [], sort_keys=True).encode())
+        # Byte-hash each injected header (sorted for determinism) so the key
+        # tracks header *contents*, not just the brainevent version proxy.
+        for path in sorted(header_paths or []):
+            h.update(path.encode())
+            try:
+                h.update(hashlib.sha256(Path(path).read_bytes()).hexdigest().encode())
+            except OSError:
+                h.update(b"<unreadable>")
+        # Truncate to 64 bits; see the Returns/Notes above for the rationale.
         return h.hexdigest()[:16]
 
     def cache_dir_for(self, name: str, key: str) -> Path:
@@ -83,12 +155,44 @@ class CompilationCache:
             return so_path
         return None
 
-    def store(self, name: str, key: str, so_path: str) -> Path:
+    def store(
+        self,
+        name: str,
+        key: str,
+        so_path: str,
+        source_is_user_dir: bool = False,
+    ) -> Path:
         """Atomically publish a built shared lib into the cache.
 
-        The artefact is moved (or copied across filesystems) into a temp file
-        next to the destination, then ``os.replace``-d into place so concurrent
-        readers never observe a partially written library.
+        The artefact is staged into a pid-suffixed temp file next to the
+        destination, then ``os.replace``-d into place so concurrent readers
+        never observe a partially written library.
+
+        Parameters
+        ----------
+        name : str
+            Module name; the published file is ``<name><ext>``.
+        key : str
+            Cache key identifying the destination directory.
+        so_path : str
+            Path to the freshly built shared library to publish.
+        source_is_user_dir : bool, optional
+            When ``True``, *so_path* lives in a caller-supplied
+            ``build_directory`` and therefore belongs to the user: the source
+            is **copied** rather than moved, so the caller's artefact is left
+            in place.  When ``False`` (default) the source is a throwaway
+            internal build dir and may be moved.
+
+        Returns
+        -------
+        Path
+            Path to the published shared library inside the cache.
+
+        Notes
+        -----
+        The staging temp file is removed via ``try/finally`` if the final
+        publish (or staging) raises, so a failed ``store`` never leaks a
+        ``.tmp`` artefact into the cache directory.
         """
         dest_dir = self.cache_dir_for(name, key)
         dest_dir.mkdir(parents=True, exist_ok=True)
@@ -98,10 +202,22 @@ class CompilationCache:
             return dest
         tmp = dest_dir / f".{name}.{os.getpid()}.tmp{self._ext()}"
         try:
-            os.replace(src, tmp)            # same-filesystem atomic move
-        except OSError:
-            shutil.copy2(src, tmp)          # cross-filesystem fallback
-        os.replace(tmp, dest)               # atomic publish
+            if source_is_user_dir:
+                # User-owned artefact: copy so we never relocate the caller's file.
+                shutil.copy2(src, tmp)
+            else:
+                try:
+                    os.replace(src, tmp)        # same-filesystem atomic move
+                except OSError:
+                    shutil.copy2(src, tmp)      # cross-filesystem fallback
+            os.replace(tmp, dest)               # atomic publish
+        finally:
+            # If staging or publish failed, drop the temp file (best-effort).
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
         return dest
 
     # ------------------------------------------------------------------
@@ -116,9 +232,19 @@ class CompilationCache:
         if not self.base_dir.exists():
             return 0
         for entry in self.base_dir.iterdir():
-            if not entry.is_dir():
-                continue
             if name is not None and not entry.name.startswith(f"{name}_"):
+                continue
+            # A symlink would pass ``is_dir()`` (it follows the link), but
+            # ``shutil.rmtree`` raises on a symlink.  Unlink the link itself
+            # (never its target) and count it as a real removal.
+            if entry.is_symlink():
+                try:
+                    entry.unlink()
+                except OSError:
+                    continue
+                removed += 1
+                continue
+            if not entry.is_dir():
                 continue
             shutil.rmtree(entry, ignore_errors=True)
             removed += 1

--- a/brainevent/_op/kernix_cache_audit_test.py
+++ b/brainevent/_op/kernix_cache_audit_test.py
@@ -1,0 +1,257 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Reproduction tests for the cache audit findings H4, M6 and L5.
+
+These tests are hermetic: they exercise ``CompilationCache`` directly (the
+cache key is a pure function; the filesystem operations use ``tmp_path``) and
+do **not** require nvcc, a host compiler, or a GPU.  Run with::
+
+    python -m pytest brainevent/_op/kernix_cache_audit_test.py -m "" -q
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from brainevent._op.kernix_cache import CompilationCache
+
+
+# ---------------------------------------------------------------------------
+# H4 — cache key must include extra_include_paths, header byte-contents,
+#      and the jaxlib version.
+# ---------------------------------------------------------------------------
+
+def test_h4a_key_depends_on_extra_include_paths(tmp_path):
+    """Two keys differing ONLY in ``extra_include_paths`` must differ.
+
+    A shadowing header on a different ``-I`` path can change the compiled
+    binary, so the include search path must be part of the cache key.
+    """
+    cache = CompilationCache(base_dir=str(tmp_path))
+    common = dict(source="__global__ void k(){}", arch="sm_80")
+
+    key_a = cache.cache_key(**common, extra_include_paths=["/opt/a/include"])
+    key_b = cache.cache_key(**common, extra_include_paths=["/opt/b/include"])
+
+    assert key_a != key_b
+
+
+def test_h4b_key_depends_on_header_bytes(tmp_path):
+    """Mutating the bytes of a hashed header file must change the key.
+
+    ``__version__`` is only a proxy for the injected headers and does not move
+    during an editable install, so the header *contents* must be hashed.
+    """
+    cache = CompilationCache(base_dir=str(tmp_path))
+    header = tmp_path / "ffi_compat.h"
+    header.write_text("#define ABI 1\n")
+    common = dict(source="int main(){}", arch="cpu")
+
+    key_before = cache.cache_key(**common, header_paths=[str(header)])
+    header.write_text("#define ABI 2\n")  # struct layout / macro change
+    key_after = cache.cache_key(**common, header_paths=[str(header)])
+
+    assert key_before != key_after
+
+
+def test_h4c_key_depends_on_jaxlib_version(monkeypatch, tmp_path):
+    """A different ``jaxlib.__version__`` must change the key.
+
+    ``pip install -U jaxlib`` changes the FFI ABI but reuses the cache dir; the
+    jaxlib version must therefore participate in the key.
+    """
+    import jaxlib
+
+    cache = CompilationCache(base_dir=str(tmp_path))
+    common = dict(source="int main(){}", arch="cpu")
+
+    monkeypatch.setattr(jaxlib, "__version__", "0.9.1", raising=False)
+    key_old = cache.cache_key(**common)
+    monkeypatch.setattr(jaxlib, "__version__", "0.10.0", raising=False)
+    key_new = cache.cache_key(**common)
+
+    assert key_old != key_new
+
+
+def test_h4_defaults_backward_compatible(tmp_path):
+    """The new parameters are optional: the legacy call signature still works."""
+    cache = CompilationCache(base_dir=str(tmp_path))
+    # Must not raise and must return a 16-hex key.
+    key = cache.cache_key(
+        source="int main(){}",
+        arch="cpu",
+        cxx_version="g++ 11",
+        extra_cflags=["-O3"],
+        extra_ldflags=["-lm"],
+    )
+    assert isinstance(key, str)
+    assert len(key) == 16
+    int(key, 16)  # valid hex
+
+
+def test_h4_cache_header_paths_covers_every_brainevent_header():
+    """``_cache_header_paths`` hashes *all* injected headers, not just ffi_compat.h.
+
+    A semantics change in ``check.h`` (abort -> throw), ``tensor.h`` (bounds
+    guards) or ``cuda_common.h`` must rebuild even when the ``brainevent``
+    version string is unchanged (editable installs), so the pipeline must feed
+    every brainevent header — both the ``brainevent/`` subdir and the top-level
+    headers — into the cache key.
+    """
+    import types
+    import brainevent
+    from brainevent._op.kernix_pipeline import _cache_header_paths
+
+    be_inc = os.path.join(os.path.dirname(brainevent.__file__), "include")
+    # ``xla_ffi_include_dir`` points at a non-existent tree: ffi.h is simply
+    # skipped (missing files are tolerated), isolating the brainevent coverage.
+    toolchain = types.SimpleNamespace(
+        brainevent_include_dir=be_inc,
+        xla_ffi_include_dir="/nonexistent-xla-include",
+    )
+
+    paths = _cache_header_paths(toolchain)
+    names = {os.path.basename(p) for p in paths}
+
+    # Headers from the ``brainevent/`` subdir and the top-level include root.
+    for required in ("ffi_compat.h", "check.h", "tensor.h", "dtypes.h", "cuda_common.h"):
+        assert required in names, f"{required} missing from cache header set: {names}"
+    # Every returned path must actually exist (missing entries are filtered out).
+    for path in paths:
+        assert os.path.isfile(path)
+
+
+# ---------------------------------------------------------------------------
+# M6 — clear() symlink handling; store() tmp leak / user-artifact move.
+# ---------------------------------------------------------------------------
+
+def test_m6a_clear_removes_and_counts_symlink_once(tmp_path):
+    """A symlinked cache entry must be removed and counted exactly once.
+
+    ``entry.is_dir()`` follows symlinks, so the old gate let a symlink through
+    to ``shutil.rmtree`` (which raises on a symlink), leaving it on disk while
+    still counting it as removed.
+    """
+    base = tmp_path / "cache"
+    base.mkdir()
+    cache = CompilationCache(base_dir=str(base))
+
+    # A real entry + a symlink entry pointing outside the cache.
+    real_entry = base / "mod_realkey0000000"
+    real_entry.mkdir()
+    (real_entry / "mod.so").write_bytes(b"\x00")
+
+    outside = tmp_path / "outside_target"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("precious")
+    link_entry = base / "mod_linkkey0000000"
+    link_entry.symlink_to(outside, target_is_directory=True)
+
+    removed = cache.clear("mod")
+
+    assert removed == 2, f"expected 2 real removals, got {removed}"
+    assert not link_entry.exists() or not link_entry.is_symlink()
+    assert not real_entry.exists()
+    # The symlink target (a user dir) must survive — only the link is removed.
+    assert outside.exists() and (outside / "keep.txt").read_text() == "precious"
+
+
+def test_m6b_store_failure_leaves_no_tmp(tmp_path, monkeypatch):
+    """If the atomic publish fails, ``store()`` must not leak a ``.tmp`` file."""
+    base = tmp_path / "cache"
+    cache = CompilationCache(base_dir=str(base))
+
+    src = tmp_path / "build" / "mod.so"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"BINARY")
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(a, b):
+        # First call = move/stage into tmp (allow); second = publish (fail).
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise OSError("simulated publish failure")
+        return real_replace(a, b)
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+
+    with pytest.raises(OSError):
+        cache.store("mod", "key0000000000000", str(src))
+
+    dest_dir = cache.cache_dir_for("mod", "key0000000000000")
+    leftover = list(dest_dir.glob("*.tmp*")) if dest_dir.exists() else []
+    assert leftover == [], f"leaked tmp files: {leftover}"
+
+
+def test_m6c_store_does_not_relocate_user_build_dir(tmp_path):
+    """``store()`` must COPY (not move) a user-supplied build artifact.
+
+    With a user ``build_directory`` the source ``.so`` belongs to the caller;
+    moving it silently relocates their file into the cache.
+    """
+    base = tmp_path / "cache"
+    cache = CompilationCache(base_dir=str(base))
+
+    user_build = tmp_path / "user_build"
+    user_build.mkdir()
+    src = user_build / "mod.so"
+    src.write_bytes(b"USER_ARTIFACT")
+
+    dest = cache.store(
+        "mod", "key0000000000001", str(src), source_is_user_dir=True
+    )
+
+    assert Path(dest).exists()
+    assert src.exists(), "store() deleted/relocated the caller's source file"
+    assert src.read_bytes() == b"USER_ARTIFACT"
+
+
+def test_m6c_store_may_move_internal_tmp_build(tmp_path):
+    """For an internal (non-user) build dir, moving the source is fine.
+
+    The default behaviour preserves the previous optimisation of moving the
+    just-built artifact out of a throwaway build dir.
+    """
+    base = tmp_path / "cache"
+    cache = CompilationCache(base_dir=str(base))
+
+    src = tmp_path / "internal_build" / "mod.so"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"TMP_ARTIFACT")
+
+    dest = cache.store("mod", "key0000000000002", str(src))
+
+    assert Path(dest).exists()
+    assert Path(dest).read_bytes() == b"TMP_ARTIFACT"
+
+
+# ---------------------------------------------------------------------------
+# L5 — docstring / truncation documentation (smoke checks).
+# ---------------------------------------------------------------------------
+
+def test_l5_key_is_64bit_truncated(tmp_path):
+    """The published key is a 16-hex (64-bit) truncation of the SHA-256 digest."""
+    cache = CompilationCache(base_dir=str(tmp_path))
+    key = cache.cache_key(source="x", arch="cpu")
+    assert len(key) == 16
+
+
+def test_l5_docstring_no_longer_says_jax_kernel_bridge():
+    """The stale 'jax-kernel-bridge version' wording must be gone."""
+    assert "jax-kernel-bridge" not in (CompilationCache.__doc__ or "")

--- a/brainevent/_op/kernix_check_propagation_test.py
+++ b/brainevent/_op/kernix_check_propagation_test.py
@@ -1,0 +1,104 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""End-to-end test for host-side check propagation (H3).
+
+A failing ``BE_CHECK`` / ``BE_CUDA_CHECK`` in host code must throw
+``BE::CheckError`` / ``BE::CudaError``, which the auto-generated FFI wrapper
+catches and converts to an ``xla::ffi::Error``.  JAX then raises a normal
+Python exception.  The old behaviour called ``abort()``, killing the whole
+interpreter with ``SIGABRT``.
+
+The proof that the process survives is implicit: if the kernel aborted, this
+pytest process would die and the test could never report ``assertRaises``
+success.
+"""
+
+import platform
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import brainevent
+
+if platform.platform().startswith('Windows'):
+    pytest.skip(reason="Windows is not supported yet.", allow_module_level=True)
+
+# A CPU kernel that fails a host-side invariant.  ``x.numel()`` is always
+# non-negative, so ``x.numel() < 0`` is always false and the check fires at
+# runtime (the compiler cannot prove it away from the source alone).
+CHECK_FAIL_SRC = r"""
+#include "brainevent/common.h"
+
+void check_fail_cpu(const BE::Tensor x, BE::Tensor y) {
+    BE_CHECK(x.numel() < 0) << "intentional failure: numel=" << x.numel();
+    float* out_ptr = static_cast<float*>(y.data_ptr());
+    out_ptr[0] = 1.0f;  // unreachable
+}
+"""
+
+
+def test_host_check_failure_raises_not_aborts():
+    """A failing BE_CHECK surfaces as a Python exception (no SIGABRT)."""
+    mod = brainevent.load_cpp_inline(
+        name="test_cpu_check_fail",
+        cpp_sources=CHECK_FAIL_SRC,
+        functions=["check_fail_cpu"],
+        force_rebuild=True,
+    )
+
+    cpu = jax.devices("cpu")[0]
+    x = jax.device_put(jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32), cpu)
+
+    with pytest.raises(Exception) as excinfo:
+        result = jax.ffi.ffi_call(
+            "test_cpu_check_fail.check_fail_cpu",
+            jax.ShapeDtypeStruct(x.shape, x.dtype),
+            vmap_method="broadcast_all",
+        )(x)
+        jax.block_until_ready(result)
+
+    # The diagnostic from check.h propagates through the FFI error.
+    message = str(excinfo.value)
+    assert "CHECK FAILED" in message or "intentional failure" in message, message
+
+
+def test_process_survives_after_check_failure():
+    """After a check failure, the interpreter is still usable (not aborted)."""
+    mod = brainevent.load_cpp_inline(
+        name="test_cpu_check_fail2",
+        cpp_sources=CHECK_FAIL_SRC.replace("check_fail_cpu", "check_fail_cpu2"),
+        functions=["check_fail_cpu2"],
+        force_rebuild=True,
+    )
+    cpu = jax.devices("cpu")[0]
+    x = jax.device_put(jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32), cpu)
+
+    with pytest.raises(Exception):
+        jax.block_until_ready(
+            jax.ffi.ffi_call(
+                "test_cpu_check_fail2.check_fail_cpu2",
+                jax.ShapeDtypeStruct(x.shape, x.dtype),
+                vmap_method="broadcast_all",
+            )(x)
+        )
+
+    # Still alive: a normal JAX computation completes after the failure.
+    assert float(jnp.sum(jnp.arange(5.0))) == 10.0
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/brainevent/_op/kernix_codegen.py
+++ b/brainevent/_op/kernix_codegen.py
@@ -472,6 +472,38 @@ _ATTR_TYPES = (
 _ATTR_RE = re.compile(r"^attr\.(\w+):(" + "|".join(_ATTR_TYPES) + r")$")
 _ATTR_RE_BARE = re.compile(r"^attr\.(\w+)$")
 
+# A function/attribute name is interpolated verbatim into generated C++ (as a
+# called symbol ``name(...)``, a derived identifier ``be_<name>_impl`` and an
+# attribute string literal).  Restrict it to a strict ASCII C++ identifier so a
+# crafted name cannot inject arbitrary code into the translation unit (H8).
+# ``str.isidentifier()`` is intentionally *not* used: it accepts Unicode
+# identifiers (e.g. ``café``) that are not portable C++ identifiers.
+_CPP_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_cpp_identifier(name: str, kind: str) -> None:
+    """Raise :class:`KernelError` unless *name* is a valid ASCII C++ identifier.
+
+    Parameters
+    ----------
+    name : str
+        Candidate identifier (function or attribute name).
+    kind : str
+        Human-readable role of *name*, used in the error message.
+
+    Raises
+    ------
+    KernelError
+        If *name* is empty or contains anything other than ASCII letters,
+        digits and underscores, or starts with a digit.
+    """
+    if not _CPP_IDENT_RE.match(name):
+        raise KernelError(
+            f"Invalid {kind} {name!r}: must be a valid C++ identifier "
+            f"(ASCII letter or underscore followed by letters/digits/underscores). "
+            f"The name is emitted verbatim into generated C++."
+        )
+
 
 @dataclass
 class FunctionSpec:
@@ -503,7 +535,17 @@ def parse_arg_spec(func_name: str, tokens: list[str]) -> FunctionSpec:
     Returns
     -------
     FunctionSpec
+
+    Raises
+    ------
+    KernelError
+        If *func_name* or any attribute name is not a valid C++ identifier, or
+        a token is malformed.
     """
+    # The function name is emitted verbatim into generated C++; reject anything
+    # that is not a plain ASCII identifier so it cannot inject code (H8).
+    _validate_cpp_identifier(func_name, "function name")
+
     spec = FunctionSpec(name=func_name)
     arg_idx = 0
     ret_idx = 0
@@ -526,6 +568,9 @@ def parse_arg_spec(func_name: str, tokens: list[str]) -> FunctionSpec:
             m = _ATTR_RE.match(token)
             if m:
                 attr_name, attr_type = m.group(1), m.group(2)
+                # Emitted both as the identifier ``attr_<name>`` and as a C++
+                # string literal in the FFI binding; validate it (H8).
+                _validate_cpp_identifier(attr_name, "attribute name")
                 spec.attrs.append((attr_name, attr_type))
                 spec.user_param_order.append(f"attr_{attr_name}")
             else:
@@ -594,7 +639,7 @@ def generate_ffi_wrapper(spec: FunctionSpec, allow_cuda_graph: bool = True) -> s
     handler_name = f"be_{name}"
 
     lines: list[str] = []
-    lines.append(f"// ── FFI wrapper for {name} (auto-generated) ──")
+    lines.append(f"// -- FFI wrapper for {name} (auto-generated) --")
     lines.append("")
 
     # ------------------------------------------------------------------
@@ -626,17 +671,7 @@ def generate_ffi_wrapper(spec: FunctionSpec, allow_cuda_graph: bool = True) -> s
     lines.append(f"    {sig}")
     lines.append(") {")
 
-    # ------------------------------------------------------------------
-    # 2. Convert buffers to Tensor
-    # ------------------------------------------------------------------
-    for i in range(spec.num_args):
-        lines.append(f"    BE::Tensor tv_arg{i} = BE::internal::buffer_to_tensor(arg{i});")
-    for i in range(spec.num_rets):
-        lines.append(f"    BE::Tensor tv_ret{i} = BE::internal::result_buffer_to_tensor(ret{i});")
-
-    # ------------------------------------------------------------------
-    # 3. Call user function in the order specified by arg_spec
-    # ------------------------------------------------------------------
+    # Compute the user-function call arguments in arg_spec order.
     call_args: list[str] = []
     for p in spec.user_param_order:
         if p.startswith("arg"):
@@ -648,8 +683,26 @@ def generate_ffi_wrapper(spec: FunctionSpec, allow_cuda_graph: bool = True) -> s
         elif p.startswith("attr_"):
             call_args.append(p)  # same variable name
 
-    lines.append(f"    {name}({', '.join(call_args)});")
-    lines.append("    return xla::ffi::Error::Success();")
+    # ------------------------------------------------------------------
+    # 2+3. Convert buffers to Tensor and call the user function, wrapped in a
+    #      try/catch so a thrown BE::CheckError / BE::CudaError (host-side
+    #      BE_CHECK / BE_CUDA_CHECK failure) or a buffer_to_tensor dtype
+    #      rejection becomes an xla::ffi::Error the JAX caller raises, instead
+    #      of aborting the whole process (H3).  Device-side check failures
+    #      still trap; only host-side throws are catchable here.
+    # ------------------------------------------------------------------
+    lines.append("    try {")
+    for i in range(spec.num_args):
+        lines.append(f"        BE::Tensor tv_arg{i} = BE::internal::buffer_to_tensor(arg{i});")
+    for i in range(spec.num_rets):
+        lines.append(f"        BE::Tensor tv_ret{i} = BE::internal::result_buffer_to_tensor(ret{i});")
+    lines.append(f"        {name}({', '.join(call_args)});")
+    lines.append("        return xla::ffi::Error::Success();")
+    lines.append("    } catch (const std::exception& e) {")
+    lines.append(
+        f'        return xla::ffi::Error::Internal(std::string("{handler_name}: ") + e.what());'
+    )
+    lines.append("    }")
     lines.append("}")
     lines.append("")
 
@@ -707,11 +760,16 @@ def preprocess_source(
     """
     parts: list[str] = []
 
-    parts.append("// ════════════════════════════════════════════════════")
+    parts.append("// ====================================================")
     parts.append("// Auto-generated by brainevent. Do not edit.")
-    parts.append("// ════════════════════════════════════════════════════")
+    parts.append("// ====================================================")
     parts.append("")
-    # Internal header: XLA FFI ↔ Tensor bridge (platform-agnostic).
+    # <string> / <exception> back the generated try/catch (Error::Internal +
+    # e.what()); include them explicitly rather than relying on transitive
+    # includes from the FFI/Tensor headers.
+    parts.append("#include <string>")
+    parts.append("#include <exception>")
+    # Internal header: XLA FFI <-> Tensor bridge (platform-agnostic).
     # ffi_compat.h includes <cuda_runtime_api.h> under __CUDACC__ so the
     # generated wrapper's cudaStream_t reference compiles without the user
     # needing to add it manually.
@@ -719,12 +777,12 @@ def preprocess_source(
     parts.append("")
 
     # User source
-    parts.append("// ── user source ─────────────────────────────────────")
+    parts.append("// -- user source -------------------------------------")
     parts.append(user_source)
     parts.append("")
 
     # FFI wrappers
-    parts.append("// ── FFI wrappers ───────────────────────────────────")
+    parts.append("// -- FFI wrappers ------------------------------------")
     for spec in function_specs:
         parts.append(generate_ffi_wrapper(spec, allow_cuda_graph=allow_cuda_graph))
 

--- a/brainevent/_op/kernix_compiler.py
+++ b/brainevent/_op/kernix_compiler.py
@@ -24,6 +24,7 @@ Adding a new backend
 """
 
 import os
+import shlex
 import subprocess
 from abc import ABC, abstractmethod
 from typing import Any
@@ -66,18 +67,29 @@ def _compile_timeout() -> int:
 
 
 def _run(cmd, *, timeout, stage):
-    """``subprocess.run`` that maps FileNotFoundError/timeout to CompilationError."""
+    """``subprocess.run`` that maps FileNotFoundError/timeout to CompilationError.
+
+    Output is decoded as UTF-8 with ``errors="replace"`` rather than the
+    platform locale.  Compiler diagnostics (nvcc / cl / g++) routinely contain
+    bytes that are not valid in a non-UTF-8 locale (e.g. Windows ``cp1252``);
+    relying on the implicit locale decoding of ``text=True`` lets a
+    ``UnicodeDecodeError`` raise *inside* ``subprocess.run`` -- before this
+    function's ``except`` clauses can run -- masking the real compiler error.
+    """
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return subprocess.run(
+            cmd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=timeout,
+        )
     except FileNotFoundError as e:
         raise CompilationError(
             f"compiler executable not found: {cmd[0]}",
-            command=" ".join(map(str, cmd)), stage=stage) from e
+            command=shlex.join(map(str, cmd)), stage=stage) from e
     except subprocess.TimeoutExpired as e:
         out = ((e.stdout or "") + (e.stderr or "")) if isinstance(e.stdout, str) else ""
         raise CompilationError(
             f"compilation timed out after {timeout}s",
-            compiler_output=out, command=" ".join(map(str, cmd)), stage=stage) from e
+            compiler_output=out, command=shlex.join(map(str, cmd)), stage=stage) from e
 
 
 def _raise_compile_error(output: str, command: str, stage: str) -> None:
@@ -198,7 +210,18 @@ class CUDABackend(CompilerBackend):
         use_fast_math: bool = False,
         **kwargs: Any,
     ) -> str:
-        """Compile preprocessed source to .so directly with nvcc."""
+        """Compile preprocessed source to .so directly with nvcc.
+
+        Notes
+        -----
+        Each element of *extra_ldflags* is treated as a single, already-split
+        linker token (the caller is responsible for splitting, exactly as if
+        it were one ``shlex``-split argv entry).  Every element is forwarded to
+        the host linker unchanged via one ``-Xlinker <token>`` pair, so a value
+        such as ``"-L/path with spaces"`` reaches the linker as a single
+        argument.  This matches the :class:`CPPBackend` semantics, where each
+        element is likewise one already-split token passed straight through.
+        """
         os.makedirs(build_dir, exist_ok=True)
         arches = [gpu_arch] if isinstance(gpu_arch, str) else list(gpu_arch)
 
@@ -245,10 +268,14 @@ class CUDABackend(CompilerBackend):
 
         cmd.extend(extra_cuda_cflags or [])
 
-        for flag in (extra_ldflags or []):
-            cmd.extend(["--linker-options", flag])
+        # Each extra_ldflags element is one already-split token forwarded to the
+        # host linker via a single ``-Xlinker <token>`` pair (mirrors how
+        # ``nvcc_host_pic_flags`` forwards host-compiler options one per flag,
+        # and keeps multi-word values such as "-L/path with spaces" intact).
+        for token in (extra_ldflags or []):
+            cmd.extend(["-Xlinker", token])
 
-        cmd_str = " ".join(cmd)
+        cmd_str = shlex.join(cmd)
         if verbose:
             print(f"nvcc command:\n  {cmd_str}")
 
@@ -293,11 +320,27 @@ class CPPBackend(CompilerBackend):
         verbose: bool = False,
         **kwargs: Any,
     ) -> str:
+        """Compile preprocessed source to a shared library with g++ / clang++.
+
+        Notes
+        -----
+        Each element of *extra_ldflags* is treated as a single, already-split
+        linker token and passed through to the compiler driver unchanged (the
+        driver forwards ``-L`` / ``-l`` / ``-Wl,`` flags to the linker).  This
+        matches the :class:`CUDABackend` semantics, where each element is
+        likewise one already-split token forwarded to the host linker.
+        """
         toolchain = self.toolchain
 
+        # Honor the caller-provided build_dir for intermediate artefacts (the
+        # CUDABackend does the same); fall back to the output directory only
+        # when no build_dir was supplied.
+        if build_dir:
+            os.makedirs(build_dir, exist_ok=True)
+        else:
+            build_dir = os.path.dirname(os.path.abspath(output_path))
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
 
-        build_dir = os.path.dirname(os.path.abspath(output_path))
         src_path = os.path.join(build_dir, "kernel.cpp")
         with open(src_path, "w", encoding="utf-8") as f:
             f.write(source)
@@ -316,9 +359,11 @@ class CPPBackend(CompilerBackend):
             cmd.extend(["-I", p])
 
         cmd.extend(extra_cflags or [])
+        # Each extra_ldflags element is one already-split token passed straight
+        # through to the compiler driver (which forwards it to the linker).
         cmd.extend(extra_ldflags or [])
 
-        cmd_str = " ".join(cmd)
+        cmd_str = shlex.join(cmd)
         if verbose:
             print(f"C++ command:\n  {cmd_str}")
 

--- a/brainevent/_op/kernix_compiler_audit_test.py
+++ b/brainevent/_op/kernix_compiler_audit_test.py
@@ -1,0 +1,224 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Reproduction tests for the kernix_compiler audit findings M11, M12, L13.
+
+These tests are hermetic: they never invoke a real ``nvcc`` / ``cl`` / ``g++``.
+``subprocess.run`` is monkeypatched to capture the argv (and kwargs) that the
+backend assembled, and the built command list is asserted on directly.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from brainevent._op import kernix_compiler as kc
+from brainevent._op.kernix_toolchain import CppToolchain, CudaToolchain
+
+
+# ---------------------------------------------------------------------------
+# Hermetic helpers
+# ---------------------------------------------------------------------------
+
+def _fake_cuda_toolchain(nvcc="nvcc", cxx="g++") -> CudaToolchain:
+    return CudaToolchain(
+        nvcc=nvcc,
+        cxx=cxx,
+        cuda_home="/usr/local/cuda",
+        cuda_include_dirs=("/usr/local/cuda/include",),
+        xla_ffi_include_dir="/xla/ffi/include",
+        brainevent_include_dir="/be/include",
+    )
+
+
+def _fake_cpp_toolchain(cxx="g++") -> CppToolchain:
+    return CppToolchain(
+        cxx=cxx,
+        xla_ffi_include_dir="/xla/ffi/include",
+        brainevent_include_dir="/be/include",
+    )
+
+
+class _Recorder:
+    """Capture the argv and kwargs of the (monkeypatched) ``subprocess.run``."""
+
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.cmd = None
+        self.kwargs = None
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = list(cmd)
+        self.kwargs = kwargs
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=self._returncode,
+            stdout=self._stdout, stderr=self._stderr,
+        )
+
+
+def _patch_run(monkeypatch, recorder):
+    # The backend calls ``subprocess.run`` via the module-level ``subprocess``.
+    monkeypatch.setattr(kc.subprocess, "run", recorder)
+
+
+def _compile_cuda(monkeypatch, tmp_path, *, extra_ldflags=None, verbose=False,
+                  nvcc="nvcc", cxx="g++"):
+    rec = _Recorder()
+    _patch_run(monkeypatch, rec)
+    out = str(tmp_path / "out.so")
+    build = str(tmp_path / "cuda_build")
+    CUDABackend = kc.CUDABackend
+    backend = CUDABackend(_fake_cuda_toolchain(nvcc=nvcc, cxx=cxx))
+    backend.compile_source(
+        "int main(){}", out, build,
+        extra_ldflags=extra_ldflags, verbose=verbose,
+    )
+    return rec
+
+
+def _compile_cpp(monkeypatch, tmp_path, *, extra_ldflags=None, verbose=False,
+                 build_dir=None, cxx="g++"):
+    rec = _Recorder()
+    _patch_run(monkeypatch, rec)
+    out = str(tmp_path / "outdir" / "out.so")
+    if build_dir is None:
+        build_dir = str(tmp_path / "cpp_build")
+    backend = kc.CPPBackend(_fake_cpp_toolchain(cxx=cxx))
+    backend.compile_source(
+        "int main(){}", out, build_dir,
+        extra_ldflags=extra_ldflags, verbose=verbose,
+    )
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# M11 — extra_ldflags splitting must be consistent across CUDA and CPP
+# ---------------------------------------------------------------------------
+
+def _linker_tokens_cpp(cmd):
+    """The raw ldflag tokens as the CPP backend forwards them."""
+    return [t for t in cmd if t in ("-L/x", "-lfoo")]
+
+
+def _linker_tokens_cuda(cmd):
+    """For each ``-Xlinker <tok>`` pair, return ``<tok>`` in order."""
+    toks = []
+    for i, t in enumerate(cmd):
+        if t == "-Xlinker" and i + 1 < len(cmd):
+            toks.append(cmd[i + 1])
+    return toks
+
+
+def test_m11_cpp_passes_ldflags_as_raw_tokens(monkeypatch, tmp_path):
+    rec = _compile_cpp(monkeypatch, tmp_path, extra_ldflags=["-L/x", "-lfoo"])
+    # CPP forwards each element verbatim, in order, exactly once.
+    assert _linker_tokens_cpp(rec.cmd) == ["-L/x", "-lfoo"]
+
+
+def test_m11_cuda_passes_each_ldflag_via_single_xlinker(monkeypatch, tmp_path):
+    rec = _compile_cuda(monkeypatch, tmp_path, extra_ldflags=["-L/x", "-lfoo"])
+    cmd = rec.cmd
+    # The deprecated/inconsistent ``--linker-options`` form must be gone.
+    assert "--linker-options" not in cmd
+    # Each element becomes exactly one ``-Xlinker <token>`` pair, in order.
+    assert _linker_tokens_cuda(cmd) == ["-L/x", "-lfoo"]
+    assert cmd.count("-Xlinker") == 2
+
+
+def test_m11_backends_are_equivalent(monkeypatch, tmp_path):
+    """Both backends pass the *same* linker tokens, in the same order, once each."""
+    cuda = _compile_cuda(monkeypatch, tmp_path, extra_ldflags=["-L/x", "-lfoo"])
+    cpp = _compile_cpp(monkeypatch, tmp_path, extra_ldflags=["-L/x", "-lfoo"])
+    assert _linker_tokens_cuda(cuda.cmd) == _linker_tokens_cpp(cpp.cmd) == ["-L/x", "-lfoo"]
+
+
+# ---------------------------------------------------------------------------
+# M12 — subprocess decoding must be utf-8 / errors="replace"
+# ---------------------------------------------------------------------------
+
+def test_m12_cuda_run_uses_utf8_replace(monkeypatch, tmp_path):
+    rec = _compile_cuda(monkeypatch, tmp_path)
+    assert rec.kwargs.get("errors") == "replace"
+    assert rec.kwargs.get("encoding") == "utf-8"
+
+
+def test_m12_cpp_run_uses_utf8_replace(monkeypatch, tmp_path):
+    rec = _compile_cpp(monkeypatch, tmp_path)
+    assert rec.kwargs.get("errors") == "replace"
+    assert rec.kwargs.get("encoding") == "utf-8"
+
+
+def test_m12_no_unicodedecodeerror_escapes(monkeypatch, tmp_path):
+    """A non-UTF-8 locale must not let UnicodeDecodeError escape subprocess.run.
+
+    We simulate ``text=True`` strict decoding: if the caller does *not* request
+    ``errors="replace"``, the fake raises UnicodeDecodeError from *inside*
+    ``subprocess.run`` (exactly where the real defect surfaces). The fix must
+    pass ``errors="replace"`` so this never triggers.
+    """
+    def fake_run(cmd, **kwargs):
+        if kwargs.get("errors") != "replace":
+            raise UnicodeDecodeError("charmap", b"\x81", 0, 1, "undecodable byte")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(kc.subprocess, "run", fake_run)
+
+    out = str(tmp_path / "out.so")
+    build = str(tmp_path / "b")
+    # Should not raise UnicodeDecodeError.
+    kc.CUDABackend(_fake_cuda_toolchain()).compile_source("x", out, build)
+    kc.CPPBackend(_fake_cpp_toolchain()).compile_source("x", out, str(tmp_path / "c"))
+
+
+def test_m12_run_helper_forwards_errors_replace(monkeypatch):
+    """The low-level ``_run`` helper itself must request errors='replace'."""
+    rec = _Recorder()
+    monkeypatch.setattr(kc.subprocess, "run", rec)
+    kc._run(["nvcc", "--version"], timeout=5, stage="probe")
+    assert rec.kwargs.get("errors") == "replace"
+    assert rec.kwargs.get("encoding") == "utf-8"
+
+
+# ---------------------------------------------------------------------------
+# L13 — shlex.join for display; CPP honors build_dir; HIP stub message
+# ---------------------------------------------------------------------------
+
+def test_l13_cuda_verbose_uses_shlex_join(monkeypatch, tmp_path, capsys):
+    # A compiler path containing a space must render shell-quoted, not split.
+    _compile_cuda(monkeypatch, tmp_path, verbose=True, nvcc="/opt/cuda tools/nvcc")
+    printed = capsys.readouterr().out
+    # shlex.join quotes the spaced path; " ".join would leave it bare.
+    assert "'/opt/cuda tools/nvcc'" in printed
+
+
+def test_l13_cpp_verbose_uses_shlex_join(monkeypatch, tmp_path, capsys):
+    _compile_cpp(monkeypatch, tmp_path, verbose=True, cxx="/opt/g cc/g++")
+    printed = capsys.readouterr().out
+    assert "'/opt/g cc/g++'" in printed
+
+
+def test_l13_cpp_honors_caller_build_dir(monkeypatch, tmp_path):
+    """CPP must write its intermediate source into the caller-provided build_dir."""
+    rec = _Recorder()
+    _patch_run(monkeypatch, rec)
+    build_dir = tmp_path / "explicit_build"
+    out = tmp_path / "outdir" / "out.so"
+    kc.CPPBackend(_fake_cpp_toolchain()).compile_source(
+        "int main(){}", str(out), str(build_dir),
+    )
+    # The kernel source goes into the honored build_dir, not the output dir.
+    assert (build_dir / "kernel.cpp").exists()
+    # And the compiled source argument points inside the build_dir.
+    src_arg = rec.cmd[1]
+    assert src_arg == str(build_dir / "kernel.cpp")
+
+
+def test_l13_hip_stub_message_is_clear():
+    backend = kc.HIPBackend()
+    with pytest.raises(NotImplementedError) as ei:
+        backend.compile_source("src", "out.so", "build")
+    msg = str(ei.value)
+    assert "HIP" in msg
+    assert "not yet implemented" in msg.lower()

--- a/brainevent/_op/kernix_error_handling_test.py
+++ b/brainevent/_op/kernix_error_handling_test.py
@@ -62,10 +62,13 @@ def test_missing_ret_in_arg_spec():
         )
 
 
-def test_duplicate_registration():
-    """Registering the same target name twice raises RegistrationError."""
-    from brainevent._error import KernelRegistrationError
+def test_duplicate_registration_same_module_is_idempotent():
+    """Re-registering the identical module under one name is a no-op (M5).
 
+    Registration is idempotent for an equivalent module (same shared-library
+    path, function, platform) so repeated eager registration does not raise or
+    clobber the live keep-alive.
+    """
     CUDA_SRC = r"""
     #include <cuda_runtime.h>
     #include "brainevent/common.h"
@@ -81,9 +84,45 @@ def test_duplicate_registration():
     )
 
     brainevent.register_ffi_target("test_dup.noop", mod, "noop")
+    # Idempotent: the identical module re-registered is a no-op, not an error.
+    brainevent.register_ffi_target("test_dup.noop", mod, "noop")
+    assert "test_dup.noop" in brainevent.list_registered_targets()
 
-    with pytest.raises(KernelRegistrationError, match="already registered"):
-        brainevent.register_ffi_target("test_dup.noop", mod, "noop")
+
+def test_duplicate_registration_different_module_raises():
+    """A *different* module under an already-used name is refused (M5).
+
+    ``jax.ffi.register_ffi_target`` would silently overwrite the live target,
+    dropping a still-referenced module; the wrapper raises instead.
+    """
+    from brainevent._error import KernelRegistrationError
+
+    CUDA_SRC = r"""
+    #include <cuda_runtime.h>
+    #include "brainevent/common.h"
+    void noop(BE::Tensor out, int64_t stream) {}
+    """
+
+    mod = brainevent.load_cuda_inline(
+        name="test_dup_reg_a",
+        cuda_sources=CUDA_SRC,
+        functions={"noop": ["ret", "stream"]},
+        auto_register=False,
+        force_rebuild=True,
+    )
+    # A second, distinct shared library (different name -> different .so path).
+    mod2 = brainevent.load_cuda_inline(
+        name="test_dup_reg_b",
+        cuda_sources=CUDA_SRC,
+        functions={"noop": ["ret", "stream"]},
+        auto_register=False,
+        force_rebuild=True,
+    )
+
+    brainevent.register_ffi_target("test_dup_conflict.noop", mod, "noop")
+
+    with pytest.raises(KernelRegistrationError, match="already registered to a different"):
+        brainevent.register_ffi_target("test_dup_conflict.noop", mod2, "noop")
 
 
 def test_diagnostics_runs():

--- a/brainevent/_op/kernix_pipeline.py
+++ b/brainevent/_op/kernix_pipeline.py
@@ -21,6 +21,7 @@ Public API: load_cuda_inline, load_cuda_file, load_cuda_dir,
             print_diagnostics.
 """
 
+import glob
 import os
 import shutil
 import sys
@@ -59,6 +60,40 @@ _REGISTERED_TARGET_SO: dict[str, str] = {}
 def _join_sources(sources: str | list[str]) -> str:
     """Concatenate a list of sources, or return a single source unchanged."""
     return "\n\n".join(sources) if isinstance(sources, list) else sources
+
+
+def _cache_header_paths(toolchain) -> list[str]:
+    """Resolve the injected headers whose byte-contents affect the build.
+
+    Every ``brainevent`` header (``ffi_compat.h``, ``tensor.h``, ``check.h``,
+    ``cuda_common.h``, ...) can be pulled into a generated translation unit, so
+    a content change in *any* of them must rebuild — hashing only ``ffi_compat.h``
+    would miss, e.g., a ``check.h`` semantics change (abort -> throw) when the
+    ``brainevent`` version is unchanged (editable installs).  jaxlib's
+    ``xla/ffi/api/ffi.h`` is hashed too so an ABI bump rebuilds.
+
+    Parameters
+    ----------
+    toolchain : CudaToolchain or CppToolchain
+        A detected toolchain exposing ``brainevent_include_dir`` and
+        ``xla_ffi_include_dir``.
+
+    Returns
+    -------
+    list of str
+        Existing header paths to byte-hash (missing files are skipped; the
+        cache key tolerates absent entries).  The order is irrelevant — the
+        cache key sorts the paths.
+    """
+    be_inc = toolchain.brainevent_include_dir
+    candidates: list[str] = []
+    # All brainevent headers: both the ``brainevent/`` subdir and any top-level
+    # headers (cuda_common.h / curand_common.h live one level up).
+    candidates.extend(glob.glob(os.path.join(be_inc, "brainevent", "*.h")))
+    candidates.extend(glob.glob(os.path.join(be_inc, "*.h")))
+    # jaxlib FFI ABI header.
+    candidates.append(os.path.join(toolchain.xla_ffi_include_dir, "xla", "ffi", "api", "ffi.h"))
+    return [p for p in candidates if os.path.isfile(p)]
 
 
 def _build_specs(
@@ -211,7 +246,9 @@ def load_cuda_inline(
     gpu_arches = resolved if explicit_pin else resolved[:1]
     arch_key = "+".join(gpu_arches)
 
-    # Compute cache key (includes optimization settings so changing them rebuilds)
+    # Compute cache key (includes optimization settings so changing them
+    # rebuilds; also the include search path, injected-header bytes, and the
+    # jaxlib FFI ABI version — see CompilationCache.cache_key).
     cache_key = _cache.cache_key(
         source=user_source,
         arch=arch_key,
@@ -223,6 +260,8 @@ def load_cuda_inline(
             + [f"--be-allow-cuda-graph={int(allow_cuda_graph)}"]
         ),
         extra_ldflags=extra_ldflags,
+        extra_include_paths=extra_include_paths,
+        header_paths=_cache_header_paths(toolchain),
     )
 
     # Check cache
@@ -262,7 +301,10 @@ def load_cuda_inline(
                 optimization_level=optimization_level,
                 use_fast_math=use_fast_math,
             )
-            so_path = str(_cache.store(name, cache_key, so_path))
+            # A user-supplied build_directory is the caller's: copy (don't move)
+            # the artefact into the cache so their file stays put.
+            so_path = str(_cache.store(
+                name, cache_key, so_path, source_is_user_dir=bool(build_directory)))
         finally:
             if cleanup:
                 shutil.rmtree(build_dir, ignore_errors=True)
@@ -416,13 +458,16 @@ def load_cpp_inline(
     # Detect toolchain (CPU — no CUDA needed)
     toolchain = detect_cpp_toolchain()
 
-    # Cache key
+    # Cache key (include search path, injected-header bytes, and the jaxlib
+    # FFI ABI version participate — see CompilationCache.cache_key).
     cache_key = _cache.cache_key(
         source=user_source,
         arch="cpu",
         cxx_version=toolchain.cxx_version,
         extra_cflags=extra_cflags,
         extra_ldflags=extra_ldflags,
+        extra_include_paths=extra_include_paths,
+        header_paths=_cache_header_paths(toolchain),
     )
 
     cached_so = None if force_rebuild else _cache.lookup(name, cache_key)
@@ -451,7 +496,10 @@ def load_cpp_inline(
                 extra_include_paths=extra_include_paths,
                 verbose=verbose,
             )
-            so_path = str(_cache.store(name, cache_key, so_path))
+            # A user-supplied build_directory is the caller's: copy (don't move)
+            # the artefact into the cache so their file stays put.
+            so_path = str(_cache.store(
+                name, cache_key, so_path, source_is_user_dir=bool(build_directory)))
         finally:
             if cleanup:
                 shutil.rmtree(build_dir, ignore_errors=True)

--- a/brainevent/_op/kernix_runtime.py
+++ b/brainevent/_op/kernix_runtime.py
@@ -16,6 +16,8 @@
 """Runtime layer: CompiledModule and JAX FFI registration."""
 
 import ctypes
+import re
+import threading
 
 import jax
 
@@ -23,13 +25,61 @@ from brainevent._error import KernelError, KernelLoadError, KernelRegistrationEr
 
 
 def _format_load_error(so_path: str, err: Exception) -> str:
+    """Build an actionable message for a failed shared-library load.
+
+    The heuristics inspect the platform loader's error text and append a
+    tailored remediation hint.  Both POSIX ``dlopen`` wording and the
+    Windows loader's ``LoadLibrary``/``FormatMessage`` phrasings are
+    recognised so the hint is useful on either platform.
+
+    Parameters
+    ----------
+    so_path : str
+        Path to the artefact that failed to load.
+    err : Exception
+        The exception raised by :class:`ctypes.CDLL` (an :class:`OSError`,
+        e.g. ``OSError("libcudart.so.12: cannot open shared object file ...")``
+        on POSIX or ``OSError("[WinError 126] The specified module could not
+        be found")`` on Windows).
+
+    Returns
+    -------
+    str
+        A multi-line, human-readable diagnostic ending with a "How to fix"
+        section.
+
+    Notes
+    -----
+    Windows loader phrasings are detected by both their ``FormatMessage`` text
+    ("The specified module could not be found", "is not a valid Win32
+    application") and their numeric ``WinError`` codes (126 = ``MOD_NOT_FOUND``,
+    127 = ``PROC_NOT_FOUND``, 193 = ``BAD_EXE_FORMAT``), since ctypes may
+    surface either form.
+    """
     msg = str(err)
     low = msg.lower()
+
+    # --- Windows loader signatures -------------------------------------
+    # Numeric WinError codes (matched on word boundaries so "126" inside an
+    # unrelated number does not trigger a false positive).
+    win_codes = set(re.findall(r"\b(126|127|193)\b", low))
+    win_mod_not_found = (
+        "the specified module could not be found" in low
+        or "the specified procedure could not be found" in low
+        or "while loading dependent" in low
+        or bool(win_codes & {"126", "127"})
+    )
+    win_bad_format = (
+        "is not a valid win32 application" in low
+        or "%1 is not a valid" in low
+        or "193" in win_codes
+    )
+
     lines = [
-        "[brainevent GPU toolchain] Failed to load .so  (code=E-LOAD)",
+        "[brainevent GPU toolchain] Failed to load shared library  (code=E-LOAD)",
         "",
-        f"Reason: cannot dlopen the compiled artefact: {so_path}",
-        f"dlopen: {msg}",
+        f"Reason: cannot load the compiled artefact: {so_path}",
+        f"loader: {msg}",
         "",
         "How to fix:",
     ]
@@ -38,7 +88,23 @@ def _format_load_error(so_path: str, err: Exception) -> str:
             "  1) The NVIDIA driver is too old for this CUDA toolkit. Upgrade the driver,",
             "     or install a jax[cudaNN] whose CUDA version matches your driver.",
         ]
-    elif "cudart" in low or "cannot open shared object" in low:
+    elif win_bad_format:
+        lines += [
+            "  1) Architecture/bitness mismatch: the DLL is not a valid Win32 application for",
+            "     this process. Ensure a 64-bit Python loads a 64-bit (x64) build -- do not mix",
+            "     32-bit and 64-bit toolchains.",
+            "  2) Rebuild the artefact with the host compiler matching your Python's architecture.",
+        ]
+    elif win_mod_not_found:
+        lines += [
+            "  1) A dependent DLL could not be found by the Windows loader. The artefact itself",
+            "     may load, but one of its dependencies (e.g. the CUDA runtime cudart64_*.dll,",
+            "     or the MSVC runtime) is missing or not on the search path.",
+            "  2) Add the directory holding the dependent DLLs to PATH (or use",
+            "     os.add_dll_directory), and confirm jax[cuda*] / the CUDA toolkit is installed.",
+            "  3) Inspect dependencies with a tool such as dumpbin /dependents or Dependencies.exe.",
+        ]
+    elif "cudart" in low or "cannot open shared object" in low or "no such file" in low:
         lines += [
             "  1) Missing CUDA runtime libraries (typically cu12). Ensure jax[cuda*] is installed correctly.",
             "  2) Add the CUDA runtime library directory to LD_LIBRARY_PATH (e.g. site-packages/nvidia/cuda_runtime/lib).",
@@ -130,6 +196,31 @@ _LIVE_MODULES: dict[str, CompiledModule] = {}
 # Track registered names to give clear errors on duplicates.
 _REGISTERED_TARGETS: set[str] = set()
 
+# Identity of each registration, used to decide whether a same-name
+# re-registration is an idempotent no-op (equivalent module) or a conflicting
+# clobber (different module).  Maps target_name → (so_path, func_name, platform).
+_REGISTRATION_KEYS: dict[str, tuple[str, str, str]] = {}
+
+# Serialises the check-and-register sequence below.  ``jax.ffi.register_ffi_target``
+# *silently overwrites* an existing target, so without this lock two threads can
+# both pass the membership check and double-register (one of them clobbering the
+# other's live module, dropping a still-referenced keep-alive).  Guarding the
+# whole read-modify-write of ``_REGISTERED_TARGETS`` / ``_LIVE_MODULES`` /
+# ``_REGISTRATION_KEYS`` makes registration atomic.
+_REGISTRATION_LOCK = threading.Lock()
+
+
+def _registration_key(
+    module: "CompiledModule", func_name: str, platform: str
+) -> tuple[str, str, str]:
+    """Build the equivalence key identifying a registration.
+
+    Two registrations that share this key produce a functionally identical FFI
+    target (same shared-library path, same function symbol, same platform) and
+    are therefore treated as the *same* registration.
+    """
+    return (str(getattr(module, "path", module)), str(func_name), str(platform))
+
 
 def register_ffi_target(
     target_name: str,
@@ -143,6 +234,15 @@ def register_ffi_target(
     After registration, the function can be invoked inside ``@jax.jit``
     via ``jax.ffi.ffi_call(target_name, ...)``.
 
+    The whole check-and-register sequence is guarded by a module-level lock and
+    is **idempotent**: re-registering the same ``target_name`` with an
+    equivalent module (identical shared-library path, function name, and
+    platform) is a no-op and does not overwrite the live keep-alive.  Attempting
+    to register a *different* module under an already-registered name raises
+    :class:`~brainevent._error.KernelRegistrationError` rather than silently
+    clobbering the previous target (``jax.ffi.register_ffi_target`` would
+    otherwise overwrite it without warning, dropping a still-referenced module).
+
     Parameters
     ----------
     target_name : str
@@ -153,19 +253,46 @@ def register_ffi_target(
         Function name within the module.
     platform : str
         Target platform (``"CUDA"`` or ``"cpu"``).
+
+    Raises
+    ------
+    KernelRegistrationError
+        If ``target_name`` is already registered to a *different* module,
+        function, or platform.
+
+    Notes
+    -----
+    Registration is process-global and intentionally has no unload path: the
+    ctypes ``CDLL`` (and therefore the loaded ``.so``) is pinned in
+    ``_LIVE_MODULES`` for the lifetime of the process so the XLA FFI target it
+    backs never dangles.  The idempotency rule above bounds this to one live
+    module per target name (rather than leaking a new one per duplicate call).
     """
-    if target_name in _REGISTERED_TARGETS:
-        raise KernelRegistrationError(f"FFI target '{target_name}' is already registered.")
+    key = _registration_key(module, func_name, platform)
 
-    fn_ptr = module.get_handler(func_name)
-    capsule = jax.ffi.pycapsule(fn_ptr)
-    jax.ffi.register_ffi_target(target_name, capsule, platform=platform)
+    with _REGISTRATION_LOCK:
+        if target_name in _REGISTERED_TARGETS:
+            existing = _REGISTRATION_KEYS.get(target_name)
+            if existing == key:
+                # Equivalent re-registration: no-op, keep the live module as-is.
+                return
+            raise KernelRegistrationError(
+                f"FFI target '{target_name}' is already registered to a different "
+                f"module (existing={existing!r}, requested={key!r}). Refusing to "
+                f"overwrite the live target; use a distinct target name."
+            )
 
-    # Keep the module alive
-    _LIVE_MODULES[target_name] = module
-    _REGISTERED_TARGETS.add(target_name)
+        fn_ptr = module.get_handler(func_name)
+        capsule = jax.ffi.pycapsule(fn_ptr)
+        jax.ffi.register_ffi_target(target_name, capsule, platform=platform)
+
+        # Keep the module alive and record its identity.
+        _LIVE_MODULES[target_name] = module
+        _REGISTERED_TARGETS.add(target_name)
+        _REGISTRATION_KEYS[target_name] = key
 
 
 def list_registered_targets() -> list[str]:
     """Return a sorted list of all registered FFI target names."""
-    return sorted(_REGISTERED_TARGETS)
+    with _REGISTRATION_LOCK:
+        return sorted(_REGISTERED_TARGETS)

--- a/brainevent/_op/kernix_runtime_audit_test.py
+++ b/brainevent/_op/kernix_runtime_audit_test.py
@@ -1,0 +1,260 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Audit reproduction tests for ``kernix_runtime``.
+
+These tests are hermetic: they never load a real native module.  The JAX FFI
+surface (``jax.ffi.register_ffi_target`` and ``jax.ffi.pycapsule``) is
+monkeypatched so the registration bridge can be exercised without a compiled
+``.so``.
+
+Covered findings (see ``dev/2026-06-13-op-issues.md``):
+
+* **M5** -- FFI-target registration race + silent overwrite; no unload.
+* **L6** -- ``_format_load_error`` only recognises POSIX dlopen wording.
+"""
+
+import threading
+
+import pytest
+
+from brainevent._error import KernelRegistrationError
+from brainevent._op import kernix_runtime as kr
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+class _FakeModule:
+    """Minimal stand-in for :class:`CompiledModule`.
+
+    Only the surface that :func:`register_ffi_target` touches is implemented:
+    a :attr:`path` (the ``so_path`` used for equivalence) and
+    :meth:`get_handler` (returning an opaque sentinel that the patched
+    ``pycapsule`` accepts).
+    """
+
+    def __init__(self, so_path: str, functions):
+        self._so_path = str(so_path)
+        self._functions = {name: object() for name in functions}
+
+    @property
+    def path(self) -> str:
+        return self._so_path
+
+    @property
+    def function_names(self):
+        return list(self._functions)
+
+    def get_handler(self, name: str):
+        return self._functions[name]
+
+
+@pytest.fixture
+def clean_registry(monkeypatch):
+    """Isolate the module-global registries and count real FFI registrations.
+
+    Yields a ``calls`` list; each successful ``jax.ffi.register_ffi_target``
+    invocation appends its ``target_name``.  The ``_LIVE_MODULES`` /
+    ``_REGISTERED_TARGETS`` containers are swapped for fresh ones so the test
+    does not see (or pollute) global state.
+    """
+    calls = []
+
+    def fake_register(target_name, capsule, platform="CUDA"):
+        calls.append(target_name)
+
+    def fake_pycapsule(fn_ptr):
+        return ("capsule", fn_ptr)
+
+    monkeypatch.setattr(kr.jax.ffi, "register_ffi_target", fake_register)
+    monkeypatch.setattr(kr.jax.ffi, "pycapsule", fake_pycapsule)
+    monkeypatch.setattr(kr, "_LIVE_MODULES", {}, raising=False)
+    monkeypatch.setattr(kr, "_REGISTERED_TARGETS", set(), raising=False)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# M5 -- registration race, idempotency, and silent-overwrite protection
+# ---------------------------------------------------------------------------
+
+def test_m5_registration_lock_exists():
+    """A module-level ``threading.Lock`` must guard the registry."""
+    assert hasattr(kr, "_REGISTRATION_LOCK"), (
+        "kernix_runtime must expose a module-level registration lock"
+    )
+    assert isinstance(kr._REGISTRATION_LOCK, type(threading.Lock()))
+
+
+def test_m5_same_module_reregistration_is_idempotent(clean_registry):
+    """(a) Re-registering the *same* module under a name is a no-op.
+
+    The second call must neither invoke ``jax.ffi.register_ffi_target`` again
+    nor overwrite the live keep-alive entry.
+    """
+    calls = clean_registry
+    mod = _FakeModule("/tmp/libfake.so", ["noop"])
+
+    kr.register_ffi_target("dup.noop", mod, "noop", platform="cpu")
+    live_after_first = kr._LIVE_MODULES["dup.noop"]
+
+    # Same module, same name, same platform -> equivalent -> idempotent.
+    kr.register_ffi_target("dup.noop", mod, "noop", platform="cpu")
+
+    assert calls == ["dup.noop"], "equivalent re-registration must not re-call FFI"
+    assert kr._LIVE_MODULES["dup.noop"] is live_after_first, (
+        "_LIVE_MODULES must not be overwritten on idempotent re-registration"
+    )
+
+
+def test_m5_concurrent_registration_single_call(clean_registry):
+    """(b) Concurrent registration of one name yields exactly one registration."""
+    calls = clean_registry
+    mod = _FakeModule("/tmp/libfake.so", ["noop"])
+
+    n_threads = 32
+    start = threading.Barrier(n_threads)
+    errors = []
+
+    def worker():
+        start.wait()
+        try:
+            kr.register_ffi_target("race.noop", mod, "noop", platform="cpu")
+        except Exception as exc:  # pragma: no cover - surfaced via assert below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent equivalent registration raised: {errors}"
+    assert calls == ["race.noop"], (
+        f"expected exactly one FFI registration, got {len(calls)}: {calls}"
+    )
+    assert kr._REGISTERED_TARGETS == {"race.noop"}
+
+
+def test_m5_different_module_same_name_raises(clean_registry):
+    """(c) A *different* module under an existing name must not silently clobber."""
+    calls = clean_registry
+    mod_a = _FakeModule("/tmp/liba.so", ["noop"])
+    mod_b = _FakeModule("/tmp/libb.so", ["noop"])  # different so_path
+
+    kr.register_ffi_target("conf.noop", mod_a, "noop", platform="cpu")
+    live_after_first = kr._LIVE_MODULES["conf.noop"]
+
+    with pytest.raises(KernelRegistrationError):
+        kr.register_ffi_target("conf.noop", mod_b, "noop", platform="cpu")
+
+    # The original keep-alive survives; the conflicting one was rejected.
+    assert kr._LIVE_MODULES["conf.noop"] is live_after_first
+    assert calls == ["conf.noop"], "conflicting registration must not re-call FFI"
+
+
+def test_m5_different_platform_same_name_raises(clean_registry):
+    """(c) Same module + name but a *different platform* is not equivalent."""
+    mod = _FakeModule("/tmp/libfake.so", ["noop"])
+    kr.register_ffi_target("plat.noop", mod, "noop", platform="cpu")
+    with pytest.raises(KernelRegistrationError):
+        kr.register_ffi_target("plat.noop", mod, "noop", platform="CUDA")
+
+
+def test_m5_different_func_same_name_raises(clean_registry):
+    """(c) Same module + name but a *different function* is not equivalent."""
+    mod = _FakeModule("/tmp/libfake.so", ["noop", "other"])
+    kr.register_ffi_target("fn.noop", mod, "noop", platform="cpu")
+    with pytest.raises(KernelRegistrationError):
+        kr.register_ffi_target("fn.noop", mod, "other", platform="cpu")
+
+
+# ---------------------------------------------------------------------------
+# L6 -- Windows loader wording must produce the helpful hint
+# ---------------------------------------------------------------------------
+
+# (error string, set of Windows-specific tokens at least one of which the hint
+#  must contain).  These tokens are *absent* from the POSIX generic fallback
+#  line, so the assertions genuinely require new Windows heuristics rather than
+#  passing on the catch-all bullet.
+WINDOWS_DEP_ERRORS = [
+    # FormatMessage text for ERROR_MOD_NOT_FOUND (126).
+    "[WinError 126] The specified module could not be found",
+    # FormatMessage text for ERROR_PROC_NOT_FOUND (127).
+    "[WinError 127] The specified procedure could not be found",
+    # Bare numeric codes that ctypes/loaders sometimes surface.
+    "error 126",
+    "Error 127 while loading dependent DLLs",
+]
+
+# Tokens that only the Windows-aware branch emits (none appear in the POSIX
+# generic fallback line).
+_WIN_DEP_TOKENS = ("dll", "path")
+_WIN_ARCH_TOKENS = ("32-bit", "64-bit", "bitness", "win32 application")
+
+# The POSIX generic catch-all bullet; the Windows branch must NOT be this.
+_GENERIC = "Verify the build succeeded and dependent libraries are available"
+
+
+@pytest.mark.parametrize("err_text", WINDOWS_DEP_ERRORS)
+def test_l6_windows_missing_dll_gives_hint(err_text):
+    """Windows missing-dependency wording yields a DLL/PATH-aware hint."""
+    out = kr._format_load_error("C:\\build\\kernel.dll", OSError(err_text))
+
+    assert "E-LOAD" in out
+    assert "C:\\build\\kernel.dll" in out
+    assert "How to fix:" in out
+    low = out.lower()
+    assert any(tok in low for tok in _WIN_DEP_TOKENS), (
+        f"no Windows DLL/PATH hint produced for {err_text!r}:\n{out}"
+    )
+    # Must add value beyond the bare POSIX generic line.
+    assert _GENERIC not in out, (
+        f"Windows error {err_text!r} fell through to the generic bullet:\n{out}"
+    )
+
+
+@pytest.mark.parametrize(
+    "err_text",
+    [
+        "[WinError 193] %1 is not a valid Win32 application",
+        "is not a valid Win32 application",
+    ],
+)
+def test_l6_windows_arch_mismatch_gives_hint(err_text):
+    """A bitness/arch mismatch (error 193) must mention 32/64-bit."""
+    out = kr._format_load_error("C:\\build\\kernel.dll", OSError(err_text))
+    low = out.lower()
+    assert any(tok in low for tok in _WIN_ARCH_TOKENS), (
+        f"no bitness hint produced for {err_text!r}:\n{out}"
+    )
+    assert _GENERIC not in out
+
+
+def test_l6_posix_paths_still_recognised():
+    """Existing POSIX heuristics must keep working after broadening."""
+    # cudart / cannot-open-shared-object branch.
+    out = kr._format_load_error(
+        "/tmp/k.so",
+        OSError("libcudart.so.12: cannot open shared object file: No such file or directory"),
+    )
+    assert "LD_LIBRARY_PATH" in out
+    # driver / forward-compatibility branch.
+    out2 = kr._format_load_error(
+        "/tmp/k.so",
+        OSError("forward compatibility was attempted on non supported HW"),
+    )
+    assert "driver" in out2.lower()

--- a/brainevent/_op/kernix_toolchain.py
+++ b/brainevent/_op/kernix_toolchain.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,8 +28,20 @@ import jax
 
 from brainevent._error import (
     KernelToolchainError, NvccNotFoundError, HostCompilerNotFoundError,
-    HeaderNotFoundError, GpuArchDetectionError,
+    HeaderNotFoundError, GpuArchDetectionError, UnsupportedArchError,
 )
+
+
+# Guards the process-global mutable caches/pins below (``_NVCC_DISCOVERY``,
+# ``_COMPUTE_CAPABILITIES``, ``_GPU_DETECT_ERROR``) so concurrent
+# ``set_*``/auto-detect callers can't race (audit L12 / Theme G).
+_STATE_LOCK = threading.Lock()
+
+# Stashes the most recent exception raised by a GPU-arch detection backend
+# (e.g. ``jax.devices("gpu")`` failing on a driver mismatch) so it can be
+# surfaced in the ``GpuArchDetectionError`` instead of being flattened into a
+# bare "no GPU" (audit M10).  Written under ``_STATE_LOCK``.
+_GPU_DETECT_ERROR: "BaseException | None" = None
 
 
 _ARCH_OK = re.compile(r"^sm_\d{2,3}[a-z]?$")
@@ -53,7 +66,13 @@ def normalize_arch(value: "str") -> str:
     Raises
     ------
     ValueError
-        If *value* is empty or not a valid capability.
+        If *value* is empty or not syntactically a capability.
+    UnsupportedArchError
+        If *value* is syntactically valid but names a nonsensical
+        architecture with compute-capability major < 2 (e.g. ``"0.0"`` →
+        ``sm_00``, ``"1.0"`` → ``sm_10``).  No real CUDA GPU has a major
+        version below 2; accepting these only defers the failure to an
+        opaque nvcc ``-gencode arch=compute_00`` error much later.
     """
     s = str(value).strip().lower()
     if not s:
@@ -71,6 +90,13 @@ def normalize_arch(value: "str") -> str:
     arch = f"sm_{digits}{suffix}"
     if not _ARCH_OK.match(arch):
         raise ValueError(f"invalid compute capability: {value!r}")
+    # Major version is all but the last digit (e.g. sm_86 → 8, sm_120 → 12).
+    major = int(digits[:-1])
+    if major < 2:
+        raise UnsupportedArchError(
+            f"unsupported compute capability {value!r} (resolved to {arch}): "
+            f"no CUDA GPU has compute-capability major < 2."
+        )
     return arch
 
 
@@ -189,14 +215,19 @@ _NVCC_DISCOVERY: "str | None" = None  # None → fall back to env then default
 
 
 def set_nvcc_discovery(prefer: str) -> None:
-    """Set nvcc discovery preference: 'pip' (default) or 'system'."""
+    """Set nvcc discovery preference: 'pip' (default) or 'system'.
+
+    The write is guarded by :data:`_STATE_LOCK` so it can't race a concurrent
+    setter or auto-detect (audit L12 / Theme G).
+    """
     if prefer not in _VALID_NVCC_DISCOVERY:
         raise ValueError(
             f"Invalid nvcc discovery preference {prefer!r}. "
             f"Valid: {_VALID_NVCC_DISCOVERY}"
         )
     global _NVCC_DISCOVERY
-    _NVCC_DISCOVERY = prefer
+    with _STATE_LOCK:
+        _NVCC_DISCOVERY = prefer
 
 
 def get_nvcc_discovery() -> str:
@@ -217,16 +248,22 @@ _COMPUTE_CAPABILITIES: "list[str] | None" = None
 
 
 def set_compute_capabilities(value: "str | list[str] | None") -> None:
-    """Pin the target compute capability/-ies process-wide (``None`` = auto)."""
+    """Pin the target compute capability/-ies process-wide (``None`` = auto).
+
+    The write is guarded by :data:`_STATE_LOCK` so it can't race a concurrent
+    setter or auto-detect (audit L12 / Theme G).  Normalization (which may
+    raise :class:`ValueError`/:class:`~brainevent._error.UnsupportedArchError`)
+    happens before the lock is taken so a bad value never mutates global state.
+    """
     global _COMPUTE_CAPABILITIES
     if value is None:
-        _COMPUTE_CAPABILITIES = None
+        with _STATE_LOCK:
+            _COMPUTE_CAPABILITIES = None
         return
     tokens = _parse_arch_spec(value)
-    if not tokens:
-        _COMPUTE_CAPABILITIES = None
-        return
-    _COMPUTE_CAPABILITIES = _dedup([normalize_arch(v) for v in tokens])
+    normalized = _dedup([normalize_arch(v) for v in tokens]) if tokens else None
+    with _STATE_LOCK:
+        _COMPUTE_CAPABILITIES = normalized
 
 
 def get_compute_capabilities() -> "list[str] | None":
@@ -385,15 +422,105 @@ def _find_host_cxx():
 
 
 def _include_from_nvcc(nvcc_path: str) -> str:
+    """Guess the CUDA include dir as ``<nvcc>/../../include``.
+
+    This ``parent.parent`` heuristic holds for a real CUDA Toolkit layout
+    (``<prefix>/bin/nvcc`` ↔ ``<prefix>/include``) but can be wrong for a
+    distro shim at ``/usr/bin/nvcc`` (whose headers live in
+    ``/usr/include`` or a versioned ``/usr/lib/cuda/include``).  Callers
+    that depend on the result validate it via :func:`_validate_cuda_include`
+    (audit L12).
+    """
     return str(Path(nvcc_path).resolve().parent.parent / "include")
 
 
+def _validate_cuda_include(
+    include_dirs: "list[str]", *, nvcc_probes: "list[CandidateProbe]"
+) -> None:
+    """Verify that ``cuda_runtime.h`` is reachable from *include_dirs*.
+
+    Parameters
+    ----------
+    include_dirs : list of str
+        Candidate CUDA include directories (as resolved alongside nvcc).
+    nvcc_probes : list of CandidateProbe
+        The discovery probes for the chosen nvcc, echoed into the error for
+        context.
+
+    Raises
+    ------
+    HeaderNotFoundError
+        If none of *include_dirs* contains ``cuda_runtime.h``.  This catches
+        the distro-``/usr/bin/nvcc``-shim failure mode where the
+        ``<nvcc>/../../include`` guess points at a directory with no CUDA
+        headers (audit L12), instead of letting compilation fail later with
+        an opaque ``cuda_runtime.h: No such file or directory``.
+    """
+    header_probes: "list[CandidateProbe]" = []
+    for d in include_dirs:
+        cand = os.path.join(d, "cuda_runtime.h")
+        if os.path.isfile(cand):
+            return
+        header_probes.append(CandidateProbe(
+            "cuda_runtime.h", cand,
+            "not-found" if os.path.isdir(d) else "not-a-file",
+        ))
+    if not include_dirs:
+        header_probes.append(CandidateProbe("cuda_runtime.h", "", "unset"))
+    raise HeaderNotFoundError(render_toolchain_error(
+        stage="header resolution", code="E-HDR",
+        summary=(
+            "CUDA header cuda_runtime.h was not found in the include "
+            "directory resolved from nvcc. The nvcc may be a distro shim "
+            "whose headers live elsewhere, or the CUDA install is incomplete."
+        ),
+        probes=(nvcc_probes or []) + header_probes,
+        remediation=[
+            "Install the matching CUDA headers (e.g. the cuda-cudart-dev / "
+            "cuda-runtime package), or",
+            "Set CUDA_HOME (or CUDA_PATH) to a complete CUDA Toolkit install, or",
+            'Install a pip CUDA wheel that bundles headers: pip install -U "jax[cuda13]"',
+        ],
+    ))
+
+
 def _cxx_version(cxx: str) -> str:
+    """Return the first line of *cxx*'s ``--version`` banner (``""`` on failure).
+
+    Parameters
+    ----------
+    cxx : str
+        Path to (or name of) the host C++ compiler.
+
+    Returns
+    -------
+    str
+        The compiler's version banner's first line, or ``""`` if the compiler
+        is missing/unrunnable.
+
+    Notes
+    -----
+    The empty-string degrade is deliberately narrow (audit M8):
+
+    * Only ``OSError`` (missing/permission) and
+      :class:`subprocess.SubprocessError` (timeouts, etc.) are swallowed --
+      a ``KeyboardInterrupt`` or other ``BaseException`` propagates.
+    * The banner is read from ``stdout`` **or** ``stderr``: MSVC's ``cl.exe``
+      prints its version to stderr, so reading only stdout silently yielded an
+      empty version that then collided in the compilation cache key.
+    * Decoding uses ``errors="replace"`` so a non-UTF-8 byte in the banner
+      degrades to a readable version string rather than raising.
+    """
     try:
-        proc = subprocess.run([cxx, "--version"], capture_output=True, text=True, timeout=10)
-        return proc.stdout.splitlines()[0].strip() if proc.stdout else ""
-    except Exception:
+        proc = subprocess.run(
+            [cxx, "--version"], capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
         return ""
+    out = proc.stdout or proc.stderr or ""
+    lines = out.splitlines()
+    return lines[0].strip() if lines else ""
 
 
 def _select_nvcc():
@@ -411,16 +538,21 @@ def _select_nvcc():
     else:
         probes.append(CandidateProbe("BRAINEVENT_NVCC_PATH", "", "unset"))
 
-    # 2. explicit CUDA_HOME
-    home = os.environ.get("CUDA_HOME")
-    if home:
-        cand = os.path.join(home, "bin", exe)
-        if os.path.isfile(cand):
-            probes.append(CandidateProbe("$CUDA_HOME/bin/nvcc", cand, "ok"))
-            return cand, [os.path.join(home, "include")], probes
-        probes.append(CandidateProbe("$CUDA_HOME/bin/nvcc", cand, "not-found"))
-    else:
-        probes.append(CandidateProbe("$CUDA_HOME/bin/nvcc", "", "unset"))
+    # 2. explicit CUDA root env vars. ``CUDA_HOME`` is the conventional Linux
+    #    name; the Windows CUDA installer instead sets ``CUDA_PATH`` (never
+    #    ``CUDA_HOME``), so both must be probed or standard Windows installs go
+    #    undiscovered when nvcc is off PATH (audit H6).
+    for var in ("CUDA_HOME", "CUDA_PATH"):
+        home = os.environ.get(var)
+        src = f"${var}/bin/nvcc"
+        if home:
+            cand = os.path.join(home, "bin", exe)
+            if os.path.isfile(cand):
+                probes.append(CandidateProbe(src, cand, "ok"))
+                return cand, [os.path.join(home, "include")], probes
+            probes.append(CandidateProbe(src, cand, "not-found"))
+        else:
+            probes.append(CandidateProbe(src, "", "unset"))
 
     # 3. preference-ordered pip vs system PATH
     order = ("pip", "system") if get_nvcc_discovery() == "pip" else ("system", "pip")
@@ -457,8 +589,16 @@ def collect_toolchain_diagnostics() -> dict:
     snap["host_cxx"] = cxx or "<not found>"
     if cxx:
         snap["host_cxx_version"] = _cxx_version(cxx)
-    for var in ("BRAINEVENT_NVCC_PATH", "CUDA_HOME", "CXX", "CONDA_PREFIX",
-                "BRAINEVENT_NVCC_PREFER", "BRAINEVENT_ALLOW_UNSUPPORTED_COMPILER",
+    # Surface a stashed GPU-arch detection failure (e.g. a CUDA driver
+    # mismatch raised by ``jax.devices("gpu")``) so it shows up in debug
+    # snapshots, not just in the GpuArchDetectionError (audit M10).
+    with _STATE_LOCK:
+        detect_err = _GPU_DETECT_ERROR
+    if detect_err is not None:
+        snap["gpu_detect_error"] = f"{type(detect_err).__name__}: {detect_err}"
+    for var in ("BRAINEVENT_NVCC_PATH", "CUDA_HOME", "CUDA_PATH", "CXX",
+                "CONDA_PREFIX", "BRAINEVENT_NVCC_PREFER",
+                "BRAINEVENT_ALLOW_UNSUPPORTED_COMPILER",
                 "BRAINEVENT_COMPUTE_CAPABILITIES"):
         snap[f"env:{var}"] = os.environ.get(var, "<unset>")
     return snap
@@ -515,7 +655,10 @@ def detect_cuda_toolchain() -> CudaToolchain:
     # nvcc version
     nvcc_version = ""
     try:
-        proc = subprocess.run([nvcc, "--version"], capture_output=True, text=True, timeout=10)
+        proc = subprocess.run(
+            [nvcc, "--version"], capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=10,
+        )
     except (FileNotFoundError, subprocess.SubprocessError) as e:
         raise NvccNotFoundError(render_toolchain_error(
             stage="nvcc discovery", code="E-NVCC",
@@ -523,6 +666,26 @@ def detect_cuda_toolchain() -> CudaToolchain:
             probes=nvcc_probes,
             remediation=["Verify this nvcc is executable and not corrupted, or use a different nvcc."],
         )) from e
+    # nvcc *ran* but exited non-zero (loader/GLIBC/driver mismatch, a stub
+    # wrapper, ...): stdout is typically empty so the "release" scan below
+    # would find nothing and misreport this as "version could not be
+    # determined". Surface the real status + captured output instead (audit
+    # H5), mirroring the returncode check in ``_arch_from_nvidia_smi``.
+    if proc.returncode != 0:
+        raise NvccNotFoundError(render_toolchain_error(
+            stage="nvcc discovery", code="E-NVCC",
+            summary=(
+                f"nvcc exited with status {proc.returncode}: it was found and "
+                f"launched but failed to run: {nvcc}"
+            ),
+            probes=nvcc_probes,
+            compiler_output=((proc.stdout or "") + (proc.stderr or "")),
+            remediation=[
+                "Check that nvcc's shared-library dependencies resolve (e.g. "
+                "ldd nvcc), the CUDA driver matches the toolkit, and it is not "
+                "a stub wrapper; or use a different nvcc.",
+            ],
+        ))
     for line in proc.stdout.splitlines():
         if "release" in line.lower():
             nvcc_version = line.strip()
@@ -532,9 +695,16 @@ def detect_cuda_toolchain() -> CudaToolchain:
             stage="nvcc discovery", code="E-NVCC",
             summary=f"nvcc exists but its version could not be determined: {nvcc}",
             probes=nvcc_probes,
-            compiler_output=(proc.stdout + proc.stderr),
+            compiler_output=((proc.stdout or "") + (proc.stderr or "")),
             remediation=["Verify this nvcc is executable and not corrupted, or use a different nvcc."],
         ))
+
+    # Validate the resolved CUDA include dir actually has cuda_runtime.h
+    # before we hand the toolchain to the compiler (audit L12): a distro
+    # /usr/bin/nvcc shim's ``../../include`` guess can point at a dir with no
+    # CUDA headers, which would otherwise fail much later with an opaque
+    # "cuda_runtime.h: No such file or directory".
+    _validate_cuda_include(list(cuda_include_dirs), nvcc_probes=nvcc_probes)
 
     # host compiler
     cxx, cxx_probes = _find_host_cxx()
@@ -687,10 +857,19 @@ def _arch_from_jax() -> "list[str] | None":
 
     Returns device order (device 0 first), so the first element is JAX's
     default device.  ``None`` when no GPU device / attribute is available.
+
+    A *broken* CUDA backend (e.g. ``jax.devices("gpu")`` raising on a
+    driver/runtime mismatch) is distinct from "no GPU present": the former's
+    exception is stashed in the module-global ``_GPU_DETECT_ERROR`` so
+    :func:`resolve_compute_capabilities` can surface the real cause instead of
+    a misleading "no GPU detected" (audit M10).
     """
     try:
         devices = jax.devices("gpu")
-    except Exception:
+    except Exception as e:  # noqa: BLE001 - intentionally broad: any backend fault
+        global _GPU_DETECT_ERROR
+        with _STATE_LOCK:
+            _GPU_DETECT_ERROR = e
         return None
     caps: "list[str]" = []
     for d in devices:
@@ -699,7 +878,7 @@ def _arch_from_jax() -> "list[str] | None":
             continue
         try:
             caps.append(normalize_arch(cc))
-        except ValueError:
+        except (ValueError, UnsupportedArchError):
             continue
     return _dedup(caps) or None
 
@@ -722,7 +901,7 @@ def _arch_from_nvidia_smi() -> "list[str] | None":
             continue
         try:
             caps.append(normalize_arch(line))
-        except ValueError:
+        except (ValueError, UnsupportedArchError):
             continue
     return _dedup(caps) or None
 
@@ -748,21 +927,44 @@ def resolve_compute_capabilities(explicit: "str | list[str] | None" = None) -> "
         out = _dedup([normalize_arch(v) for v in _parse_arch_spec(env)])
         if out:
             return out
+    # Clear any stale detection error before re-probing the live backends.
+    global _GPU_DETECT_ERROR
+    with _STATE_LOCK:
+        _GPU_DETECT_ERROR = None
     for source in (_arch_from_jax, _arch_from_nvidia_smi):
         arches = source()
         if arches:
             return arches
+
+    # A backend that *raised* (e.g. JAX's CUDA backend failing on a
+    # driver/runtime mismatch) is reported distinctly from "no GPU present",
+    # so the operator isn't sent down the wrong remediation path (audit M10).
+    with _STATE_LOCK:
+        cause = _GPU_DETECT_ERROR
+    if cause is not None:
+        summary = (
+            "GPU compute-capability detection failed: a CUDA backend raised "
+            f"while querying devices ({type(cause).__name__}). This usually "
+            "means a broken/mismatched CUDA driver or runtime, not the absence "
+            "of a GPU."
+        )
+        compiler_output = f"{type(cause).__name__}: {cause}"
+    else:
+        summary = ("Could not detect a GPU compute capability "
+                   "(no JAX GPU device, and nvidia-smi unavailable).")
+        compiler_output = ""
     raise GpuArchDetectionError(render_toolchain_error(
         stage="compute capability detection", code="E-ARCH",
-        summary="Could not detect a GPU compute capability (no JAX GPU device, and nvidia-smi unavailable).",
+        summary=summary,
         probes=[CandidateProbe("nvidia-smi", shutil.which("nvidia-smi") or "", "not-found")],
+        compiler_output=compiler_output,
         remediation=[
             "Run on a machine with a visible GPU, or",
             "Set BRAINEVENT_COMPUTE_CAPABILITIES (e.g. '8.6,8.0'), or",
             "Call brainevent.config.set_compute_capability('8.6'), or",
             "Pass compute_capability='sm_86' to the load function",
         ],
-    ))
+    )) from cause
 
 
 def detect_cuda_arch() -> "list[str]":

--- a/brainevent/_op/kernix_toolchain_audit_test.py
+++ b/brainevent/_op/kernix_toolchain_audit_test.py
@@ -1,0 +1,245 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Audit-driven reproduction tests for ``kernix_toolchain``.
+
+Each test pins a defect from the 2026-06-13 ``dev/`` audit (H5, H6, M8, M9,
+M10, L12).  Every test is hermetic: ``subprocess.run`` and environment
+variables are monkeypatched so no real ``nvcc``/host compiler/GPU is needed.
+
+Run with ``pytest -m ""`` (the markerless invocation the working agreement
+prescribes).
+"""
+
+import sys
+import threading
+
+import pytest
+
+from brainevent._op import kernix_toolchain as kt
+from brainevent._op.kernix_toolchain import CandidateProbe
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="kernix toolchain tests are not supported on Windows",
+)
+
+
+def _touch_exec(p):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("")
+    p.chmod(0o755)
+
+
+def _fake_proc(*, returncode=0, stdout="", stderr=""):
+    """Build a stand-in for ``subprocess.CompletedProcess``."""
+    return type(
+        "R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr}
+    )()
+
+
+# --- H5: nvcc --version exit code never checked ---------------------------
+
+def test_h5_nvcc_version_nonzero_exit_reports_status(monkeypatch, tmp_path):
+    """nvcc that runs but exits non-zero must surface the status + output.
+
+    Reproduces H5: ``proc.returncode`` was ignored, so a loader/driver
+    mismatch (non-zero exit, empty stdout) was misreported as
+    "version could not be determined".
+    """
+    from brainevent._error import NvccNotFoundError
+
+    nvcc = tmp_path / "cu13" / "bin" / "nvcc"
+    _touch_exec(nvcc)
+    monkeypatch.setattr(
+        kt, "_select_nvcc",
+        lambda: (str(nvcc), [str(tmp_path / "cu13" / "include")], []),
+    )
+    # nvcc launches, but exits 1 with a loader error on stderr and no stdout.
+    monkeypatch.setattr(
+        kt.subprocess, "run",
+        lambda *a, **k: _fake_proc(
+            returncode=1, stdout="",
+            stderr="nvcc: error while loading shared libraries: libcuda.so.1",
+        ),
+    )
+    with pytest.raises(NvccNotFoundError) as ei:
+        kt.detect_cuda_toolchain()
+    msg = str(ei.value)
+    # The message must point at the non-zero exit, not at "version parsing".
+    assert "status 1" in msg
+    assert "libcuda.so.1" in msg
+    assert "could not be determined" not in msg
+
+
+# --- H6: CUDA_PATH never consulted ----------------------------------------
+
+def test_h6_select_nvcc_uses_cuda_path(monkeypatch, tmp_path):
+    """``CUDA_PATH`` (the Windows installer var) must be probed like CUDA_HOME.
+
+    Reproduces H6: only ``CUDA_HOME`` was read, so a standard Windows CUDA
+    install (which sets ``CUDA_PATH``) was never found when nvcc is off PATH.
+    """
+    nvcc = tmp_path / "cudapath" / "bin" / "nvcc"
+    _touch_exec(nvcc)
+    monkeypatch.delenv("BRAINEVENT_NVCC_PATH", raising=False)
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.setenv("CUDA_PATH", str(tmp_path / "cudapath"))
+    # Nothing on PATH and no pip wheel, so CUDA_PATH is the only hit.
+    monkeypatch.setattr(kt, "_find_pip_cuda", lambda roots=None: (None, []))
+    monkeypatch.setattr(kt.shutil, "which", lambda n: None)
+    path, includes, probes = kt._select_nvcc()
+    assert path == str(nvcc)
+    assert includes == [str(tmp_path / "cudapath" / "include")]
+    # A probe must record that CUDA_PATH was the source.
+    assert any("CUDA_PATH" in p.source for p in probes)
+
+
+# --- M8: _cxx_version swallows all exceptions; stderr banner invisible -----
+
+def test_m8_cxx_version_reads_stderr_banner(monkeypatch):
+    """MSVC-style compilers print their banner to stderr; it must be parsed.
+
+    Reproduces the stderr half of M8: only ``stdout`` was read, so every
+    ``cl.exe`` yielded an empty version (cache-key collision).
+    """
+    monkeypatch.setattr(
+        kt.subprocess, "run",
+        lambda *a, **k: _fake_proc(
+            returncode=0, stdout="",
+            stderr="Microsoft (R) C/C++ Optimizing Compiler Version 19.39\n",
+        ),
+    )
+    assert "Microsoft" in kt._cxx_version("cl.exe")
+
+
+def test_m8_cxx_version_filenotfound_degrades(monkeypatch):
+    """A missing compiler still degrades to ``""`` (no crash)."""
+    def boom(*a, **k):
+        raise FileNotFoundError("no such compiler")
+
+    monkeypatch.setattr(kt.subprocess, "run", boom)
+    assert kt._cxx_version("/nope/g++") == ""
+
+
+def test_m8_cxx_version_does_not_swallow_keyboardinterrupt(monkeypatch):
+    """A ``KeyboardInterrupt`` must propagate, not be flattened to ``""``.
+
+    Reproduces the bare-``except`` half of M8: ``except Exception`` already
+    spares ``KeyboardInterrupt``, but the original code's intent (narrow the
+    except) is what we assert here.
+    """
+    def boom(*a, **k):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(kt.subprocess, "run", boom)
+    with pytest.raises(KeyboardInterrupt):
+        kt._cxx_version("/usr/bin/g++")
+
+
+# --- M9: normalize_arch accepts nonsensical caps --------------------------
+
+@pytest.mark.parametrize("bad", ["1.0", "0.0", "sm_00", "sm_10", "10", "00"])
+def test_m9_normalize_arch_rejects_major_lt_2(bad):
+    """No real GPU has compute-capability major < 2; reject it loudly.
+
+    Reproduces M9: ``"0.0"`` and ``"1.0"`` normalized to ``sm_00`` / ``sm_10``
+    and only failed much later inside nvcc.
+    """
+    from brainevent._error import UnsupportedArchError
+    with pytest.raises((UnsupportedArchError, ValueError)):
+        kt.normalize_arch(bad)
+
+
+@pytest.mark.parametrize("good,expected", [
+    ("7.5", "sm_75"), ("8.6", "sm_86"), ("2.0", "sm_20"), ("9.0a", "sm_90a"),
+])
+def test_m9_normalize_arch_still_accepts_valid(good, expected):
+    assert kt.normalize_arch(good) == expected
+
+
+# --- M10: GPU arch detection swallows real driver errors ------------------
+
+def test_m10_jax_driver_error_surfaced_in_message(monkeypatch):
+    """A broken CUDA backend must surface its cause, not look like "no GPU".
+
+    Reproduces M10: ``jax.devices("gpu")`` raising on a driver mismatch was
+    flattened to the same ``None`` as "no GPU present", hiding the traceback.
+    """
+    from brainevent._error import GpuArchDetectionError
+
+    sentinel = "CUDA driver version is insufficient for CUDA runtime version"
+
+    class FakeJax:
+        @staticmethod
+        def devices(kind):
+            raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(kt, "jax", FakeJax)
+    monkeypatch.setattr(kt, "_arch_from_nvidia_smi", lambda: None)
+    monkeypatch.delenv("BRAINEVENT_COMPUTE_CAPABILITIES", raising=False)
+    monkeypatch.setattr(kt, "_COMPUTE_CAPABILITIES", None)
+
+    # _arch_from_jax must not blow up, but it must record the cause.
+    assert kt._arch_from_jax() is None
+    with pytest.raises(GpuArchDetectionError) as ei:
+        kt.resolve_compute_capabilities()
+    assert sentinel in str(ei.value)
+
+
+# --- L12: include validation + global-state lock --------------------------
+
+def test_l12_include_validation_rejects_bogus_dir(monkeypatch, tmp_path):
+    """A resolved include dir lacking ``cuda_runtime.h`` is rejected clearly.
+
+    Reproduces the ``parent.parent`` half of L12: a distro ``/usr/bin/nvcc``
+    shim yields an include dir with no CUDA headers.
+    """
+    from brainevent._error import HeaderNotFoundError
+
+    # nvcc at <prefix>/bin/nvcc → include guessed at <prefix>/include, which
+    # exists but contains no cuda_runtime.h (the distro-shim failure mode).
+    prefix = tmp_path / "usr"
+    nvcc = prefix / "bin" / "nvcc"
+    _touch_exec(nvcc)
+    (prefix / "include").mkdir(parents=True)
+
+    with pytest.raises(HeaderNotFoundError) as ei:
+        kt._validate_cuda_include([str(prefix / "include")], nvcc_probes=[])
+    assert "cuda_runtime.h" in str(ei.value)
+
+
+def test_l12_include_validation_accepts_real_dir(tmp_path):
+    """A dir that does contain ``cuda_runtime.h`` validates without error."""
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "cuda_runtime.h").write_text("/* header */")
+    # Must not raise.
+    kt._validate_cuda_include([str(inc)], nvcc_probes=[])
+
+
+def test_l12_global_state_lock_exists_and_used(monkeypatch):
+    """A ``threading.Lock`` must guard the mutable module caches.
+
+    Reproduces the unsynchronized-globals half of L12.
+    """
+    assert isinstance(kt._STATE_LOCK, type(threading.Lock()))
+
+    # The lock must actually be taken while a setter mutates global state:
+    # patch it with a recording proxy and confirm acquisition.
+    acquired = []
+
+    class RecordingLock:
+        def __enter__(self):
+            acquired.append(True)
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(kt, "_STATE_LOCK", RecordingLock())
+    kt.set_nvcc_discovery("system")
+    try:
+        kt.set_compute_capabilities("8.6")
+    finally:
+        kt.set_compute_capabilities(None)
+    assert acquired, "global-state setters must acquire _STATE_LOCK"

--- a/brainevent/_op/kernix_toolchain_test.py
+++ b/brainevent/_op/kernix_toolchain_test.py
@@ -168,6 +168,7 @@ def test_select_nvcc_env_override(monkeypatch, tmp_path):
 def test_select_nvcc_pip_first(monkeypatch):
     monkeypatch.delenv("BRAINEVENT_NVCC_PATH", raising=False)
     monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)  # H6: now also probed
     monkeypatch.setattr(kt, "_NVCC_DISCOVERY", "pip")
     monkeypatch.setattr(kt, "_find_pip_cuda",
                         lambda roots=None: (("/pip/nvcc", ["/pip/include"]), []))
@@ -180,6 +181,7 @@ def test_select_nvcc_system_pref(monkeypatch, tmp_path):
     from pathlib import Path
     monkeypatch.delenv("BRAINEVENT_NVCC_PATH", raising=False)
     monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)  # H6: now also probed
     monkeypatch.setattr(kt, "_NVCC_DISCOVERY", "system")
     monkeypatch.setattr(kt, "_find_pip_cuda",
                         lambda roots=None: (("/pip/nvcc", ["/pip/include"]), []))
@@ -196,6 +198,7 @@ def test_select_nvcc_system_pref(monkeypatch, tmp_path):
 def test_select_nvcc_not_found(monkeypatch):
     monkeypatch.delenv("BRAINEVENT_NVCC_PATH", raising=False)
     monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)  # H6: now also probed
     monkeypatch.setattr(kt, "_NVCC_DISCOVERY", "pip")
     monkeypatch.setattr(kt, "_find_pip_cuda", lambda roots=None: (None, []))
     monkeypatch.setattr(kt.shutil, "which", lambda n: None)
@@ -222,13 +225,18 @@ def test_detect_cuda_toolchain_no_host_cxx(monkeypatch, tmp_path):
     from brainevent._error import HostCompilerNotFoundError
     nvcc = tmp_path / "cu13" / "bin" / "nvcc"
     _touch_exec(nvcc)
+    inc = tmp_path / "cu13" / "include"
+    inc.mkdir(parents=True, exist_ok=True)
+    (inc / "cuda_runtime.h").write_text("/* header */")  # L12: include is validated
     monkeypatch.setattr(
         kt, "_select_nvcc",
-        lambda: (str(nvcc), [str(tmp_path / "cu13" / "include")], []),
+        lambda: (str(nvcc), [str(inc)], []),
     )
+    # returncode is now inspected (H5), so the stub must provide it.
     monkeypatch.setattr(
         kt.subprocess, "run",
-        lambda *a, **k: type("R", (), {"stdout": "Cuda release 13.0", "stderr": ""})(),
+        lambda *a, **k: type(
+            "R", (), {"returncode": 0, "stdout": "Cuda release 13.0", "stderr": ""})(),
     )
     monkeypatch.setattr(kt, "_find_host_cxx", lambda: (None, []))
     with pytest.raises(HostCompilerNotFoundError) as ei:

--- a/brainevent/_op/main.py
+++ b/brainevent/_op/main.py
@@ -15,13 +15,14 @@
 # ==============================================================================
 
 import functools
+import warnings
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Optional
 
 import jax
-from jax.interpreters import xla, batching, ad, mlir
+from jax.interpreters import batching, ad, mlir
 
-from brainevent._compatible_import import Primitive
+from brainevent._compatible_import import Primitive, apply_primitive
 from brainevent._error import KernelFallbackExhaustedError
 from brainevent._registry import register_primitive
 from brainevent._typing import KernelGenerator
@@ -104,8 +105,8 @@ class XLACustomKernel:
 
     Supported backends by platform:
 
-    - **CPU**: Numba, CUDA
-    - **GPU**: Pallas, CUDA, Numba CUDA, Warp, Triton
+    - **CPU**: Numba, Pallas
+    - **GPU**: Pallas, cuda_raw (nvcc), Numba CUDA, Warp, Triton
     - **TPU**: Pallas
 
     The workflow for using this class is:
@@ -167,19 +168,22 @@ class XLACustomKernel:
         if doc is not None:
             self.__doc__ = doc
 
-        # abstract evaluation
-        self.primitive.def_impl(functools.partial(xla.apply_primitive, self.primitive))
+        # abstract evaluation.  ``apply_primitive`` is resolved version-tolerantly
+        # in ``_compatible_import`` (L3).
+        self.primitive.def_impl(functools.partial(apply_primitive, self.primitive))
         self.primitive.def_abstract_eval(self._abstract_eval)
 
         # batching rule
         self.register_general_batching()
 
         # kernel storage: platform -> backend -> KernelEntry
-        self._kernels: Dict[str, Dict[str, KernelEntry]] = {}
+        self._kernels: dict[str, dict[str, KernelEntry]] = {}
         # default backends per platform: platform -> backend_name
-        self._defaults: Dict[str, str] = {}
+        self._defaults: dict[str, str] = {}
         # tracks which platforms have had lowering registered
         self._registered_platforms: set = set()
+        # backend-selection warnings already emitted (deduplicated, M13)
+        self._warned_backends: set = set()
 
         # call function for benchmarking
         self._call_fn: Optional[Callable] = None
@@ -190,6 +194,23 @@ class XLACustomKernel:
         self._benchmark_data_fn: Optional[Callable] = None
         # Auto-register in global registry
         register_primitive(name, self)
+
+    def _warn_backend_once(self, message: str) -> None:
+        """Emit *message* as a ``UserWarning`` at most once per instance.
+
+        Backend selection runs on every lowering; deduplicating on the message
+        text keeps an ambiguous-backend or ignored-global-backend warning (M13)
+        from repeating on each trace while still surfacing distinct situations.
+
+        Parameters
+        ----------
+        message : str
+            The warning text; also the deduplication key.
+        """
+        if message in self._warned_backends:
+            return
+        self._warned_backends.add(message)
+        warnings.warn(message, stacklevel=3)
 
     def _abstract_eval(self, *ins, outs: OutType, **kwargs):
         """Compute the abstract output types for the primitive.
@@ -400,14 +421,34 @@ class XLACustomKernel:
                 if global_be is not None and global_be in kernels:
                     backend_to_use = global_be
                 else:
+                    if global_be is not None:
+                        # A global backend was requested but is not registered for
+                        # this platform/primitive.  The per-call path raises here;
+                        # the global path stays lenient, but must not *silently*
+                        # discard the user's choice (M13).
+                        self._warn_backend_once(
+                            f"Global backend '{global_be}' is not registered for "
+                            f"platform '{platform}' in primitive '{self.name}'; "
+                            f"ignoring it and using the primitive default."
+                        )
                     backend_to_use = self._defaults.get(platform)
 
             # Get the kernel entry
             if backend_to_use and backend_to_use in kernels:
                 pass
             else:
-                # Fallback to first registered kernel
-                backend_to_use = next(iter(kernels))
+                # No explicit/global/default backend resolved: fall back to the
+                # first registered kernel.  When more than one is registered the
+                # choice is dict-insertion-order arbitrary, so log it (M13).
+                fallback_be = next(iter(kernels))
+                if len(kernels) > 1:
+                    self._warn_backend_once(
+                        f"No default backend set for platform '{platform}' in "
+                        f"primitive '{self.name}'; using first-registered backend "
+                        f"'{fallback_be}' out of {sorted(kernels)}. "
+                        f"Set one explicitly with set_default('{platform}', <backend>)."
+                    )
+                backend_to_use = fallback_be
 
             if backend_to_use == 'pallas':
                 check_pallas_jax_version()
@@ -575,24 +616,22 @@ class XLACustomKernel:
         kg: KernelGenerator,
         asdefault: bool = False
     ):
-        """Register a cuda_raw (nvcc-compiled) kernel for the CPU or GPU platform.
+        """Register a cuda_raw (nvcc-compiled) kernel for the GPU platform.
 
         Convenience wrapper around :meth:`def_kernel` with
-        ``backend='cuda_raw'``.  The kernel generator function should
-        call :func:`brainevent.load_cuda_file` or
-        :func:`brainevent.load_cuda_inline` to compile and
-        register the CUDA kernel, then return a closure that calls it via
-        ``jax.ffi.ffi_call``.
+        ``backend='cuda_raw'`` and ``platform='gpu'`` (a cuda_raw kernel is
+        always GPU; the platform is not configurable).  The kernel generator
+        function should call :func:`brainevent.load_cuda_file` or
+        :func:`brainevent.load_cuda_inline` to compile and register the CUDA
+        kernel, then return a closure that calls it via ``jax.ffi.ffi_call``.
 
         Parameters
         ----------
-        platform : str
-            Target platform.  Must be ``'cpu'`` or ``'gpu'``.
         kg : KernelGenerator
             A callable that compiles and returns the kernel function.
         asdefault : bool, optional
             If ``True``, set cuda_raw as the default backend for the
-            given platform.  Default is ``False``.
+            GPU platform.  Default is ``False``.
 
         See Also
         --------
@@ -711,7 +750,7 @@ class XLACustomKernel:
         return self._defaults.get(platform)
 
     @property
-    def defaults(self) -> Dict[str, str]:
+    def defaults(self) -> dict[str, str]:
         """Return a copy of all default backends.
 
         Returns
@@ -1002,7 +1041,7 @@ class XLACustomKernel:
         ----------
         fn : callable
             A callable with signature
-            ``fn(*, platform: str) -> List[BenchmarkConfig]``.
+            ``fn(*, platform: str) -> list[BenchmarkConfig]``.
 
         See Also
         --------
@@ -1019,7 +1058,7 @@ class XLACustomKernel:
         """
         self._benchmark_data_fn = fn
 
-    def available_backends(self, platform: str) -> List[str]:
+    def available_backends(self, platform: str) -> list[str]:
         """Return the list of registered backend names for a platform.
 
         Parameters
@@ -1063,7 +1102,7 @@ class XLACustomKernel:
         atol: float = 1e-3,
         verbose: bool = False,
         catch_errors: bool = True,
-        backends: Optional[List[str]] = None,
+        backends: Optional[list[str]] = None,
     ) -> BenchmarkResult:
         """Benchmark all registered backends across every configured data config.
 
@@ -1163,7 +1202,7 @@ class XLACustomKernel:
 
         configs = self._benchmark_data_fn(platform=platform)
 
-        records: List[BenchmarkRecord] = []
+        records: list[BenchmarkRecord] = []
 
         for config in configs:
             config_outputs = {}  # backend -> output for cross-backend comparison

--- a/brainevent/_op/main_audit_test.py
+++ b/brainevent/_op/main_audit_test.py
@@ -1,0 +1,99 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Audit tests for ``brainevent/_op/main.py`` (L3, M13).
+
+* L3 - ``apply_primitive`` is resolved through the ``_compatible_import`` shim
+  and is identical to the function the legacy ``jax.interpreters.xla`` path
+  exposed.
+* M13 - a global backend that is not registered for a platform no longer fails
+  silently: the selection emits a (deduplicated) warning and falls back to the
+  primitive default, still producing the correct result.
+"""
+
+import importlib.util
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jax.interpreters import xla
+
+from brainevent._compatible_import import apply_primitive
+from brainevent._op.main import XLACustomKernel
+from brainevent.config import set_backend, clear_backends
+
+numba_installed = importlib.util.find_spec('numba') is not None
+
+
+def test_l3_apply_primitive_shim_is_xla_apply_primitive():
+    """The shim resolves to exactly the same callable as the legacy path."""
+    assert xla.apply_primitive is apply_primitive
+
+
+def test_m13_warn_backend_once_deduplicates():
+    """``_warn_backend_once`` emits each distinct message at most once."""
+    k = XLACustomKernel('m13_dedup_probe')
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        k._warn_backend_once('message-A')
+        k._warn_backend_once('message-A')  # duplicate -> suppressed
+        k._warn_backend_once('message-B')
+    messages = [str(w.message) for w in caught]
+    assert messages == ['message-A', 'message-B']
+
+
+@pytest.mark.skipif(not numba_installed, reason='Numba not installed')
+def test_m13_unregistered_global_backend_warns_and_falls_back():
+    """A global backend absent for this platform warns, then uses the default."""
+    import numba
+    from brainevent import numba_kernel
+
+    def gen(**kwargs):
+        @numba.njit
+        def add_one(x, out):
+            for i in range(x.size):
+                out[i] = x[i] + 1.0
+
+        def kernel(x):
+            return numba_kernel(add_one, outs=kwargs['outs'])(x)
+
+        return kernel
+
+    prim = XLACustomKernel('m13_global_mismatch_probe')
+    prim.def_numba_kernel(gen)  # 'numba' becomes the cpu default automatically
+
+    cpu = jax.devices('cpu')[0]
+    x = jax.device_put(jnp.arange(8, dtype=jnp.float32), cpu)
+
+    # Request a global cpu backend that was never registered for this primitive.
+    set_backend('cpu', 'warp')
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            out = prim(x, outs=[jax.ShapeDtypeStruct((8,), jnp.float32)])
+            jax.block_until_ready(out)
+        text = ' '.join(str(w.message) for w in caught)
+        assert 'warp' in text and 'ignoring' in text.lower(), text
+        # ...and the fallback still produced the correct numbers.
+        np.testing.assert_allclose(np.asarray(out[0]), np.arange(8) + 1.0)
+    finally:
+        clear_backends()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/brainevent/_op/numba_cuda_ffi.py
+++ b/brainevent/_op/numba_cuda_ffi.py
@@ -13,23 +13,29 @@
 # limitations under the License.
 # ==============================================================================
 
+import contextlib
 import ctypes
 import importlib.util
 import threading
 import traceback
-from ctypes import c_void_p, c_size_t, POINTER, CFUNCTYPE, Structure
+from ctypes import c_void_p, POINTER, CFUNCTYPE
 from typing import Callable, Dict, Tuple, Union
 
 import jax
 import numpy as np
 
 from .numba_ffi import (
+    XLA_FFI_API_MAJOR,
+    XLA_FFI_API_MINOR,
+    XLA_FFI_Error_Code,
     XLA_FFI_Extension_Type,
-    XLA_FFI_Extension_Base,
     XLA_FFI_Metadata_Extension,
     XLA_FFI_CallFrame,
     XLA_FFI_Buffer,
-    _XLA_FFI_DTYPE_TO_NUMPY,
+    make_ffi_error,
+    resolve_buffer_dtype,
+    get_xla_stream,
+    get_device_ordinal,
     _normalize_shapes_and_dtypes,
 )
 from .util import OutType, abstract_arguments
@@ -73,116 +79,57 @@ def import_numba_cuda():
     return cuda
 
 _NUMBA_CUDA_FFI_HANDLES: Dict[str, object] = {}
+# Maps a kernel/shape/dtype/launch signature to an already-registered FFI
+# target so repeated eager calls reuse one registration instead of leaking a
+# fresh handler (and ctypes callback) per call (H1).
+_NUMBA_CUDA_FFI_TARGETS: Dict[tuple, str] = {}
 _CUDA_FFI_CALLBACK_COUNTER = 0
-_CUDA_FFI_CALLBACK_LOCK = threading.Lock()
+# Serializes target registration (trace/lowering time).  There is deliberately
+# no per-launch lock: each callback operates only on its own call-local device
+# arrays and on XLA's stream, so concurrent launches cannot race (L15).
+_CUDA_REGISTRATION_LOCK = threading.Lock()
 
 # The typed FFI callback signature: void* fn(XLA_FFI_CallFrame*)
 _CUDA_FFI_CALLBACK_TYPE = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_CallFrame))
 
 
 # ---------------------------------------------------------------------------
-# XLA FFI API structures for CUDA stream extraction
-# (Based on XLA's C API: xla/ffi/api/c_api.h)
+# Device-context binding
+#
+# The XLA FFI ctypes structures, the stream getter and the device-ordinal
+# getter live in ``numba_ffi`` (the single source of truth for the FFI ABI).
+# This bridge imports ``get_xla_stream`` / ``get_device_ordinal`` from there
+# and only adds the numba-CUDA-specific device-context helper below.
 # ---------------------------------------------------------------------------
 
-class XLA_FFI_Api_Version(Structure):
-    """XLA FFI API version structure.
+def _device_context(ordinal):
+    """Return a context manager binding numba.cuda to device *ordinal*.
 
-    Mirrors the ``XLA_FFI_Api_Version`` struct from XLA's C API header
-    (``xla/ffi/api/c_api.h``).  Used internally to interpret version
-    information from the XLA FFI API pointer.
-    """
-    _fields_ = [
-        ("struct_size", c_size_t),
-        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
-        ("major_version", ctypes.c_int),
-        ("minor_version", ctypes.c_int),
-    ]
-
-
-class XLA_FFI_Stream_Get_Args(Structure):
-    """Arguments for the ``XLA_FFI_Stream_Get`` function.
-
-    Mirrors the ``XLA_FFI_Stream_Get_Args`` struct from XLA's C API.
-    The ``ctx`` field is set to the execution context from the call
-    frame, and ``stream`` is populated by XLA with the active CUDA
-    stream pointer upon return.
-    """
-    _fields_ = [
-        ("struct_size", c_size_t),
-        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
-        ("ctx", c_void_p),  # XLA_FFI_ExecutionContext*
-        ("stream", c_void_p),  # Output: cudaStream_t
-    ]
-
-
-# Function pointer type: XLA_FFI_Error* (*XLA_FFI_Stream_Get)(XLA_FFI_Stream_Get_Args*)
-_XLA_FFI_Stream_Get_Fn = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_Stream_Get_Args))
-
-
-class XLA_FFI_Api(Structure):
-    """Partial mirror of the ``XLA_FFI_Api`` structure from XLA's C API.
-
-    Only fields up to and including ``XLA_FFI_Stream_Get`` are declared;
-    later fields are not needed for CUDA stream extraction and are
-    omitted.
-
-    See Also
-    --------
-    _get_stream_from_callframe : Uses this structure to extract the
-        CUDA stream from an XLA call frame.
-    """
-    _fields_ = [
-        ("struct_size", c_size_t),
-        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
-        ("api_version", XLA_FFI_Api_Version),  # Embedded struct, not pointer
-        ("internal_api", c_void_p),
-        ("XLA_FFI_Error_Create", c_void_p),
-        ("XLA_FFI_Error_GetMessage", c_void_p),
-        ("XLA_FFI_Error_Destroy", c_void_p),
-        ("XLA_FFI_Handler_Register", c_void_p),
-        ("XLA_FFI_Stream_Get", _XLA_FFI_Stream_Get_Fn),
-        # ... other fields not needed for stream extraction
-    ]
-
-
-def _get_stream_from_callframe(call_frame) -> int:
-    """Extract the CUDA stream pointer from an XLA FFI call frame.
-
-    Calls the ``XLA_FFI_Stream_Get`` function exposed by XLA's API
-    pointer to obtain the ``cudaStream_t`` associated with the current
-    execution context.
+    XLA may place an FFI call on any visible GPU; the device arrays and the
+    stream must be constructed on *that* device's context, not on whatever
+    device numba currently has selected (C3).  Entering ``cuda.gpus[ordinal]``
+    pushes the matching device context for the duration of the launch.
 
     Parameters
     ----------
-    call_frame : XLA_FFI_CallFrame
-        The call frame structure passed to the FFI callback by XLA.
+    ordinal : int or None
+        Device ordinal reported by ``XLA_FFI_DeviceOrdinal_Get``.  ``None``
+        (older jaxlib that does not expose the ordinal) yields a
+        :class:`contextlib.nullcontext`, falling back to numba's current
+        device.
 
     Returns
     -------
-    int
-        The CUDA stream pointer (``cudaStream_t``) as a Python integer.
-
-    Notes
-    -----
-    This function is internal and should not be called directly.  It is
-    used by :class:`NumbaCudaFfiHandler` and
-    :class:`NumbaCudaCallableHandler` to obtain the XLA-managed CUDA
-    stream for zero-copy kernel launches.
+    context manager
+        Binds the requested device on ``__enter__`` and restores the previous
+        device on ``__exit__``.
     """
-    api = call_frame.api
-    # Prepare stream get arguments
-    stream_args = XLA_FFI_Stream_Get_Args()
-    stream_args.struct_size = ctypes.sizeof(XLA_FFI_Stream_Get_Args)
-    stream_args.extension_start = POINTER(XLA_FFI_Extension_Base)()
-    stream_args.ctx = call_frame.ctx
-    stream_args.stream = None
-
-    # Call XLA's stream getter
-    api_ptr = ctypes.cast(api, POINTER(XLA_FFI_Api))
-    api_ptr.contents.XLA_FFI_Stream_Get(stream_args)
-
-    return stream_args.stream
+    if ordinal is None:
+        return contextlib.nullcontext()
+    try:
+        return import_numba_cuda().gpus[ordinal]
+    except Exception:  # noqa: BLE001 - unknown ordinal -> keep current device
+        return contextlib.nullcontext()
 
 
 def _numba_stream_from_ptr(stream_ptr: int):
@@ -192,7 +139,7 @@ def _numba_stream_from_ptr(stream_ptr: int):
     ----------
     stream_ptr : int
         The ``cudaStream_t`` pointer as a Python integer (e.g.,
-        obtained from :func:`_get_stream_from_callframe`).
+        obtained from :func:`brainevent._op.numba_ffi.get_xla_stream`).
 
     Returns
     -------
@@ -229,7 +176,18 @@ def _device_array_from_buffer(data_ptr: int, shape: Tuple[int, ...], dtype: np.d
     The returned array does **not** own the underlying memory.  The
     caller must ensure that the memory remains valid for the lifetime
     of the array.
+
+    A zero-element buffer is materialised as a fresh empty device array
+    rather than wrapped, because XLA may hand a null pointer for an empty
+    buffer and ``as_cuda_array`` rejects a null base pointer (M3).
     """
+    dtype = np.dtype(dtype)
+    shape = tuple(int(d) for d in shape)
+    size = 1
+    for d in shape:
+        size *= d
+    if size == 0:
+        return import_numba_cuda().device_array(shape, dtype=dtype)
 
     class DevicePointerWrapper:
         """Wrapper class that implements __cuda_array_interface__ protocol."""
@@ -241,10 +199,14 @@ def _device_array_from_buffer(data_ptr: int, shape: Tuple[int, ...], dtype: np.d
 
         @property
         def __cuda_array_interface__(self):
+            # ``strides`` is ``None`` to declare the buffer C-contiguous; the
+            # ffi_call ``input_layouts``/``output_layouts`` make XLA honour
+            # this (M4), so the row-major reshape from ``shape`` is exact.
             return {
                 'shape': self._shape,
                 'typestr': self._dtype.str,
                 'data': (self._ptr, False),  # (ptr, read_only)
+                'strides': None,
                 'version': 3,
             }
 
@@ -283,7 +245,14 @@ def _compute_launch_config(
     Raises
     ------
     ValueError
-        If *launch_dims* has more than 3 dimensions.
+        If *launch_dims* has zero or more than 3 dimensions, contains a
+        negative extent, or if *threads_per_block* is not positive.
+
+    Notes
+    -----
+    A zero extent along an axis is allowed and yields a grid of ``0`` blocks
+    along that axis (an empty launch); the per-axis block size is clamped to a
+    minimum of ``1`` so the grid computation never divides by zero (M3).
 
     Examples
     --------
@@ -303,33 +272,22 @@ def _compute_launch_config(
     """
     if isinstance(launch_dims, int):
         launch_dims = (launch_dims,)
+    launch_dims = tuple(int(d) for d in launch_dims)
 
-    if len(launch_dims) == 1:
-        total = launch_dims[0]
-        block = (min(threads_per_block, total),)
-        grid = ((total + block[0] - 1) // block[0],)
-    elif len(launch_dims) == 2:
-        # For 2D, use a square-ish block
-        block_x = min(16, launch_dims[0])
-        block_y = min(16, launch_dims[1])
-        block = (block_x, block_y)
-        grid = (
-            (launch_dims[0] + block[0] - 1) // block[0],
-            (launch_dims[1] + block[1] - 1) // block[1],
-        )
-    elif len(launch_dims) == 3:
-        # For 3D
-        block_x = min(8, launch_dims[0])
-        block_y = min(8, launch_dims[1])
-        block_z = min(4, launch_dims[2])
-        block = (block_x, block_y, block_z)
-        grid = (
-            (launch_dims[0] + block[0] - 1) // block[0],
-            (launch_dims[1] + block[1] - 1) // block[1],
-            (launch_dims[2] + block[2] - 1) // block[2],
-        )
-    else:
-        raise ValueError(f"launch_dims must have 1-3 dimensions, got {len(launch_dims)}")
+    n = len(launch_dims)
+    if n < 1 or n > 3:
+        raise ValueError(f"launch_dims must have 1-3 dimensions, got {n}")
+    if any(d < 0 for d in launch_dims):
+        raise ValueError(f"launch_dims extents must be non-negative, got {launch_dims}")
+    if threads_per_block < 1:
+        raise ValueError(f"threads_per_block must be positive, got {threads_per_block}")
+
+    # Per-axis caps: 1-D uses the configurable budget, 2-D a 16x16 tile, 3-D an
+    # 8x8x4 tile.  ``max(1, ...)`` guards a zero extent so the grid division
+    # below never divides by zero; a zero extent then produces a 0-block grid.
+    caps = {1: (threads_per_block,), 2: (16, 16), 3: (8, 8, 4)}[n]
+    block = tuple(max(1, min(cap, dim)) for cap, dim in zip(caps, launch_dims))
+    grid = tuple((dim + blk - 1) // blk for dim, blk in zip(launch_dims, block))
 
     return grid, block
 
@@ -423,8 +381,11 @@ class NumbaCudaFfiHandler:
 
         Returns
         -------
-        None
-            Returns ``None`` to indicate success to XLA.
+        None or int
+            ``None`` (XLA OkStatus) on success, or an ``XLA_FFI_Error*``
+            pointer (as an integer) when the launch raised, so the failure
+            surfaces to the JAX caller instead of being reported as success
+            (C1).
         """
         try:
             call_frame = call_frame_ptr.contents
@@ -438,42 +399,64 @@ class NumbaCudaFfiHandler:
                         ext_ptr, POINTER(XLA_FFI_Metadata_Extension)
                     ).contents
                     metadata = metadata_ext.metadata.contents
-                    metadata.api_version.major_version = 0
-                    metadata.api_version.minor_version = 1
+                    metadata.api_version.major_version = XLA_FFI_API_MAJOR
+                    metadata.api_version.minor_version = XLA_FFI_API_MINOR
                     metadata.traits = 0  # not command-buffer-compatible
                     return None  # success
 
-            # Extract input buffers as CUDA device arrays
-            n_inputs = call_frame.args.size
-            input_arrays = []
-            for i in range(n_inputs):
-                buf_ptr = ctypes.cast(
-                    call_frame.args.args[i], POINTER(XLA_FFI_Buffer)
-                ).contents
-                shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype, self.input_dtypes[i])
-                input_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
+            api_ptr = call_frame.api
+            ctx = call_frame.ctx
 
-            # Extract output buffers as CUDA device arrays
-            n_outputs = call_frame.rets.size
-            output_arrays = []
-            for i in range(n_outputs):
-                buf_ptr = ctypes.cast(
-                    call_frame.rets.rets[i], POINTER(XLA_FFI_Buffer)
-                ).contents
-                shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype, self.output_dtypes[i])
-                output_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
+            # Bind the GPU XLA placed this call on before building any device
+            # array or stream, so they reference the correct device (C3).
+            ordinal = get_device_ordinal(api_ptr, ctx)
+            with _device_context(ordinal):
+                # Extract input buffers as CUDA device arrays.  ``resolve_buffer_dtype``
+                # raises on a known-but-unsupported dtype (e.g. bf16, which numba
+                # CUDA cannot launch) rather than silently mis-decoding it (C2).
+                n_inputs = call_frame.args.size
+                input_arrays = []
+                for i in range(n_inputs):
+                    buf_ptr = ctypes.cast(
+                        call_frame.args.args[i], POINTER(XLA_FFI_Buffer)
+                    ).contents
+                    shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
+                    dtype = resolve_buffer_dtype(buf_ptr.dtype, self.input_dtypes[i])
+                    input_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
 
-            # Extract XLA's CUDA stream and launch kernel on it
-            stream_ptr = _get_stream_from_callframe(call_frame)
-            # Use XLA's stream - no synchronization needed
-            stream = _numba_stream_from_ptr(stream_ptr)
-            with _CUDA_FFI_CALLBACK_LOCK:
-                self.kernel[self.grid, self.block, stream, self.shared_mem](*input_arrays, *output_arrays)
+                # Extract output buffers as CUDA device arrays
+                n_outputs = call_frame.rets.size
+                output_arrays = []
+                for i in range(n_outputs):
+                    buf_ptr = ctypes.cast(
+                        call_frame.rets.rets[i], POINTER(XLA_FFI_Buffer)
+                    ).contents
+                    shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
+                    dtype = resolve_buffer_dtype(buf_ptr.dtype, self.output_dtypes[i])
+                    output_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
 
-        except Exception:
+                # Extract XLA's CUDA stream (checked: a failed lookup raises
+                # rather than yielding a null/garbage stream) and launch on it.
+                stream_ptr = get_xla_stream(api_ptr, ctx)
+                stream = _numba_stream_from_ptr(stream_ptr)
+
+                # Skip a degenerate launch: a zero grid/block dimension is a
+                # driver error and there is no work for an empty problem (M3).
+                if 0 not in self.grid and 0 not in self.block:
+                    self.kernel[self.grid, self.block, stream, self.shared_mem](*input_arrays, *output_arrays)
+
+        except Exception as exc:  # noqa: BLE001 - surfaced to XLA as an FFI error
             traceback.print_exc()
+            try:
+                err_api_ptr = call_frame_ptr.contents.api
+            except Exception:
+                err_api_ptr = None
+            return make_ffi_error(
+                err_api_ptr,
+                XLA_FFI_Error_Code.INTERNAL,
+                f'Numba CUDA kernel {self.name!r} raised '
+                f'{type(exc).__name__}: {exc}',
+            )
 
         return None  # success
 
@@ -534,28 +517,44 @@ def _register_numba_cuda_ffi_target(
 
     import_numba_cuda()
 
-    target_name = f'brainevent_numba_cuda_ffi_{_CUDA_FFI_CALLBACK_COUNTER}'
-    _CUDA_FFI_CALLBACK_COUNTER += 1
-
-    handler = NumbaCudaFfiHandler(
-        name=target_name,
-        kernel=kernel,
-        input_shapes=input_shapes,
-        input_dtypes=input_dtypes,
-        output_shapes=output_shapes,
-        output_dtypes=output_dtypes,
-        grid=grid,
-        block=block,
-        shared_mem=shared_mem,
-    )
-
-    # Keep the handler alive to prevent GC of ctypes callback
-    _NUMBA_CUDA_FFI_HANDLES[target_name] = handler
-
     out_types = tuple(
         jax.ShapeDtypeStruct(shape, dtype)
         for shape, dtype in zip(output_shapes, output_dtypes)
     )
+
+    # Reuse an existing registration for an identical kernel/signature.  Every
+    # eager call would otherwise mint a fresh target name and register a new FFI
+    # handler, leaking one handler (and ctypes callback) per call (H1).  The
+    # cached handler keeps *kernel* alive, so ``id(kernel)`` cannot be recycled
+    # while the entry lives.
+    signature = (
+        id(kernel), input_shapes, input_dtypes, output_shapes, output_dtypes,
+        grid, block, shared_mem,
+    )
+    with _CUDA_REGISTRATION_LOCK:
+        cached_name = _NUMBA_CUDA_FFI_TARGETS.get(signature)
+        if cached_name is not None:
+            return cached_name, out_types
+
+        target_name = f'brainevent_numba_cuda_ffi_{_CUDA_FFI_CALLBACK_COUNTER}'
+        _CUDA_FFI_CALLBACK_COUNTER += 1
+
+        handler = NumbaCudaFfiHandler(
+            name=target_name,
+            kernel=kernel,
+            input_shapes=input_shapes,
+            input_dtypes=input_dtypes,
+            output_shapes=output_shapes,
+            output_dtypes=output_dtypes,
+            grid=grid,
+            block=block,
+            shared_mem=shared_mem,
+        )
+
+        # Keep the handler alive to prevent GC of ctypes callback
+        _NUMBA_CUDA_FFI_HANDLES[target_name] = handler
+        _NUMBA_CUDA_FFI_TARGETS[signature] = target_name
+
     return target_name, out_types
 
 
@@ -622,7 +621,7 @@ def numba_cuda_kernel(
         If Numba with CUDA support is not available.
     ValueError
         If neither ``(grid, block)`` nor ``launch_dims`` is specified.
-    AssertionError
+    TypeError
         If *kernel* is not a ``numba.cuda.dispatcher.CUDADispatcher``.
 
     See Also
@@ -634,9 +633,9 @@ def numba_cuda_kernel(
 
     Notes
     -----
-    Each call to the returned function registers a **new** FFI target.
-    For performance-critical inner loops, consider caching the returned
-    callable.
+    Registrations are memoised by ``(kernel, shapes, dtypes, grid, block,
+    shared_mem)``: repeated calls with an identical signature reuse a single
+    FFI target instead of leaking one handler per call (H1).
 
     Examples
     --------
@@ -676,11 +675,13 @@ def numba_cuda_kernel(
 
     from numba.cuda.dispatcher import CUDADispatcher
 
-    # Validate kernel type
-    assert isinstance(kernel, CUDADispatcher), (
-        f'The kernel must be a Numba CUDA JIT-compiled function (from @cuda.jit), '
-        f'but got {type(kernel).__name__}.'
-    )
+    # Validate kernel type.  Use an explicit ``raise`` rather than ``assert`` so
+    # the check survives ``python -O`` (which strips assertions) (L14).
+    if not isinstance(kernel, CUDADispatcher):
+        raise TypeError(
+            f'The kernel must be a Numba CUDA JIT-compiled function (from @cuda.jit), '
+            f'but got {type(kernel).__name__}.'
+        )
 
     # Compute grid and block dimensions
     if grid is not None and block is not None:
@@ -706,6 +707,11 @@ def numba_cuda_kernel(
         tuple(out.dtype for out in out_info),
         'output',
     )
+    # Pin row-major layouts so XLA hands the handler C-contiguous device
+    # buffers; the callback wraps them by ``dims`` only and cannot recover a
+    # non-default layout from ``XLA_FFI_Buffer`` (M4).  ``ffi_call`` takes
+    # layouts major-to-minor, so row-major is ``range(ndim)``.
+    output_layouts = tuple(tuple(range(len(out.shape))) for out in out_info)
 
     def call(*ins):
         """Invoke the registered Numba CUDA kernel through XLA FFI.
@@ -727,6 +733,7 @@ def numba_cuda_kernel(
             tuple(inp.dtype for inp in in_info),
             'input',
         )
+        input_layouts = tuple(tuple(range(len(shape))) for shape in input_shapes)
 
         # Register FFI target
         target_name, out_types = _register_numba_cuda_ffi_target(
@@ -746,6 +753,8 @@ def numba_cuda_kernel(
             out_types,
             input_output_aliases=input_output_aliases,
             vmap_method=vmap_method,
+            input_layouts=list(input_layouts),
+            output_layouts=list(output_layouts),
         )(*ins)
 
         return jax.tree.unflatten(out_treedef, result)
@@ -758,8 +767,10 @@ def numba_cuda_kernel(
 # ===========================================================================
 
 _NUMBA_CUDA_CALLABLE_HANDLES: Dict[str, object] = {}
+# Maps a func/io-count/shape/dtype signature to an already-registered target so
+# repeated eager calls reuse one registration instead of leaking per call (H1).
+_NUMBA_CUDA_CALLABLE_TARGETS: Dict[tuple, str] = {}
 _CUDA_CALLABLE_CALLBACK_COUNTER = 0
-_CUDA_CALLABLE_LOCK = threading.Lock()
 
 # The typed FFI callback signature: void* fn(XLA_FFI_CallFrame*)
 _CUDA_CALLABLE_CALLBACK_TYPE = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_CallFrame))
@@ -847,8 +858,11 @@ class NumbaCudaCallableHandler:
 
         Returns
         -------
-        None
-            Returns ``None`` to indicate success to XLA.
+        None or int
+            ``None`` (XLA OkStatus) on success, or an ``XLA_FFI_Error*``
+            pointer (as an integer) when the user function raised, so the
+            failure surfaces to the JAX caller instead of being reported as
+            success (C1).
         """
         try:
             call_frame = call_frame_ptr.contents
@@ -862,52 +876,64 @@ class NumbaCudaCallableHandler:
                         ext_ptr, POINTER(XLA_FFI_Metadata_Extension)
                     ).contents
                     metadata = metadata_ext.metadata.contents
-                    metadata.api_version.major_version = 0
-                    metadata.api_version.minor_version = 1
+                    metadata.api_version.major_version = XLA_FFI_API_MAJOR
+                    metadata.api_version.minor_version = XLA_FFI_API_MINOR
                     metadata.traits = 0  # not command-buffer-compatible
                     return None  # success
 
-            # Extract input buffers as Numba CUDA device arrays
-            n_inputs = call_frame.args.size
-            input_arrays = []
-            for i in range(n_inputs):
-                buf_ptr = ctypes.cast(
-                    call_frame.args.args[i], POINTER(XLA_FFI_Buffer)
-                ).contents
-                shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype)
-                if dtype is None and i < len(self.input_dtypes):
-                    dtype = self.input_dtypes[i]
-                elif dtype is None:
-                    dtype = np.dtype(np.float32)
-                input_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
+            api_ptr = call_frame.api
+            ctx = call_frame.ctx
 
-            # Extract output buffers as Numba CUDA device arrays
-            n_outputs = call_frame.rets.size
-            output_arrays = []
-            for i in range(n_outputs):
-                buf_ptr = ctypes.cast(
-                    call_frame.rets.rets[i], POINTER(XLA_FFI_Buffer)
-                ).contents
-                shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype)
-                if dtype is None and i < len(self.output_dtypes):
-                    dtype = self.output_dtypes[i]
-                elif dtype is None:
-                    dtype = np.dtype(np.float32)
-                output_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
+            # Bind the GPU XLA placed this call on before building any device
+            # array or stream, so they reference the correct device (C3).
+            ordinal = get_device_ordinal(api_ptr, ctx)
+            with _device_context(ordinal):
+                # Extract input buffers.  ``resolve_buffer_dtype`` raises on a
+                # known-but-unsupported dtype rather than silently mis-decoding
+                # it, and uses the abstract fallback for an unknown code (C2).
+                n_inputs = call_frame.args.size
+                input_arrays = []
+                for i in range(n_inputs):
+                    buf_ptr = ctypes.cast(
+                        call_frame.args.args[i], POINTER(XLA_FFI_Buffer)
+                    ).contents
+                    shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
+                    fallback = self.input_dtypes[i] if i < len(self.input_dtypes) else np.dtype(np.float32)
+                    dtype = resolve_buffer_dtype(buf_ptr.dtype, fallback)
+                    input_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
 
-            # Extract XLA's CUDA stream and create Numba stream wrapper
-            stream_ptr = _get_stream_from_callframe(call_frame)
-            stream = _numba_stream_from_ptr(stream_ptr)
+                # Extract output buffers as Numba CUDA device arrays
+                n_outputs = call_frame.rets.size
+                output_arrays = []
+                for i in range(n_outputs):
+                    buf_ptr = ctypes.cast(
+                        call_frame.rets.rets[i], POINTER(XLA_FFI_Buffer)
+                    ).contents
+                    shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
+                    fallback = self.output_dtypes[i] if i < len(self.output_dtypes) else np.dtype(np.float32)
+                    dtype = resolve_buffer_dtype(buf_ptr.dtype, fallback)
+                    output_arrays.append(_device_array_from_buffer(buf_ptr.data, shape, dtype))
 
-            # Call the user function
-            # Signature: func(in1, in2, ..., out1, out2, ..., stream)
-            with _CUDA_CALLABLE_LOCK:
+                # Extract XLA's CUDA stream (checked) and create Numba wrapper.
+                stream_ptr = get_xla_stream(api_ptr, ctx)
+                stream = _numba_stream_from_ptr(stream_ptr)
+
+                # Call the user function
+                # Signature: func(in1, in2, ..., out1, out2, ..., stream)
                 self.func(*input_arrays, *output_arrays, stream)
 
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - surfaced to XLA as an FFI error
             traceback.print_exc()
+            try:
+                err_api_ptr = call_frame_ptr.contents.api
+            except Exception:
+                err_api_ptr = None
+            return make_ffi_error(
+                err_api_ptr,
+                XLA_FFI_Error_Code.INTERNAL,
+                f'Numba CUDA callable {self.name!r} raised '
+                f'{type(exc).__name__}: {exc}',
+            )
 
         return None  # success
 
@@ -964,26 +990,39 @@ def _register_numba_cuda_callable_target(
 
     import_numba_cuda()
 
-    target_name = f'brainevent_numba_cuda_callable_{_CUDA_CALLABLE_CALLBACK_COUNTER}'
-    _CUDA_CALLABLE_CALLBACK_COUNTER += 1
-
-    handler = NumbaCudaCallableHandler(
-        name=target_name,
-        func=func,
-        num_inputs=num_inputs,
-        num_outputs=num_outputs,
-        input_dtypes=input_dtypes,
-        output_shapes=output_shapes,
-        output_dtypes=output_dtypes,
-    )
-
-    # Keep the handler alive to prevent GC of the ctypes callback
-    _NUMBA_CUDA_CALLABLE_HANDLES[target_name] = handler
-
     out_types = tuple(
         jax.ShapeDtypeStruct(shape, dtype)
         for shape, dtype in zip(output_shapes, output_dtypes)
     )
+
+    # Reuse an existing registration for an identical func/signature so repeated
+    # eager calls do not each leak a handler and ctypes callback (H1).  The
+    # cached handler keeps *func* alive, so ``id(func)`` cannot be recycled.
+    signature = (
+        id(func), num_inputs, num_outputs, input_dtypes, output_shapes, output_dtypes,
+    )
+    with _CUDA_REGISTRATION_LOCK:
+        cached_name = _NUMBA_CUDA_CALLABLE_TARGETS.get(signature)
+        if cached_name is not None:
+            return cached_name, out_types
+
+        target_name = f'brainevent_numba_cuda_callable_{_CUDA_CALLABLE_CALLBACK_COUNTER}'
+        _CUDA_CALLABLE_CALLBACK_COUNTER += 1
+
+        handler = NumbaCudaCallableHandler(
+            name=target_name,
+            func=func,
+            num_inputs=num_inputs,
+            num_outputs=num_outputs,
+            input_dtypes=input_dtypes,
+            output_shapes=output_shapes,
+            output_dtypes=output_dtypes,
+        )
+
+        # Keep the handler alive to prevent GC of the ctypes callback
+        _NUMBA_CUDA_CALLABLE_HANDLES[target_name] = handler
+        _NUMBA_CUDA_CALLABLE_TARGETS[signature] = target_name
+
     return target_name, out_types
 
 
@@ -1050,9 +1089,9 @@ def numba_cuda_callable(
 
     Notes
     -----
-    Each call to the returned function registers a new FFI target.  For
-    performance-critical inner loops, consider caching the returned
-    callable.
+    Registrations are memoised by ``(func, io-counts, shapes, dtypes)``:
+    repeated calls with an identical signature reuse a single FFI target
+    instead of leaking one handler per call (H1).
 
     Scalar (0-d) inputs are not supported because Numba CUDA cannot
     create device arrays from 0-d buffers.  Wrap scalar values in 1-d
@@ -1111,6 +1150,8 @@ def numba_cuda_callable(
         'output',
     )
     num_outputs = len(out_info)
+    # Pin row-major layouts so XLA hands C-contiguous device buffers (M4).
+    output_layouts = tuple(tuple(range(len(out.shape))) for out in out_info)
 
     def call(*inputs):
         """Invoke the registered callable through XLA FFI.
@@ -1139,6 +1180,7 @@ def numba_cuda_callable(
         # -- collect input metadata --------------------------------------------
         in_info, _ = abstract_arguments(inputs)
         input_dtypes = tuple(np.dtype(inp.dtype) for inp in in_info)
+        input_layouts = tuple(tuple(range(len(inp.shape))) for inp in in_info)
 
         # -- register the FFI target -------------------------------------------
         target_name, out_types = _register_numba_cuda_callable_target(
@@ -1156,6 +1198,8 @@ def numba_cuda_callable(
             out_types,
             input_output_aliases=input_output_aliases,
             vmap_method=vmap_method,
+            input_layouts=list(input_layouts),
+            output_layouts=list(output_layouts),
         )(*inputs)
 
         return jax.tree.unflatten(out_treedef, result)

--- a/brainevent/_op/numba_cuda_ffi_audit_test.py
+++ b/brainevent/_op/numba_cuda_ffi_audit_test.py
@@ -1,0 +1,240 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Reproduction tests for the numba-CUDA FFI bridge audit fixes.
+
+Covers the GPU-bridge findings from ``dev/2026-06-13-op-issues.md``:
+
+* C1 - a raising kernel/callable surfaces as a JAX error, not silent success.
+* C2 - ``float16`` round-trips; ``bfloat16`` (unsupported by numba CUDA) is
+  rejected loudly instead of mis-decoded.
+* M3 - ``_compute_launch_config`` guards zero/negative extents (no
+  ``ZeroDivisionError``); an empty launch is skipped without crashing.
+* H1 - repeated calls with an identical signature reuse one FFI registration.
+
+The pure-function ``_compute_launch_config`` tests run on any platform; the
+end-to-end tests require a real GPU and are skipped otherwise.
+"""
+
+import importlib.util
+import os
+import unittest
+
+os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from brainevent._op import numba_cuda_ffi
+from brainevent._op.numba_cuda_ffi import _compute_launch_config
+
+# --- backend / numba-cuda detection ----------------------------------------
+numba_installed = importlib.util.find_spec('numba') is not None
+numba_cuda_available = False
+if numba_installed:
+    try:
+        from numba import cuda
+
+        numba_cuda_available = cuda.is_available()
+    except ImportError:
+        pass
+numba_cuda_available = numba_cuda_available and (jax.default_backend() == 'gpu')
+
+requires_gpu = pytest.mark.skipif(
+    not numba_cuda_available, reason='Numba CUDA / GPU backend not available'
+)
+
+
+class TestComputeLaunchConfig(unittest.TestCase):
+    """``_compute_launch_config`` guards (M3) - pure, no GPU required."""
+
+    def test_basic_1d_2d_3d(self):
+        self.assertEqual(_compute_launch_config(1024), ((4,), (256,)))
+        self.assertEqual(_compute_launch_config((64, 64)), ((4, 4), (16, 16)))
+        grid, block = _compute_launch_config((16, 16, 8))
+        self.assertEqual(block, (8, 8, 4))
+        self.assertEqual(grid, (2, 2, 2))
+
+    def test_zero_extent_no_zero_division(self):
+        # Previously: block=(min(256,0),)=(0,) -> grid = -1 // 0 -> ZeroDivisionError.
+        grid, block = _compute_launch_config(0)
+        self.assertEqual(grid, (0,))
+        self.assertEqual(block, (1,))  # clamped to >= 1
+        # A zero extent on one axis of a multi-D launch is also safe.
+        grid, block = _compute_launch_config((0, 32))
+        self.assertEqual(grid[0], 0)
+        self.assertTrue(all(b >= 1 for b in block))
+
+    def test_negative_extent_raises(self):
+        with self.assertRaises(ValueError):
+            _compute_launch_config(-1)
+        with self.assertRaises(ValueError):
+            _compute_launch_config((8, -2))
+
+    def test_bad_dimensionality_raises(self):
+        with self.assertRaises(ValueError):
+            _compute_launch_config(())  # zero dims
+        with self.assertRaises(ValueError):
+            _compute_launch_config((1, 2, 3, 4))  # > 3 dims
+
+    def test_nonpositive_threads_per_block_raises(self):
+        with self.assertRaises(ValueError):
+            _compute_launch_config(1024, threads_per_block=0)
+
+
+@requires_gpu
+class TestKernelCorrectness(unittest.TestCase):
+    """End-to-end correctness with the device-context binding in place (C3)."""
+
+    def test_elementwise_add(self):
+        from numba import cuda
+        from brainevent import numba_cuda_kernel
+
+        @cuda.jit
+        def add_kernel(x, y, out):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = x[i] + y[i]
+
+        fn = numba_cuda_kernel(
+            add_kernel,
+            outs=jax.ShapeDtypeStruct((1024,), jnp.float32),
+            launch_dims=1024,
+        )
+        x = jnp.arange(1024, dtype=jnp.float32)
+        y = jnp.ones(1024, dtype=jnp.float32)
+        out = np.asarray(jax.jit(fn)(x, y))
+        np.testing.assert_allclose(out, np.arange(1024) + 1.0, rtol=1e-6)
+
+    def test_float16_roundtrip(self):
+        # float16 is supported by numba CUDA; it must round-trip (C2).
+        from numba import cuda
+        from brainevent import numba_cuda_kernel
+
+        @cuda.jit
+        def copy_kernel(x, out):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = x[i]
+
+        fn = numba_cuda_kernel(
+            copy_kernel,
+            outs=jax.ShapeDtypeStruct((256,), jnp.float16),
+            launch_dims=256,
+        )
+        x = jnp.arange(256, dtype=jnp.float16)
+        out = np.asarray(jax.jit(fn)(x))
+        np.testing.assert_array_equal(out, np.arange(256, dtype=np.float16))
+
+
+@requires_gpu
+class TestErrorPropagation(unittest.TestCase):
+    """A raising callback must surface as a JAX error, never silent success (C1)."""
+
+    def test_callable_exception_propagates(self):
+        from brainevent import numba_cuda_callable
+
+        def boom(x, out, stream):
+            raise RuntimeError('intentional-kernel-failure')
+
+        fn = numba_cuda_callable(
+            boom, outs=jax.ShapeDtypeStruct((4,), jnp.float32)
+        )
+        x = jnp.ones(4, dtype=jnp.float32)
+        with self.assertRaises(Exception):
+            # Force execution so the FFI error is materialised, not deferred.
+            jax.block_until_ready(jax.jit(fn)(x))
+
+    def test_bfloat16_rejected(self):
+        # numba CUDA cannot launch bfloat16 kernels; the bridge must reject the
+        # call (an error) rather than silently mis-decode the bytes (C2).
+        from numba import cuda
+        from brainevent import numba_cuda_kernel
+
+        @cuda.jit
+        def copy_kernel(x, out):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = x[i]
+
+        fn = numba_cuda_kernel(
+            copy_kernel,
+            outs=jax.ShapeDtypeStruct((128,), jnp.bfloat16),
+            launch_dims=128,
+        )
+        x = jnp.arange(128, dtype=jnp.bfloat16)
+        with self.assertRaises(Exception):
+            jax.block_until_ready(jax.jit(fn)(x))
+
+
+@requires_gpu
+class TestEmptyLaunch(unittest.TestCase):
+    """An empty problem must not crash the launch (M3)."""
+
+    def test_zero_size_output(self):
+        from numba import cuda
+        from brainevent import numba_cuda_kernel
+
+        @cuda.jit
+        def add_kernel(x, y, out):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = x[i] + y[i]
+
+        fn = numba_cuda_kernel(
+            add_kernel,
+            outs=jax.ShapeDtypeStruct((0,), jnp.float32),
+            launch_dims=0,
+        )
+        x = jnp.zeros((0,), dtype=jnp.float32)
+        y = jnp.zeros((0,), dtype=jnp.float32)
+        out = np.asarray(jax.jit(fn)(x, y))
+        self.assertEqual(out.shape, (0,))
+
+
+@requires_gpu
+class TestRegistrationCaching(unittest.TestCase):
+    """Repeated identical calls reuse a single FFI registration (H1)."""
+
+    def test_kernel_registration_cached(self):
+        from numba import cuda
+        from brainevent import numba_cuda_kernel
+
+        @cuda.jit
+        def add_kernel(x, y, out):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = x[i] + y[i]
+
+        fn = numba_cuda_kernel(
+            add_kernel,
+            outs=jax.ShapeDtypeStruct((512,), jnp.float32),
+            launch_dims=512,
+        )
+        x = jnp.arange(512, dtype=jnp.float32)
+        y = jnp.ones(512, dtype=jnp.float32)
+
+        before = len(numba_cuda_ffi._NUMBA_CUDA_FFI_TARGETS)
+        for _ in range(5):
+            jax.block_until_ready(fn(x, y))
+        after = len(numba_cuda_ffi._NUMBA_CUDA_FFI_TARGETS)
+        # Five identical-signature calls add exactly one registration.
+        self.assertEqual(after - before, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainevent/_op/numba_cuda_ffi_test.py
+++ b/brainevent/_op/numba_cuda_ffi_test.py
@@ -496,13 +496,17 @@ class TestNumbaCudaKernelErrors(unittest.TestCase):
             )
 
     def test_non_cuda_kernel_raises(self):
-        """Test that non-CUDA kernel raises AssertionError."""
+        """Test that a non-CUDA kernel raises TypeError.
+
+        The check uses an explicit ``raise TypeError`` (not ``assert``) so it
+        survives ``python -O``, which strips assertions (L14).
+        """
         from brainevent import numba_cuda_kernel
 
         def regular_function(x, out):
             pass
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             numba_cuda_kernel(
                 regular_function,
                 outs=jax.ShapeDtypeStruct((64,), jnp.float32),
@@ -533,16 +537,18 @@ class TestNumbaCudaKernelXLAStream(unittest.TestCase):
             launch_dims=n,
         )
 
-        # Track if XLA stream was used
+        # Track if XLA stream was used.  The bridge now resolves the stream via
+        # the shared, error-checked ``get_xla_stream(api_ptr, ctx)`` helper
+        # imported from ``numba_ffi``; patch that module-global to observe it.
         stream_ptrs = []
-        orig_get_stream = ffi._get_stream_from_callframe
+        orig_get_stream = ffi.get_xla_stream
 
-        def tracking_get_stream(call_frame):
-            ptr = orig_get_stream(call_frame)
+        def tracking_get_stream(api_ptr, ctx):
+            ptr = orig_get_stream(api_ptr, ctx)
             stream_ptrs.append(ptr)
             return ptr
 
-        ffi._get_stream_from_callframe = tracking_get_stream
+        ffi.get_xla_stream = tracking_get_stream
 
         try:
             a = jnp.arange(n, dtype=jnp.float32)
@@ -560,7 +566,7 @@ class TestNumbaCudaKernelXLAStream(unittest.TestCase):
             )
             jax.block_until_ready((a, b, result))
         finally:
-            ffi._get_stream_from_callframe = orig_get_stream
+            ffi.get_xla_stream = orig_get_stream
 
 
 # ===========================================================================

--- a/brainevent/_op/numba_ffi.py
+++ b/brainevent/_op/numba_ffi.py
@@ -18,10 +18,11 @@ import enum
 import importlib.util
 import threading
 import traceback
-from ctypes import c_void_p, c_int, c_int64, c_uint32, c_size_t, POINTER, Structure, CFUNCTYPE
+from ctypes import c_void_p, c_int, c_int32, c_int64, c_uint32, c_size_t, c_char_p, POINTER, Structure, CFUNCTYPE
 from typing import Callable, Dict, Sequence, Tuple
 
 import jax
+import ml_dtypes
 import numpy as np
 
 from .util import OutType, abstract_arguments
@@ -32,8 +33,26 @@ __all__ = [
 
 numba_installed = importlib.util.find_spec('numba') is not None
 _NUMBA_CPU_FFI_HANDLES: Dict[str, object] = {}
+# Maps a kernel/shape/dtype signature to an already-registered FFI target name so
+# repeated eager calls reuse one registration instead of leaking one per call (H1).
+_NUMBA_CPU_FFI_TARGETS: Dict[tuple, str] = {}
 _FFI_CALLBACK_COUNTER = 0
-_FFI_CALLBACK_LOCK = threading.Lock()
+# Serializes target registration (trace/lowering time, distinct from execution).
+_REGISTRATION_LOCK = threading.Lock()
+
+# XLA FFI API version implemented by this bridge (jaxlib c_api.h
+# XLA_FFI_API_MAJOR / XLA_FFI_API_MINOR).  Reported back during the metadata
+# handshake so XLA does not reject the handler on a version mismatch.
+XLA_FFI_API_MAJOR = 0
+XLA_FFI_API_MINOR = 3
+
+
+class XLA_FFI_Error_Code(enum.IntEnum):
+    """Subset of XLA FFI error codes (mirrors ``absl::StatusCode``)."""
+    OK = 0
+    INVALID_ARGUMENT = 3
+    UNIMPLEMENTED = 12
+    INTERNAL = 13
 
 
 # ---------------------------------------------------------------------------
@@ -76,12 +95,25 @@ class XLA_FFI_Handler_TraitsBits(enum.IntEnum):
     COMMAND_BUFFER_COMPATIBLE = 1 << 0
 
 
+class XLA_FFI_TypeId(Structure):
+    """ctypes struct for an XLA FFI type identifier (state type id)."""
+    _fields_ = [
+        ("type_id", c_int64),
+    ]
+
+
 class XLA_FFI_Metadata(Structure):
-    """ctypes struct for XLA FFI handler metadata."""
+    """ctypes struct for XLA FFI handler metadata.
+
+    Mirrors ``struct XLA_FFI_Metadata`` in jaxlib ``c_api.h``: the trailing
+    ``state_type_id`` field must be present or XLA reads/writes past the end of
+    the struct during the metadata handshake.
+    """
     _fields_ = [
         ("struct_size", c_size_t),
         ("api_version", XLA_FFI_Api_Version),
         ("traits", c_uint32),
+        ("state_type_id", XLA_FFI_TypeId),
     ]
 
 
@@ -154,6 +186,209 @@ class XLA_FFI_CallFrame(Structure):
     ]
 
 
+class XLA_FFI_Error_Create_Args(Structure):
+    """ctypes struct for arguments to ``XLA_FFI_Error_Create``."""
+    _fields_ = [
+        ("struct_size", c_size_t),
+        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
+        ("message", c_char_p),
+        ("errc", c_int),  # XLA_FFI_Error_Code
+    ]
+
+
+class XLA_FFI_Stream_Get_Args(Structure):
+    """ctypes struct for arguments to ``XLA_FFI_Stream_Get``."""
+    _fields_ = [
+        ("struct_size", c_size_t),
+        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
+        ("ctx", c_void_p),  # XLA_FFI_ExecutionContext*
+        ("stream", c_void_p),  # void* (out)
+    ]
+
+
+class XLA_FFI_DeviceOrdinal_Get_Args(Structure):
+    """ctypes struct for arguments to ``XLA_FFI_DeviceOrdinal_Get``.
+
+    Mirrors ``struct XLA_FFI_DeviceOrdinal_Get_Args`` in jaxlib ``c_api.h``.
+    ``device_ordinal`` is an out parameter: XLA writes the ordinal of the
+    device this call executes on so the GPU bridge can bind the matching CUDA
+    context before building device arrays (C3).
+    """
+    _fields_ = [
+        ("struct_size", c_size_t),
+        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
+        ("ctx", c_void_p),  # XLA_FFI_ExecutionContext*
+        ("device_ordinal", c_int32),  # int32_t (out)
+    ]
+
+
+# Function-pointer signatures for the API entries these bridges actually call.
+XLA_FFI_Error_Create_Func = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_Error_Create_Args))
+XLA_FFI_Stream_Get_Func = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_Stream_Get_Args))
+XLA_FFI_DeviceOrdinal_Get_Func = CFUNCTYPE(c_void_p, POINTER(XLA_FFI_DeviceOrdinal_Get_Args))
+
+
+class XLA_FFI_Api(Structure):
+    """ctypes view of the XLA FFI API dispatch table (jaxlib ``c_api.h``).
+
+    Every ``_XLA_FFI_API_STRUCT_FIELD`` entry is a function pointer, so the
+    table can be modelled as a flat sequence of pointers.  The two entries this
+    bridge invokes (``XLA_FFI_Error_Create`` and ``XLA_FFI_Stream_Get``) are
+    typed as :class:`ctypes.CFUNCTYPE`; the rest are opaque ``c_void_p`` of the
+    same width so the field offsets stay exact.
+    """
+    _fields_ = [
+        ("struct_size", c_size_t),
+        ("extension_start", POINTER(XLA_FFI_Extension_Base)),
+        ("api_version", XLA_FFI_Api_Version),
+        ("internal_api", c_void_p),
+        ("XLA_FFI_Error_Create", XLA_FFI_Error_Create_Func),
+        ("XLA_FFI_Error_GetMessage", c_void_p),
+        ("XLA_FFI_Error_Destroy", c_void_p),
+        ("XLA_FFI_Handler_Register", c_void_p),
+        ("XLA_FFI_Stream_Get", XLA_FFI_Stream_Get_Func),
+        ("XLA_FFI_Type_Register", c_void_p),
+        ("XLA_FFI_ExecutionContext_Get", c_void_p),
+        ("XLA_FFI_State_Set", c_void_p),
+        ("XLA_FFI_State_Get", c_void_p),
+        ("XLA_FFI_DeviceMemory_Allocate", c_void_p),
+        ("XLA_FFI_DeviceMemory_Free", c_void_p),
+        ("XLA_FFI_ThreadPool_Schedule", c_void_p),
+        ("XLA_FFI_ThreadPool_NumThreads", c_void_p),
+        ("XLA_FFI_Future_Create", c_void_p),
+        ("XLA_FFI_Future_SetAvailable", c_void_p),
+        ("XLA_FFI_Future_SetError", c_void_p),
+        ("XLA_FFI_RunId_Get", c_void_p),
+        ("XLA_FFI_DeviceOrdinal_Get", XLA_FFI_DeviceOrdinal_Get_Func),
+    ]
+
+
+def make_ffi_error(api_ptr, code, message: str):
+    """Build an ``XLA_FFI_Error*`` to return from a failed FFI callback.
+
+    A typed FFI callback signals failure by returning a non-null
+    ``XLA_FFI_Error*``.  Returning ``None`` (a null pointer) is XLA's *Ok*
+    status, so an exception that is merely printed and swallowed is reported to
+    XLA as success — producing silent wrong answers.  This constructs a real
+    error object via the API table referenced by the call frame.
+
+    Parameters
+    ----------
+    api_ptr : int or None
+        Value of ``XLA_FFI_CallFrame.api`` (address of the ``XLA_FFI_Api``
+        table).  ``None``/0 disables error creation.
+    code : XLA_FFI_Error_Code or int
+        Status code to attach to the error.
+    message : str
+        Human-readable message surfaced to the JAX caller.
+
+    Returns
+    -------
+    int or None
+        The ``XLA_FFI_Error*`` pointer value, or ``None`` when the API table is
+        unavailable (in which case XLA falls back to Ok status).
+    """
+    if not api_ptr:
+        return None
+    api = ctypes.cast(api_ptr, POINTER(XLA_FFI_Api)).contents
+    args = XLA_FFI_Error_Create_Args(
+        struct_size=ctypes.sizeof(XLA_FFI_Error_Create_Args),
+        extension_start=None,
+        message=message.encode('utf-8'),
+        errc=int(code),
+    )
+    return api.XLA_FFI_Error_Create(ctypes.byref(args))
+
+
+def get_xla_stream(api_ptr, ctx) -> int:
+    """Return the CUDA stream XLA assigned to this FFI call.
+
+    A GPU FFI handler must launch its kernel on the stream XLA hands it, not on
+    a stream of its own; otherwise the kernel races XLA's own work on the device
+    (use-before-write / write-after-read hazards).  ``XLA_FFI_Stream_Get``
+    returns an ``XLA_FFI_Error*`` whose non-null value previously went unchecked
+    — a failed lookup would silently yield a null/garbage stream.
+
+    Parameters
+    ----------
+    api_ptr : int
+        Value of ``XLA_FFI_CallFrame.api`` (address of the ``XLA_FFI_Api``).
+    ctx : int
+        Value of ``XLA_FFI_CallFrame.ctx`` (the execution context).
+
+    Returns
+    -------
+    int
+        The CUDA stream handle as an integer (``0`` is the legal default
+        stream).
+
+    Raises
+    ------
+    RuntimeError
+        If the API table is unavailable or ``XLA_FFI_Stream_Get`` reports an
+        error.  Raised (not swallowed) so the surrounding callback converts it
+        into a real ``XLA_FFI_Error`` rather than returning a wrong answer.
+    """
+    if not api_ptr:
+        raise RuntimeError('XLA FFI API table pointer is null; cannot resolve the CUDA stream.')
+    api = ctypes.cast(api_ptr, POINTER(XLA_FFI_Api)).contents
+    args = XLA_FFI_Stream_Get_Args(
+        struct_size=ctypes.sizeof(XLA_FFI_Stream_Get_Args),
+        extension_start=None,
+        ctx=ctx,
+        stream=None,
+    )
+    err = api.XLA_FFI_Stream_Get(ctypes.byref(args))
+    if err:
+        raise RuntimeError('XLA_FFI_Stream_Get reported an error while resolving the CUDA stream.')
+    # ``stream`` may legitimately be 0 (the default stream); only a hard lookup
+    # failure (signalled by *err*) is an error.  Normalise None -> 0.
+    return int(args.stream) if args.stream else 0
+
+
+def get_device_ordinal(api_ptr, ctx):
+    """Return the device ordinal XLA placed this FFI call on, or ``None``.
+
+    Used by the GPU bridge to bind the matching CUDA context
+    (``with cuda.gpus[ordinal]:``) before constructing device arrays, so a
+    multi-GPU execution builds arrays and launches on the device that actually
+    owns the buffers (C3).  Returns ``None`` when the ordinal cannot be queried
+    (older jaxlib that does not populate ``XLA_FFI_DeviceOrdinal_Get``), letting
+    the caller fall back to numba's current device.
+
+    Parameters
+    ----------
+    api_ptr : int
+        Value of ``XLA_FFI_CallFrame.api``.
+    ctx : int
+        Value of ``XLA_FFI_CallFrame.ctx``.
+
+    Returns
+    -------
+    int or None
+        The device ordinal, or ``None`` if it is unavailable.
+    """
+    if not api_ptr:
+        return None
+    try:
+        api = ctypes.cast(api_ptr, POINTER(XLA_FFI_Api)).contents
+        fn = api.XLA_FFI_DeviceOrdinal_Get
+        if not fn:
+            return None
+        args = XLA_FFI_DeviceOrdinal_Get_Args(
+            struct_size=ctypes.sizeof(XLA_FFI_DeviceOrdinal_Get_Args),
+            extension_start=None,
+            ctx=ctx,
+            device_ordinal=-1,
+        )
+        err = fn(ctypes.byref(args))
+        if err or args.device_ordinal < 0:
+            return None
+        return int(args.device_ordinal)
+    except Exception:  # noqa: BLE001 - ordinal is best-effort; fall back to current device
+        return None
+
+
 # XLA FFI dtype enum -> numpy dtype mapping
 # (from xla/ffi/api/c_api.h XLA_FFI_DataType)
 _XLA_FFI_DTYPE_TO_NUMPY = {
@@ -170,21 +405,80 @@ _XLA_FFI_DTYPE_TO_NUMPY = {
     11: np.dtype(np.float32),  # F32
     12: np.dtype(np.float64),  # F64
     15: np.dtype(np.complex64),  # C64
-    16: np.dtype(np.bfloat16) if hasattr(np, 'bfloat16') else None,  # BF16
+    16: np.dtype(ml_dtypes.bfloat16),  # BF16
     18: np.dtype(np.complex128),  # C128
 }
 
 
+def resolve_buffer_dtype(dtype_code: int, fallback: np.dtype) -> np.dtype:
+    """Resolve an XLA FFI dtype enum to a numpy dtype.
+
+    Distinguishes a *known-but-unsupported* dtype code (raise, never silently
+    reinterpret the bytes) from an *unknown* code (use the caller's abstract
+    fallback).  Replaces ``dict.get(code, fallback)``, which returned the stored
+    ``None`` instead of *fallback* when a code was present-but-unmapped.
+
+    Parameters
+    ----------
+    dtype_code : int
+        ``XLA_FFI_Buffer.dtype`` value (an ``XLA_FFI_DataType`` enum).
+    fallback : numpy.dtype
+        Dtype to use when *dtype_code* is not in the table (the abstract dtype
+        JAX assigned to the buffer).
+
+    Returns
+    -------
+    numpy.dtype
+        The resolved element dtype.
+
+    Raises
+    ------
+    TypeError
+        If *dtype_code* is known to the table but maps to no numpy dtype.
+    """
+    if dtype_code in _XLA_FFI_DTYPE_TO_NUMPY:
+        resolved = _XLA_FFI_DTYPE_TO_NUMPY[dtype_code]
+        if resolved is None:
+            raise TypeError(
+                f'XLA FFI dtype code {dtype_code} has no numpy representation in this build.'
+            )
+        return resolved
+    return np.dtype(fallback)
+
+
 def _numpy_from_buffer(data_ptr, shape, dtype):
-    """Create a zero-copy numpy array from a raw data pointer."""
+    """Create a numpy array viewing a raw XLA buffer pointer.
+
+    Reconstructs the array from a raw-byte view (``np.frombuffer`` over a
+    ``ctypes`` char array) rather than ``numpy.ctypeslib.as_ctypes_type``, which
+    raises for ``float16``, ``bfloat16``, ``complex64`` and ``complex128``.  The
+    byte view is exact for every fixed-width dtype and remains writable, so a
+    numba kernel can write results straight into the output buffer.
+
+    Parameters
+    ----------
+    data_ptr : int
+        Address of the buffer's first byte.
+    shape : tuple of int
+        Logical shape of the array.
+    dtype : numpy.dtype
+        Element type used to interpret the raw bytes.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of *shape* and *dtype* sharing memory with the buffer, or a fresh
+        empty array when the buffer holds zero elements.
+    """
+    dtype = np.dtype(dtype)
     size = 1
     for dim in shape:
-        size *= dim
+        size *= int(dim)
     if size == 0:
         return np.empty(shape, dtype=dtype)
-    c_type = np.ctypeslib.as_ctypes_type(dtype)
-    buffer = (c_type * size).from_address(data_ptr)
-    return np.ctypeslib.as_array(buffer).reshape(shape)
+    nbytes = size * dtype.itemsize
+    raw = (ctypes.c_char * nbytes).from_address(data_ptr)
+    return np.frombuffer(raw, dtype=dtype).reshape(shape)
 
 
 # The typed FFI callback signature: void* fn(XLA_FFI_CallFrame*)
@@ -231,8 +525,8 @@ class NumbaCpuFfiHandler:
                         ext_ptr, POINTER(XLA_FFI_Metadata_Extension)
                     ).contents
                     metadata = metadata_ext.metadata.contents
-                    metadata.api_version.major_version = 0
-                    metadata.api_version.minor_version = 1
+                    metadata.api_version.major_version = XLA_FFI_API_MAJOR
+                    metadata.api_version.minor_version = XLA_FFI_API_MINOR
                     metadata.traits = 0  # not command-buffer-compatible
                     return None  # success
 
@@ -244,7 +538,7 @@ class NumbaCpuFfiHandler:
                     call_frame.args.args[i], POINTER(XLA_FFI_Buffer)
                 ).contents
                 shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype, self.input_dtypes[i])
+                dtype = resolve_buffer_dtype(buf_ptr.dtype, self.input_dtypes[i])
                 input_arrays.append(_numpy_from_buffer(buf_ptr.data, shape, dtype))
 
             # Extract output buffers
@@ -255,15 +549,26 @@ class NumbaCpuFfiHandler:
                     call_frame.rets.rets[i], POINTER(XLA_FFI_Buffer)
                 ).contents
                 shape = tuple(buf_ptr.dims[d] for d in range(buf_ptr.rank))
-                dtype = _XLA_FFI_DTYPE_TO_NUMPY.get(buf_ptr.dtype, self.output_dtypes[i])
+                dtype = resolve_buffer_dtype(buf_ptr.dtype, self.output_dtypes[i])
                 output_arrays.append(_numpy_from_buffer(buf_ptr.data, shape, dtype))
 
-            # Call the numba kernel
-            with _FFI_CALLBACK_LOCK:
-                self.kernel(*input_arrays, *output_arrays)
+            # Call the numba kernel.  No global lock is held: every call works
+            # only on its own call-local input/output arrays, so concurrent XLA
+            # worker threads cannot race here (H7).
+            self.kernel(*input_arrays, *output_arrays)
 
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - surfaced to XLA as an FFI error
             traceback.print_exc()
+            try:
+                api_ptr = call_frame_ptr.contents.api
+            except Exception:
+                api_ptr = None
+            return make_ffi_error(
+                api_ptr,
+                XLA_FFI_Error_Code.INTERNAL,
+                f'Numba CPU kernel {self.name!r} raised '
+                f'{type(exc).__name__}: {exc}',
+            )
 
         return None  # success
 
@@ -298,25 +603,38 @@ def _register_numba_cpu_ffi_target(
     if not numba_installed:
         raise ImportError('Numba is required to compile the CPU kernel for the custom operator.')
 
-    target_name = f'brainevent_numba_ffi_{_FFI_CALLBACK_COUNTER}'
-    _FFI_CALLBACK_COUNTER += 1
-
-    handler = NumbaCpuFfiHandler(
-        name=target_name,
-        kernel=kernel,
-        input_shapes=input_shapes,
-        input_dtypes=input_dtypes,
-        output_shapes=output_shapes,
-        output_dtypes=output_dtypes,
-    )
-
-    # Keep the handler alive to prevent GC of ctypes callback
-    _NUMBA_CPU_FFI_HANDLES[target_name] = handler
-
     out_types = tuple(
         jax.ShapeDtypeStruct(shape, dtype)
         for shape, dtype in zip(output_shapes, output_dtypes)
     )
+
+    # Reuse an existing registration for an identical kernel/signature.  Every
+    # eager call would otherwise mint a fresh target name and register a new FFI
+    # handler, leaking one handler (and ctypes callback) per call (H1).  The
+    # cached handler keeps *kernel* alive, so ``id(kernel)`` cannot be recycled
+    # while the entry lives.
+    signature = (id(kernel), input_shapes, input_dtypes, output_shapes, output_dtypes)
+    with _REGISTRATION_LOCK:
+        cached_name = _NUMBA_CPU_FFI_TARGETS.get(signature)
+        if cached_name is not None:
+            return cached_name, out_types
+
+        target_name = f'brainevent_numba_ffi_{_FFI_CALLBACK_COUNTER}'
+        _FFI_CALLBACK_COUNTER += 1
+
+        handler = NumbaCpuFfiHandler(
+            name=target_name,
+            kernel=kernel,
+            input_shapes=input_shapes,
+            input_dtypes=input_dtypes,
+            output_shapes=output_shapes,
+            output_dtypes=output_dtypes,
+        )
+
+        # Keep the handler alive to prevent GC of ctypes callback.
+        _NUMBA_CPU_FFI_HANDLES[target_name] = handler
+        _NUMBA_CPU_FFI_TARGETS[signature] = target_name
+
     return target_name, out_types
 
 
@@ -430,7 +748,17 @@ def numba_kernel(
         tuple(out.dtype for out in out_info),
         'output',
     )
-    assert isinstance(kernel, CPUDispatcher), 'The kernel must be a Numba JIT-compiled function.'
+    # Use an explicit ``raise`` rather than ``assert`` so the check survives
+    # ``python -O`` (which strips assertions) (L14).
+    if not isinstance(kernel, CPUDispatcher):
+        raise TypeError('The kernel must be a Numba JIT-compiled function (numba.njit).')
+
+    # Pin row-major layouts so XLA is contractually required to hand the handler
+    # C-contiguous buffers; the callback reshapes by ``dims`` only and cannot
+    # recover a non-default layout from ``XLA_FFI_Buffer`` (M4).  ``ffi_call``
+    # takes layouts in major-to-minor order, so row-major is the natural
+    # ``range(ndim)`` (it reverses these to XLA's minor-to-major internally).
+    output_layouts = tuple(tuple(range(len(out.shape))) for out in out_info)
 
     def call(*ins):
         # input information
@@ -440,6 +768,7 @@ def numba_kernel(
             tuple(inp.dtype for inp in in_info),
             'input',
         )
+        input_layouts = tuple(tuple(range(len(shape))) for shape in input_shapes)
 
         # register FFI target
         target_name, out_types = _register_numba_cpu_ffi_target(
@@ -452,6 +781,8 @@ def numba_kernel(
             out_types,
             input_output_aliases=input_output_aliases,
             vmap_method=vmap_method,
+            input_layouts=list(input_layouts),
+            output_layouts=list(output_layouts),
         )(*ins)
         return jax.tree.unflatten(out_treedef, results)
 

--- a/brainevent/_op/numba_ffi_audit_test.py
+++ b/brainevent/_op/numba_ffi_audit_test.py
@@ -1,0 +1,119 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for the 2026-06-13 ``_op`` audit (CPU / Numba bridge).
+
+Covers: C1 (kernel exceptions must propagate, not silently report success),
+C2 (fp16/bf16/complex buffer views must be byte-accurate), M7 (metadata struct
+shape), and H1 (FFI-target registration must be cached, not leaked per call).
+"""
+
+import importlib.util
+import os
+
+os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+numba_installed = importlib.util.find_spec('numba') is not None
+cpu_platform = jax.default_backend() == 'cpu'
+if not cpu_platform or not numba_installed:
+    pytest.skip(
+        allow_module_level=True,
+        reason='Numba CPU FFI audit tests only run on CPU platform with Numba installed',
+    )
+
+import numba
+
+from brainevent._op import numba_ffi as _m
+from brainevent._op.numba_ffi import (
+    _numpy_from_buffer,
+    XLA_FFI_Metadata,
+    numba_kernel,
+)
+
+
+# --- C2: byte-accurate buffer views for dtypes ctypes cannot represent ---------
+
+class TestBufferViewDtypes:
+    """``_numpy_from_buffer`` must reconstruct every fixed-width dtype exactly."""
+
+    def _roundtrip(self, arr):
+        view = _numpy_from_buffer(arr.ctypes.data, arr.shape, arr.dtype)
+        np.testing.assert_array_equal(view, arr)
+
+    def test_float16(self):
+        self._roundtrip(np.arange(6, dtype=np.float16).reshape(2, 3))
+
+    def test_bfloat16(self):
+        import ml_dtypes
+        bf16 = np.dtype(ml_dtypes.bfloat16)
+        self._roundtrip(np.arange(6, dtype=bf16).reshape(2, 3))
+
+    def test_complex64(self):
+        arr = (np.arange(4) + 1j * np.arange(4)).astype(np.complex64)
+        self._roundtrip(arr)
+
+    def test_complex128(self):
+        arr = (np.arange(4) + 1j * np.arange(4)).astype(np.complex128)
+        self._roundtrip(arr)
+
+    def test_float32_still_correct(self):
+        self._roundtrip(np.arange(12, dtype=np.float32).reshape(3, 4))
+
+
+# --- M7: metadata struct must expose state_type_id -----------------------------
+
+def test_metadata_struct_has_state_type_id():
+    names = {name for name, _ in XLA_FFI_Metadata._fields_}
+    assert 'state_type_id' in names
+
+
+# --- C1: kernel exceptions must propagate, not be reported as success ----------
+
+class TestErrorPropagation:
+    def test_raising_kernel_surfaces_exception(self):
+        @numba.njit
+        def boom(x, out):
+            raise ValueError('intentional kernel failure')
+
+        kernel = numba_kernel(boom, outs=jax.ShapeDtypeStruct((4,), jnp.float32))
+        with pytest.raises(Exception):
+            jax.block_until_ready(kernel(jnp.arange(4, dtype=jnp.float32)))
+
+
+# --- H1: registration must be cached, not leaked once per call -----------------
+
+class TestRegistrationCaching:
+    def test_eager_calls_do_not_leak_targets(self):
+        @numba.njit
+        def add1(x, out):
+            for i in range(out.size):
+                out[i] = x[i] + 1.0
+
+        kernel = numba_kernel(add1, outs=jax.ShapeDtypeStruct((4,), jnp.float32))
+        x = jnp.arange(4, dtype=jnp.float32)
+        jax.block_until_ready(kernel(x))  # warm up / first registration
+        before = len(_m._NUMBA_CPU_FFI_HANDLES)
+        for _ in range(8):
+            jax.block_until_ready(kernel(x))
+        after = len(_m._NUMBA_CPU_FFI_HANDLES)
+        assert after == before, f'leaked {after - before} FFI targets across 8 eager calls'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/brainevent/_op/numba_ffi_test.py
+++ b/brainevent/_op/numba_ffi_test.py
@@ -697,20 +697,20 @@ class TestNumbaKernelErrors(unittest.TestCase):
     """Tests for error handling."""
 
     def test_non_numba_function_raises(self):
-        """Test that non-Numba function raises AssertionError."""
+        """Test that a non-Numba function raises ``TypeError``."""
 
         def regular_function(x, out):
             pass
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             numba_kernel(
                 regular_function,
                 outs=jax.ShapeDtypeStruct((64,), jnp.float32),
             )
 
     def test_lambda_raises(self):
-        """Test that lambda function raises AssertionError."""
-        with self.assertRaises(AssertionError):
+        """Test that a lambda function raises ``TypeError``."""
+        with self.assertRaises(TypeError):
             numba_kernel(
                 lambda x, out: None,
                 outs=jax.ShapeDtypeStruct((64,), jnp.float32),

--- a/brainevent/_op/util.py
+++ b/brainevent/_op/util.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, Optional, Protocol, Sequence, Tuple, TYPE_CHEC
 import jax
 import numpy as np
 from jax import tree_util
-from jax.interpreters import ad
+from jax.interpreters import ad, batching
 
 from brainevent._compatible_import import Primitive, init_zero
 
@@ -171,8 +171,10 @@ def defjvp(primitive: Union[Primitive, 'XLACustomKernel'], *jvp_rules: Optional[
     -----
     When the primitive has ``multiple_results=True``, a custom internal
     JVP implementation (``_standard_jvp``) is used that correctly
-    handles tuple outputs.  For single-result primitives, the standard
-    ``jax.interpreters.ad.standard_jvp`` is used.
+    handles tuple outputs.  For single-result primitives,
+    ``_single_result_jvp`` -- an inlined equivalent of the standard JAX
+    JVP -- is used.  (JAX's ``jax.interpreters.ad.standard_jvp`` was
+    removed in JAX 0.9, so this implementation no longer depends on it.)
 
     Examples
     --------
@@ -201,9 +203,49 @@ def defjvp(primitive: Union[Primitive, 'XLACustomKernel'], *jvp_rules: Optional[
         # functools.partial pre-fills the jvp_rules and primitive arguments for _standard_jvp.
         ad.primitive_jvps[primitive] = functools.partial(_standard_jvp, jvp_rules, primitive)
     else:
-        # If no (single result), use the standard JAX JVP handler (ad.standard_jvp).
-        # This maintains compatibility with standard JAX behavior for single-result primitives.
-        ad.primitive_jvps[primitive] = functools.partial(ad.standard_jvp, jvp_rules, primitive)
+        # If no (single result), use an inlined standard JVP.
+        # ``jax.interpreters.ad.standard_jvp`` was removed in JAX 0.9, so we
+        # reproduce its behavior here to keep single-result primitives working.
+        ad.primitive_jvps[primitive] = functools.partial(_single_result_jvp, jvp_rules, primitive)
+
+
+def _single_result_jvp(jvp_rules, primitive: Primitive, primals, tangents, **params):
+    """Compute the JVP for a single-result primitive.
+
+    This is an internal helper used by :func:`defjvp` when the primitive
+    has ``multiple_results=False``.  It reproduces the behavior of the
+    standard JAX JVP (``jax.interpreters.ad.standard_jvp``, removed in
+    JAX 0.9): it binds the primals, evaluates each per-input JVP rule
+    whose tangent is not ``Zero``, and sums the resulting tangent
+    contributions into the single output tangent.
+
+    Parameters
+    ----------
+    jvp_rules : sequence of callable or None
+        Per-input JVP rules (see :func:`defjvp`).
+    primitive : Primitive
+        The JAX primitive (single result).
+    primals : tuple
+        Primal input values.
+    tangents : tuple
+        Tangent input values (may contain ``ad.Zero``).
+    **params
+        Additional keyword arguments forwarded from the primitive bind.
+
+    Returns
+    -------
+    tuple
+        A pair ``(val_out, tangent_out)`` where *val_out* is the single
+        primal output and *tangent_out* is the summed tangent
+        contribution.
+    """
+    val_out = primitive.bind(*primals, **params)
+    tangents_out = [
+        rule(t, *primals, **params)
+        for rule, t in zip(jvp_rules, tangents)
+        if rule is not None and type(t) is not ad.Zero
+    ]
+    return val_out, functools.reduce(ad.add_tangents, tangents_out, init_zero(val_out))
 
 
 def _standard_jvp(jvp_rules, primitive: Primitive, primals, tangents, **params):
@@ -234,15 +276,37 @@ def _standard_jvp(jvp_rules, primitive: Primitive, primals, tangents, **params):
         of primal outputs and *tangents_out* is the summed tangent
         contributions with the same pytree structure as *val_out*.
     """
-    assert primitive.multiple_results
+    if not primitive.multiple_results:
+        raise ValueError(
+            f"_standard_jvp is only valid for multiple-result primitives, "
+            f"but {primitive} has multiple_results=False."
+        )
     val_out = tuple(primitive.bind(*primals, **params))
     tree = tree_util.tree_structure(val_out)
     tangents_out = []
     for rule, t in zip(jvp_rules, tangents):
         if rule is not None and type(t) is not ad.Zero:
-            r = tuple(rule(t, *primals, **params))
+            out = rule(t, *primals, **params)
+            # A multi-result JVP rule must return an explicit sequence (one
+            # tangent per output).  Wrapping a bare array in ``tuple(...)``
+            # would instead iterate its leading axis and silently fragment it
+            # into per-row leaves, so reject non-sequence returns loudly.
+            if not isinstance(out, (tuple, list)):
+                raise TypeError(
+                    f"JVP rule {getattr(rule, '__name__', rule)!r} for "
+                    f"multiple-result primitive {primitive} must return a "
+                    f"tuple/list of tangents (one per output), but got "
+                    f"{type(out).__name__}."
+                )
+            r = tuple(out)
+            if tree_util.tree_structure(r) != tree:
+                raise ValueError(
+                    f"JVP rule {getattr(rule, '__name__', rule)!r} for "
+                    f"{primitive} returned a tangent with pytree structure "
+                    f"{tree_util.tree_structure(r)}, which does not match the "
+                    f"primitive output structure {tree}."
+                )
             tangents_out.append(r)
-            assert tree_util.tree_structure(r) == tree
     r = functools.reduce(
         _add_tangents,
         tangents_out,
@@ -301,15 +365,22 @@ def general_batching_rule(
     outs : pytree
         The batched outputs from applying the primitive.
     out_dim : pytree
-        A pytree with the same structure as *outs*, where every leaf
-        is ``0``, indicating that the batch dimension is the leading
-        axis of each output.
+        A pytree with the same structure as *outs*.  When at least one
+        operand is batched, every leaf is ``0`` (the batch dimension is
+        the leading axis of each output).  When no operand is batched
+        (every entry of *axes* is ``None``), every leaf is
+        ``jax.interpreters.batching.not_mapped`` to signal that the
+        outputs carry no batch dimension.
 
     Notes
     -----
     All batch dimensions are moved to axis 0 before scanning.  The scan
     carry is unused (always ``0``); only the stacked scan outputs are
-    returned.
+    returned.  As a special case, if *no* operand is batched the function
+    short-circuits: it binds the primitive once on the original arguments
+    and reports every output as unbatched, avoiding an empty
+    ``jax.lax.scan`` (which would raise ``ValueError: scan got no values
+    to scan over``).
 
     See Also
     --------
@@ -335,6 +406,17 @@ def general_batching_rule(
         else:
             batch_args[f'ax{ax_i}'] = args[ax_i] if ax == 0 else jax.numpy.moveaxis(args[ax_i], ax, 0)
             batch_axes.append(ax_i)
+
+    # If no operand is actually batched (every axis is ``None``), there is
+    # nothing to scan over -- ``jax.lax.scan(f, 0, {})`` would raise
+    # "scan got no values to scan over".  Bind the primitive once and mark
+    # every output as unbatched.
+    if not batch_args:
+        if isinstance(prim, Primitive):
+            out = prim.bind(*args, **kwargs)
+        else:
+            out = prim(*args, **kwargs)
+        return out, tree_util.tree_map(lambda _: batching.not_mapped, out)
 
     def f(_, x):
         """Apply the primitive to a single batch element for ``jax.lax.scan``.
@@ -495,9 +577,13 @@ def jaxtype_to_warptype(dtype: Union[np.dtype, type]) -> Any:
     Parameters
     ----------
     dtype : numpy.dtype or type
-        The data type to convert.  Accepts any object that can be
-        compared with NumPy scalar types (e.g., ``np.float32``,
-        ``jnp.float32``, ``np.dtype('float32')``).
+        The data type to convert.  Accepts anything ``numpy.dtype`` can
+        normalize, including NumPy scalar types (``np.float32``), JAX
+        dtypes (``jnp.float32``), ``np.dtype`` instances
+        (``np.dtype('float32')``), and Python builtins (``float``,
+        ``int``, ``bool``).  Builtins are normalized via
+        ``numpy.dtype`` first (e.g. ``float`` -> ``float64``,
+        ``int`` -> the platform default integer, ``bool`` -> ``bool_``).
 
     Returns
     -------
@@ -510,10 +596,12 @@ def jaxtype_to_warptype(dtype: Union[np.dtype, type]) -> Any:
     ImportError
         If the ``warp`` package is not installed.
     ValueError
-        If *dtype* does not correspond to any supported Warp type.
-        Supported types include: ``float16``, ``float32``, ``float64``,
-        ``int8``, ``int16``, ``int32``, ``int64``, ``uint8``,
-        ``uint16``, ``uint32``, ``uint64``, and ``bool_``.
+        If *dtype* cannot be normalized by ``numpy.dtype`` or does not
+        correspond to any supported Warp type.  Supported types are:
+        ``float16``, ``float32``, ``float64``, ``int8``, ``int16``,
+        ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
+        ``uint64``, and ``bool_``.  ``bfloat16`` and complex dtypes are
+        **not** supported by Warp and raise a clear ``ValueError``.
 
     See Also
     --------
@@ -523,10 +611,13 @@ def jaxtype_to_warptype(dtype: Union[np.dtype, type]) -> Any:
 
     Notes
     -----
-    The mapping covers all scalar types supported by both NumPy and
-    Warp: ``float16``, ``float32``, ``float64``, ``int8`` through
-    ``int64``, ``uint8`` through ``uint64``, and ``bool_``.  Complex
-    types are not supported by Warp and will raise ``ValueError``.
+    The dtype is first normalized with ``numpy.dtype(dtype)`` so that
+    Python builtins and dtype-like objects all resolve to a canonical
+    ``numpy.dtype`` before mapping.  This avoids the pitfall that
+    ``float == np.float64`` is ``False`` even though ``np.dtype(float)``
+    *is* ``float64``.  The mapping covers all scalar types supported by
+    both NumPy and Warp.  ``bfloat16`` (which Warp has no scalar for) and
+    complex types are unsupported and raise ``ValueError``.
 
     Examples
     --------
@@ -535,42 +626,49 @@ def jaxtype_to_warptype(dtype: Union[np.dtype, type]) -> Any:
         >>> import numpy as np
         >>> warp_type = jaxtype_to_warptype(np.float32)
         >>> warp_type  # warp.float32
+        >>> jaxtype_to_warptype(float) is jaxtype_to_warptype(np.float64)
+        True
     """
     warp_mod = import_warp()
 
-    # float
-    if dtype == np.float16:
-        return warp_mod.float16
-    elif dtype == np.float32:
-        return warp_mod.float32
-    elif dtype == np.float64:
-        return warp_mod.float64
+    # Normalize Python builtins (float/int/bool) and dtype-like objects to a
+    # canonical numpy.dtype.  Without this, ``float == np.float64`` is False
+    # and builtins would be spuriously rejected despite the Union[..., type]
+    # signature.  ``bfloat16`` / unrecognized objects raise TypeError here,
+    # which we surface as a clear ValueError below.
+    try:
+        np_dtype = np.dtype(dtype)
+    except TypeError as exc:
+        raise ValueError(
+            f"Warp does not support computations with dtype: {dtype!r}"
+        ) from exc
 
-    # integer
-    elif dtype == np.int8:
-        return warp_mod.int8
-    elif dtype == np.int16:
-        return warp_mod.int16
-    elif dtype == np.int32:
-        return warp_mod.int32
-    elif dtype == np.int64:
-        return warp_mod.int64
+    _warp_scalar_types = {
+        # float
+        np.dtype(np.float16): warp_mod.float16,
+        np.dtype(np.float32): warp_mod.float32,
+        np.dtype(np.float64): warp_mod.float64,
+        # integer
+        np.dtype(np.int8): warp_mod.int8,
+        np.dtype(np.int16): warp_mod.int16,
+        np.dtype(np.int32): warp_mod.int32,
+        np.dtype(np.int64): warp_mod.int64,
+        # unsigned integer
+        np.dtype(np.uint8): warp_mod.uint8,
+        np.dtype(np.uint16): warp_mod.uint16,
+        np.dtype(np.uint32): warp_mod.uint32,
+        np.dtype(np.uint64): warp_mod.uint64,
+        # boolean
+        np.dtype(np.bool_): warp_mod.bool,
+    }
 
-    # unsigned integer
-    elif dtype == np.uint8:
-        return warp_mod.uint8
-    elif dtype == np.uint16:
-        return warp_mod.uint16
-    elif dtype == np.uint32:
-        return warp_mod.uint32
-    elif dtype == np.uint64:
-        return warp_mod.uint64
-
-    # boolean
-    elif dtype == np.bool_:
-        return warp_mod.bool
-    else:
-        raise ValueError(f"Warp does not support computations with dtype: {dtype}")
+    try:
+        return _warp_scalar_types[np_dtype]
+    except KeyError:
+        raise ValueError(
+            f"Warp does not support computations with dtype: {np_dtype} "
+            f"(bfloat16 and complex types are unsupported)."
+        )
 
 
 def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct) -> Any:
@@ -600,7 +698,11 @@ def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct) -> Any:
         :func:`jaxtype_to_warptype`).
     ValueError
         If the dtype in *jax_info* is not supported by Warp (propagated
-        from :func:`jaxtype_to_warptype`).
+        from :func:`jaxtype_to_warptype`), or if *jax_info* describes a
+        0-D scalar (``ndim == 0``).  Warp arrays have a minimum
+        dimensionality of 1, so a 0-D input is rejected rather than
+        silently promoted to ``ndim=1`` (which would create a hidden
+        JAX<->Warp shape mismatch).
 
     See Also
     --------
@@ -614,6 +716,12 @@ def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct) -> Any:
     descriptor (not an actual array).  This is typically used in Warp
     kernel function signatures to define input/output types.
 
+    Warp has a minimum array dimensionality of 1.  A JAX 0-D scalar
+    (``shape == ()``, ``ndim == 0``) therefore has no faithful Warp array
+    representation; passing one raises ``ValueError`` instead of being
+    silently bumped to ``ndim=1``.  Reshape the scalar to ``(1,)`` before
+    conversion if a length-1 array is intended.
+
     Examples
     --------
     .. code-block:: python
@@ -624,5 +732,11 @@ def jaxinfo_to_warpinfo(jax_info: jax.ShapeDtypeStruct) -> Any:
         >>> warp_arr_type = jaxinfo_to_warpinfo(info)
     """
     warp_mod = import_warp()
+    if jax_info.ndim == 0:
+        raise ValueError(
+            "Warp arrays require ndim >= 1, but got a 0-D scalar "
+            f"(shape={jax_info.shape!r}). Reshape to (1,) before conversion "
+            "if a length-1 array is intended."
+        )
     dtype = jaxtype_to_warptype(jax_info.dtype)
     return warp_mod.array(dtype=dtype, ndim=jax_info.ndim)

--- a/brainevent/_op/util_audit_test.py
+++ b/brainevent/_op/util_audit_test.py
@@ -1,0 +1,271 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+"""Reproduction tests for the ``brainevent/_op/util.py`` audit findings.
+
+Each test targets one finding from
+``dev/2026-06-13-op-issues.md``:
+
+* **H2** -- ``defjvp`` single-result path called the removed
+  ``jax.interpreters.ad.standard_jvp`` -> ``AttributeError`` at registration.
+* **M1** -- ``general_batching_rule`` crashed (``scan got no values``) when
+  every operand axis is ``None``.
+* **M2** -- ``_standard_jvp`` fragmented a bare-array JVP return by iterating
+  its leading axis and validated structure with a strippable ``assert``.
+* **L1** -- ``jaxtype_to_warptype`` spuriously rejected Python builtin
+  ``float``/``int``/``bool`` (``float == np.float64`` is ``False``).
+* **L2** -- ``jaxinfo_to_warpinfo`` silently mapped a 0-D scalar to
+  ``ndim=1``.
+
+The tests are written to fail against the pre-fix ``util.py`` and pass once
+the corrected behavior is in place.
+"""
+
+import functools
+import importlib.util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jax.extend.core import Primitive
+from jax.interpreters import ad, batching, mlir
+
+from brainevent._op import util
+from brainevent._op.util import (
+    defjvp,
+    general_batching_rule,
+    jaxtype_to_warptype,
+    jaxinfo_to_warpinfo,
+)
+
+warp_installed = importlib.util.find_spec('warp') is not None
+
+
+# ---------------------------------------------------------------------------
+# H2 -- public ``defjvp`` on a single-result primitive must work on JAX >= 0.9
+# ---------------------------------------------------------------------------
+
+def test_h2_defjvp_single_result_primitive():
+    """``defjvp`` on a single-result primitive registers and differentiates.
+
+    Pre-fix this raised ``AttributeError`` at *registration* time because the
+    ``multiple_results=False`` branch referenced the removed
+    ``ad.standard_jvp``.  Post-fix the inlined standard JVP must let
+    ``jax.jvp`` / ``jax.grad`` flow through the primitive.
+    """
+    prim = Primitive('h2_single_result_mul')
+    prim.multiple_results = False
+    prim.def_impl(lambda x, y: x * y)
+    prim.def_abstract_eval(
+        lambda x, y: jax.core.ShapedArray(jnp.broadcast_shapes(x.shape, y.shape), x.dtype)
+    )
+
+    # d/dx (x*y) = y ; d/dy (x*y) = x
+    # This call must NOT raise AttributeError on JAX >= 0.9.
+    defjvp(prim,
+           lambda xdot, x, y: xdot * y,
+           lambda ydot, x, y: x * ydot)
+
+    def call(x, y):
+        return prim.bind(x, y)
+
+    x = jnp.asarray(3.0)
+    y = jnp.asarray(5.0)
+
+    # forward-mode
+    primal, tangent = jax.jvp(call, (x, y), (jnp.asarray(1.0), jnp.asarray(0.0)))
+    assert float(primal) == pytest.approx(15.0)
+    assert float(tangent) == pytest.approx(5.0)  # == y
+
+    # reverse-mode
+    gx = jax.grad(call, argnums=0)(x, y)
+    gy = jax.grad(call, argnums=1)(x, y)
+    assert float(gx) == pytest.approx(5.0)  # y
+    assert float(gy) == pytest.approx(3.0)  # x
+
+
+# ---------------------------------------------------------------------------
+# M1 -- ``general_batching_rule`` with all-None axes must short-circuit
+# ---------------------------------------------------------------------------
+
+def test_m1_general_batching_rule_all_unbatched():
+    """All-``None`` axes must bind directly, not invoke an empty ``scan``.
+
+    Pre-fix ``jax.lax.scan(f, 0, {})`` raised
+    ``ValueError: scan got no values to scan over``.  Post-fix the rule
+    binds the primitive once and reports every output as unbatched
+    (``batching.not_mapped``).
+    """
+    prim = Primitive('m1_unbatched_add')
+    prim.multiple_results = False
+    prim.def_impl(lambda x, y: x + y)
+    prim.def_abstract_eval(lambda x, y: jax.core.ShapedArray(x.shape, x.dtype))
+    # Needed only by the scan path; the all-None case must short-circuit
+    # *before* the scan, so registering a lowering simply makes the test robust.
+    mlir.register_lowering(prim, mlir.lower_fun(lambda x, y: x + y, multiple_results=False))
+
+    a = jnp.arange(3.0)
+    b = jnp.ones((3,))
+
+    out, out_dim = general_batching_rule(prim, (a, b), (None, None))
+
+    np.testing.assert_allclose(np.asarray(out), np.asarray(a + b))
+    # Every output dim must be flagged unbatched.  ``batching.not_mapped`` is
+    # ``None``, which the default pytree flattener treats as an empty node, so
+    # we flatten with ``is_leaf`` recognizing the sentinel as a real leaf
+    # (this mirrors how JAX inspects output batch dims).
+    is_not_mapped = lambda x: x is batching.not_mapped
+    leaves = jax.tree.leaves(out_dim, is_leaf=is_not_mapped)
+    assert leaves, 'expected at least one output-dim leaf'
+    assert all(leaf is batching.not_mapped for leaf in leaves)
+    # The out_dim pytree must mirror the output structure.
+    assert (jax.tree.structure(out_dim, is_leaf=is_not_mapped)
+            == jax.tree.structure(out))
+
+
+def test_m1_general_batching_rule_mixed_still_works():
+    """A genuinely batched operand still scans and reports leading-axis output.
+
+    Guards against the short-circuit accidentally swallowing the normal path.
+    """
+    prim = Primitive('m1_mixed_add')
+    prim.multiple_results = False
+    prim.def_impl(lambda x, y: x + y)
+    prim.def_abstract_eval(lambda x, y: jax.core.ShapedArray(x.shape, x.dtype))
+    # The scan body binds the primitive; lowering lets the traced scan execute.
+    mlir.register_lowering(prim, mlir.lower_fun(lambda x, y: x + y, multiple_results=False))
+
+    batched = jnp.arange(6.0).reshape(2, 3)  # batched along axis 0
+    unbatched = jnp.ones((3,))
+
+    out, out_dim = general_batching_rule(prim, (batched, unbatched), (0, None))
+
+    np.testing.assert_allclose(np.asarray(out), np.asarray(batched + unbatched))
+    assert all(leaf == 0 for leaf in jax.tree.leaves(out_dim))
+
+
+# ---------------------------------------------------------------------------
+# M2 -- ``_standard_jvp`` must reject a bare-array JVP return (no fragmenting)
+# ---------------------------------------------------------------------------
+
+def test_m2_standard_jvp_rejects_bare_array_return():
+    """A multi-result JVP rule returning a bare array must raise ``TypeError``.
+
+    Pre-fix ``tuple(rule(...))`` iterated the leading axis of the returned
+    array (silent fragmentation) and validated structure with a strippable
+    ``assert``.  Post-fix a non-sequence return is a clear ``TypeError``.
+    """
+    prim = Primitive('m2_multi_result')
+    prim.multiple_results = True
+    prim.def_impl(lambda x: (x, x))
+    prim.def_abstract_eval(
+        lambda x: (jax.core.ShapedArray(x.shape, x.dtype),
+                   jax.core.ShapedArray(x.shape, x.dtype))
+    )
+
+    # This rule INCORRECTLY returns a bare array instead of a (t0, t1) tuple.
+    def bad_rule(xdot, x):
+        return xdot  # bare array -- should be a length-2 sequence
+
+    defjvp(prim, bad_rule)
+
+    def call(x):
+        return prim.bind(x)
+
+    x = jnp.arange(4.0)
+    with pytest.raises(TypeError):
+        jax.jvp(call, (x,), (jnp.ones_like(x),))
+
+
+def test_m2_standard_jvp_accepts_proper_sequence_return():
+    """A correctly-shaped multi-result JVP rule still differentiates."""
+    prim = Primitive('m2_multi_result_ok')
+    prim.multiple_results = True
+    prim.def_impl(lambda x: (x * 2.0, x * 3.0))
+    prim.def_abstract_eval(
+        lambda x: (jax.core.ShapedArray(x.shape, x.dtype),
+                   jax.core.ShapedArray(x.shape, x.dtype))
+    )
+
+    def good_rule(xdot, x):
+        return (xdot * 2.0, xdot * 3.0)
+
+    defjvp(prim, good_rule)
+
+    def call(x):
+        a, b = prim.bind(x)
+        return a, b
+
+    x = jnp.arange(4.0)
+    (pa, pb), (ta, tb) = jax.jvp(call, (x,), (jnp.ones_like(x),))
+    np.testing.assert_allclose(np.asarray(ta), np.full((4,), 2.0))
+    np.testing.assert_allclose(np.asarray(tb), np.full((4,), 3.0))
+
+
+# ---------------------------------------------------------------------------
+# L1 -- ``jaxtype_to_warptype`` must accept Python builtins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not warp_installed, reason='warp not installed')
+def test_l1_jaxtype_to_warptype_accepts_python_builtins():
+    """Python builtin ``float``/``int``/``bool`` must map like their dtypes.
+
+    Pre-fix ``float == np.float64`` is ``False`` so builtins spuriously
+    raised ``ValueError``.  Post-fix ``np.dtype(...)`` normalization makes
+    ``float`` resolve to whatever ``np.dtype(float)`` is (float64).
+    """
+    # The builtin must resolve to the same Warp type as its normalized dtype.
+    assert jaxtype_to_warptype(float) is jaxtype_to_warptype(np.dtype(float))
+    assert jaxtype_to_warptype(int) is jaxtype_to_warptype(np.dtype(int))
+    assert jaxtype_to_warptype(bool) is jaxtype_to_warptype(np.dtype(bool))
+
+    # And concretely: np.dtype(float) is float64 on every supported platform.
+    assert jaxtype_to_warptype(float) is jaxtype_to_warptype(np.float64)
+
+
+@pytest.mark.skipif(not warp_installed, reason='warp not installed')
+def test_l1_jaxtype_to_warptype_unsupported_raises_clear_error():
+    """Complex / bfloat16 (unsupported by Warp) must raise a clear error."""
+    with pytest.raises(ValueError):
+        jaxtype_to_warptype(np.complex64)
+
+
+# ---------------------------------------------------------------------------
+# L2 -- ``jaxinfo_to_warpinfo`` must not silently bump a 0-D scalar to ndim=1
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not warp_installed, reason='warp not installed')
+def test_l2_jaxinfo_to_warpinfo_rejects_scalar():
+    """A 0-D ``ShapeDtypeStruct`` must be handled explicitly, not silently bumped.
+
+    Pre-fix ``warp.array(ndim=0)`` silently became ``ndim=1`` (JAX<->Warp
+    ndim mismatch).  Post-fix a clear error is raised for ``ndim == 0``.
+    """
+    scalar = jax.ShapeDtypeStruct(shape=(), dtype=np.float32)
+    assert scalar.ndim == 0
+    with pytest.raises(ValueError):
+        jaxinfo_to_warpinfo(scalar)
+
+
+@pytest.mark.skipif(not warp_installed, reason='warp not installed')
+def test_l2_jaxinfo_to_warpinfo_normal_ndim_ok():
+    """A normal >=1-D struct still converts and preserves ``ndim``."""
+    info = jax.ShapeDtypeStruct(shape=(4, 5), dtype=np.float32)
+    warp_arr_type = jaxinfo_to_warpinfo(info)
+    assert warp_arr_type.ndim == 2

--- a/brainevent/include/brainevent/check.h
+++ b/brainevent/include/brainevent/check.h
@@ -15,16 +15,48 @@
 
 #pragma once
 /// @file check.h
-/// @brief JKB assertion and CUDA error-checking macros.
+/// @brief BE assertion and CUDA error-checking macros.
+///
+/// On the host these macros *throw* (``BE::CheckError`` / ``BE::CudaError``,
+/// both ``std::runtime_error``) so a generated FFI wrapper can catch
+/// ``std::exception`` and return an ``xla::ffi::Error`` - keeping the Python
+/// interpreter alive - instead of calling ``abort()`` and killing the process
+/// with ``SIGABRT``.  In device code (``__CUDA_ARCH__``) exceptions are
+/// unavailable, so the failing path prints a diagnostic and ``__trap()``s.
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cinttypes>
+
+#ifndef __CUDA_ARCH__
+#include <stdexcept>
+#include <string>
+
+namespace BE {
+
+/// Thrown by ``BE_CHECK`` when a host-side invariant fails.
+class CheckError : public std::runtime_error {
+public:
+    explicit CheckError(const std::string& message) : std::runtime_error(message) {}
+};
+
+/// Thrown by ``BE_CUDA_CHECK`` when a CUDA runtime call fails on the host.
+class CudaError : public std::runtime_error {
+public:
+    explicit CudaError(const std::string& message) : std::runtime_error(message) {}
+};
+
+}  // namespace BE
+#endif  // __CUDA_ARCH__
 
 // ---------------------------------------------------------------------------
 // BE_CHECK(cond) << "message";
 //
-// Abort with a diagnostic if @p cond is false.  The streaming operator
-// allows building the message lazily.
+// Throw (host) or trap (device) with a diagnostic if @p cond is false.  The
+// streaming operator builds the message lazily.  ``BE_CHECK`` is intended for
+// host code; it is exercised on the happy path (not during stack unwinding),
+// so throwing from the message stream's destructor is safe.
 // ---------------------------------------------------------------------------
 
 namespace BE {
@@ -39,16 +71,25 @@ public:
     explicit CheckFailMessageStream(std::nullptr_t)
         : file_(nullptr), line_(0), cond_(nullptr), active_(false) {}
 
-    ~CheckFailMessageStream() {
-        if (active_) {
-            fprintf(stderr, "[be] CHECK FAILED at %s:%d: %s", file_, line_, cond_);
-            if (buf_[0] != '\0') {
-                fprintf(stderr, " — %s", buf_);
-            }
-            fprintf(stderr, "\n");
-            fflush(stderr);
-            abort();
+    // Throws BE::CheckError on the host so the failure can be converted to an
+    // xla::ffi::Error by the FFI wrapper.  ``noexcept(false)`` is required
+    // because the throw happens here, at end of the full expression.
+    ~CheckFailMessageStream() noexcept(false) {
+        if (!active_) return;
+#ifdef __CUDA_ARCH__
+        printf("[be] CHECK FAILED at %s:%d: %s %s\n", file_, line_, cond_, buf_);
+        __trap();
+#else
+        char msg[640];
+        if (buf_[0] != '\0') {
+            snprintf(msg, sizeof(msg), "[be] CHECK FAILED at %s:%d: %s - %s",
+                     file_, line_, cond_, buf_);
+        } else {
+            snprintf(msg, sizeof(msg), "[be] CHECK FAILED at %s:%d: %s",
+                     file_, line_, cond_);
         }
+        throw ::BE::CheckError(msg);
+#endif
     }
 
     // Prevent copies so the destructor fires exactly once.
@@ -62,10 +103,9 @@ public:
         o.active_ = false;  // moved-from instance must not fire
     }
 
-    template <typename T>
-    CheckFailMessageStream& operator<<(const T& val);
-
     // Specialisations for common types to avoid pulling in <sstream>.
+    // (No catch-all template overload: streaming an unsupported type is a
+    // compile error here rather than a link error against an undefined template.)
     CheckFailMessageStream& operator<<(const char* s) {
         if (active_ && s) append(s);
         return *this;
@@ -75,7 +115,7 @@ public:
         return *this;
     }
     CheckFailMessageStream& operator<<(int64_t v) {
-        if (active_) { char tmp[32]; snprintf(tmp, sizeof(tmp), "%ld", (long)v); append(tmp); }
+        if (active_) { char tmp[32]; snprintf(tmp, sizeof(tmp), "%" PRId64, v); append(tmp); }
         return *this;
     }
     CheckFailMessageStream& operator<<(size_t v) {
@@ -101,31 +141,84 @@ private:
     int pos_ = 0;
 };
 
+// Consumes a CheckFailMessageStream and yields void so that BE_CHECK's ternary
+// has two ``void`` branches.  Without this, ``cond ? Stream(nullptr) :
+// Stream(...)`` would force the conditional operator to materialise a
+// (deleted-copy) temporary of the non-copyable stream.  ``operator&`` has lower
+// precedence than ``operator<<``, so ``Voidify() & stream << x`` binds as
+// ``Voidify() & (stream << x)``.  The ``const&`` parameter binds to both the
+// lvalue returned by ``operator<<`` (message present) and the stream temporary
+// itself (no message); the temporary's throwing destructor still fires at the
+// end of the full expression.
+class Voidify {
+public:
+    void operator&(const CheckFailMessageStream&) const {}
+};
+
 }  // namespace internal
 }  // namespace BE
 
 /// General-purpose assertion with streaming message.
 ///     BE_CHECK(x.ndim() == 1) << "expected 1D, got " << x.ndim();
+///
+/// Expands so the ternary has two ``void`` operands (see ``Voidify``); the
+/// failing branch builds a temporary ``CheckFailMessageStream`` whose
+/// destructor throws ``BE::CheckError`` (host) or traps (device) at the end of
+/// the full expression.
 #define BE_CHECK(cond)                                                   \
-    (cond) ? ::BE::internal::CheckFailMessageStream(nullptr)             \
-           : ::BE::internal::CheckFailMessageStream(                     \
-                 __FILE__, __LINE__, #cond)
+    (cond) ? (void)0                                                     \
+           : ::BE::internal::Voidify() &                                 \
+                 ::BE::internal::CheckFailMessageStream(                 \
+                     __FILE__, __LINE__, #cond)
 
 /// CUDA runtime API error check.
 ///     BE_CUDA_CHECK(cudaGetLastError());
+///
+/// On the host a failing call throws BE::CudaError (an xla::ffi::Error after
+/// the wrapper catch); in device code it traps.  ``cudaGetErrorString`` /
+/// ``cudaGetErrorName`` are host-only, so the device path reports the numeric
+/// error code only.
+#ifdef __CUDA_ARCH__
 #define BE_CUDA_CHECK(expr)                                              \
     do {                                                                  \
-        cudaError_t __jkb_err = (expr);                                   \
-        if (__jkb_err != cudaSuccess) {                                   \
-            fprintf(stderr,                                               \
-                    "[be] CUDA error at %s:%d: %s (%s)\n",              \
-                    __FILE__, __LINE__,                                    \
-                    cudaGetErrorString(__jkb_err),                         \
-                    cudaGetErrorName(__jkb_err));                          \
-            fflush(stderr);                                               \
-            abort();                                                      \
+        cudaError_t __be_err = (expr);                                    \
+        if (__be_err != cudaSuccess) {                                    \
+            printf("[be] CUDA error at %s:%d: code %d\n",                 \
+                   __FILE__, __LINE__, (int)__be_err);                    \
+            __trap();                                                     \
         }                                                                 \
     } while (0)
+#else
+#define BE_CUDA_CHECK(expr)                                              \
+    do {                                                                  \
+        cudaError_t __be_err = (expr);                                    \
+        if (__be_err != cudaSuccess) {                                    \
+            char __be_msg[256];                                           \
+            snprintf(__be_msg, sizeof(__be_msg),                          \
+                     "[be] CUDA error at %s:%d: %s (%s)",                 \
+                     __FILE__, __LINE__,                                   \
+                     cudaGetErrorString(__be_err),                        \
+                     cudaGetErrorName(__be_err));                         \
+            throw ::BE::CudaError(__be_msg);                              \
+        }                                                                 \
+    } while (0)
+#endif
 
-/// Check after kernel launch (catches configuration errors).
+/// Check after a kernel launch.
+///
+/// NOTE: ``cudaGetLastError()`` only surfaces *synchronous* launch errors
+/// (invalid grid/block dims, excessive shared memory).  Asynchronous faults
+/// (illegal address, out-of-bounds access) are reported at the next
+/// synchronization point and may therefore be misattributed to a later,
+/// unrelated operation.  Use ``BE_CHECK_KERNEL_LAUNCH_SYNC()`` while debugging
+/// to pin a fault to its launch site.
 #define BE_CHECK_KERNEL_LAUNCH() BE_CUDA_CHECK(cudaGetLastError())
+
+/// Like ``BE_CHECK_KERNEL_LAUNCH()`` but also synchronizes the device first so
+/// asynchronous kernel faults are caught here rather than at a later sync.
+/// This forces a full device synchronization and is intended for debug builds.
+#define BE_CHECK_KERNEL_LAUNCH_SYNC()                                    \
+    do {                                                                  \
+        BE_CUDA_CHECK(cudaGetLastError());                                \
+        BE_CUDA_CHECK(cudaDeviceSynchronize());                           \
+    } while (0)

--- a/brainevent/include/brainevent/dtypes.h
+++ b/brainevent/include/brainevent/dtypes.h
@@ -15,9 +15,9 @@
 
 #pragma once
 /// @file dtypes.h
-/// @brief XLA DataType ↔ BE::DType conversion and dispatch macros.
+/// @brief XLA DataType <-> BE::DType conversion and dispatch macros.
 ///
-/// INTERNAL HEADER — included only in auto-generated FFI wrappers,
+/// INTERNAL HEADER - included only in auto-generated FFI wrappers,
 /// never directly by user CUDA code (it pulls in XLA FFI headers).
 
 #include "brainevent/tensor.h"
@@ -26,6 +26,10 @@
 namespace BE {
 
 /// Convert an XLA FFI DataType to BE::DType.
+///
+/// Unmapped types (f8/f4/sub-byte/TOKEN) return ``DType::Invalid``, whose
+/// ``dtype_size()`` is 0.  Callers must reject ``Invalid`` rather than build a
+/// zero-stride tensor; ``BE::internal::buffer_to_tensor`` does this loudly (L11).
 inline DType xla_to_jkb_dtype(xla::ffi::DataType dt) noexcept {
     using D = xla::ffi::DataType;
     switch (dt) {
@@ -50,6 +54,6 @@ inline DType xla_to_jkb_dtype(xla::ffi::DataType dt) noexcept {
 
 // Dispatch macros have moved to the user-facing header jkb/dispatch.h
 // (included via jkb/common.h).  This internal header only provides
-// the XLA DataType ↔ BE::DType conversion.
+// the XLA DataType <-> BE::DType conversion.
 
 }  // namespace BE

--- a/brainevent/include/brainevent/ffi_compat.h
+++ b/brainevent/include/brainevent/ffi_compat.h
@@ -17,7 +17,7 @@
 /// @file ffi_compat.h
 /// @brief Converts XLA FFI buffer types to BE::Tensor.
 ///
-/// INTERNAL HEADER — included only in auto-generated FFI wrappers,
+/// INTERNAL HEADER - included only in auto-generated FFI wrappers,
 /// never directly by user CUDA code.
 
 #include "xla/ffi/api/ffi.h"
@@ -34,11 +34,24 @@ namespace BE {
 namespace internal {
 
 /// Build a Tensor from an XLA FFI input buffer.
+///
+/// Throws ``std::invalid_argument`` (host only) for a dtype with no BE::DType
+/// mapping (f8/f4/sub-byte/token), instead of building a ``DType::Invalid``
+/// tensor whose ``element_size()`` is silently 0 (L11).  The generated FFI
+/// wrapper catches this and returns an ``xla::ffi::Error``.
 inline Tensor buffer_to_tensor(xla::ffi::AnyBuffer buf) {
     void* data = buf.untyped_data();
     auto dims = buf.dimensions();
     int ndim = static_cast<int>(dims.size());
     DType dtype = xla_to_jkb_dtype(buf.element_type());
+#ifndef __CUDA_ARCH__
+    if (dtype == DType::Invalid) {
+        throw std::invalid_argument(
+            "BE: unsupported XLA FFI buffer dtype (XLA DataType enum " +
+            std::to_string(static_cast<int>(buf.element_type())) +
+            "); no BE::DType mapping exists for this type");
+    }
+#endif
     return Tensor(data, dims.begin(), ndim, dtype);
 }
 

--- a/brainevent/include/brainevent/tensor.h
+++ b/brainevent/include/brainevent/tensor.h
@@ -15,7 +15,7 @@
 
 #pragma once
 /// @file tensor.h
-/// @brief BE::Tensor — lightweight, self-contained tensor descriptor.
+/// @brief BE::Tensor - lightweight, self-contained tensor descriptor.
 ///
 /// Tensor does NOT own the data it points to. It stores shape and
 /// C-contiguous strides internally (up to kMaxDim dimensions) so that a
@@ -23,6 +23,13 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <cassert>
+#include <climits>
+
+#ifndef __CUDA_ARCH__
+#include <stdexcept>
+#include <string>
+#endif
 
 namespace BE {
 
@@ -112,8 +119,20 @@ public:
 
     /// Construct from raw components.  Strides are computed assuming
     /// C-contiguous (row-major) layout.
+    ///
+    /// Throws ``std::out_of_range`` (host only) if @p ndim is negative or
+    /// exceeds ``kMaxDim`` - without this guard a rank-9+ buffer would read
+    /// past @p shape and silently truncate the rank, after which ``shape(i)``
+    /// returns uninitialised storage (M15).
     Tensor(void* data, const int64_t* shape, int ndim, DType dtype)
         : data_(data), ndim_(ndim), dtype_(dtype) {
+#ifndef __CUDA_ARCH__
+        if (ndim < 0 || ndim > kMaxDim) {
+            throw std::out_of_range(
+                "BE::Tensor: ndim " + std::to_string(ndim) +
+                " is out of range [0, " + std::to_string(kMaxDim) + "]");
+        }
+#endif
         for (int i = 0; i < kMaxDim; ++i) {
             shape_[i] = (i < ndim) ? shape[i] : 0;
             strides_[i] = 0;
@@ -142,7 +161,7 @@ public:
     template <typename T>
     T* data_ptr() const noexcept { return static_cast<T*>(data_); }
 
-    /// Alias for ``data_ptr()`` — kept for backward compatibility.
+    /// Alias for ``data_ptr()`` - kept for backward compatibility.
     void* data() const noexcept { return data_; }
 
     // -- shape / strides ----------------------------------------------
@@ -150,11 +169,19 @@ public:
     /// Number of dimensions.
     int ndim() const noexcept { return ndim_; }
 
-    /// Size along dimension @p i.
-    int64_t shape(int i) const noexcept { return shape_[i]; }
+    /// Size along dimension @p i.  Debug builds assert ``0 <= i < ndim`` (M15);
+    /// release builds trust the caller (the accessor stays ``noexcept`` and
+    /// device-callable).
+    int64_t shape(int i) const noexcept {
+        assert(i >= 0 && i < ndim_);
+        return shape_[i];
+    }
 
-    /// Stride (in elements) along dimension @p i.
-    int64_t stride(int i) const noexcept { return strides_[i]; }
+    /// Stride (in elements) along dimension @p i.  Debug builds assert bounds.
+    int64_t stride(int i) const noexcept {
+        assert(i >= 0 && i < ndim_);
+        return strides_[i];
+    }
 
     /// Pointer to the internal shape array.
     const int64_t* shape_ptr() const noexcept { return shape_; }
@@ -162,8 +189,11 @@ public:
     /// Pointer to the internal strides array.
     const int64_t* strides_ptr() const noexcept { return strides_; }
 
-    /// Alias: size(i) == shape(i).
-    int64_t size(int i) const noexcept { return shape_[i]; }
+    /// Alias: size(i) == shape(i).  Debug builds assert bounds.
+    int64_t size(int i) const noexcept {
+        assert(i >= 0 && i < ndim_);
+        return shape_[i];
+    }
 
     // -- dtype --------------------------------------------------------
 
@@ -176,8 +206,11 @@ public:
     // -- aggregate queries --------------------------------------------
 
     /// Total number of elements.
+    ///
+    /// A rank-0 tensor (scalar) has exactly one element: the empty product is
+    /// 1, not 0 (M14).  Returning 0 here previously made ``nbytes()`` 0 for
+    /// every scalar.
     int64_t numel() const noexcept {
-        if (ndim_ == 0) return 0;
         int64_t n = 1;
         for (int i = 0; i < ndim_; ++i) n *= shape_[i];
         return n;
@@ -188,7 +221,31 @@ public:
         return static_cast<size_t>(numel()) * element_size();
     }
 
+#ifndef __CUDA_ARCH__
+    /// ``numel()`` narrowed to ``int``, with an overflow guard (host only).
+    ///
+    /// CUDA launch extents are commonly passed as ``int``.  This throws
+    /// ``std::overflow_error`` instead of silently truncating (possibly to a
+    /// negative value) when the element count exceeds ``INT_MAX`` (M14).
+    int numel_checked_int() const {
+        int64_t n = numel();
+        if (n > static_cast<int64_t>(INT_MAX)) {
+            throw std::overflow_error(
+                "BE::Tensor::numel_checked_int: element count " +
+                std::to_string(n) + " exceeds INT_MAX");
+        }
+        return static_cast<int>(n);
+    }
+#endif
+
     /// Whether the tensor is C-contiguous.
+    ///
+    /// NOTE: with the current constructors this always returns ``true`` - the
+    /// raw-components constructor *fabricates* C-contiguous strides and XLA's
+    /// ``XLA_FFI_Buffer`` exposes only ``dims`` (no strides), so a non-default
+    /// layout is unrecoverable here.  The check is retained for the day a
+    /// constructor accepts explicit strides; until then treat it as an
+    /// invariant, not a runtime discriminator (L7).
     bool is_contiguous() const noexcept {
         if (ndim_ <= 1) return true;
         int64_t expected = 1;

--- a/brainevent/include/cuda_common.h
+++ b/brainevent/include/cuda_common.h
@@ -44,6 +44,22 @@
 // =========================================================================
 
 /*
+ * PRECONDITION (all warp_reduce_* helpers below): FULLY CONVERGED WARP.
+ * Every helper uses __shfl_down_sync(0xffffffff, ...), i.e. it asserts that
+ * ALL 32 lanes of the warp participate.  Calling any of these from a path that
+ * a subset of lanes reached -- e.g. after `if (tid >= n) return;` or inside a
+ * data-dependent branch -- is undefined behaviour: it may hang or fold in
+ * garbage from inactive/retired lanes (M17).
+ *
+ * Callers with partial warps MUST mask off out-of-range lanes BEFORE the
+ * reduction (pad the inactive lanes with the reduction identity -- 0 for sum,
+ * -inf/+inf for max/min -- and let all 32 lanes call the helper), rather than
+ * early-returning. Computing __activemask() INSIDE the helper is intentionally
+ * NOT done: it would silently fold over whatever lanes happen to be active and
+ * mask the real bug instead of surfacing it.
+ */
+
+/*
  * NOTE ON FP16/BF16 REDUCTIONS:
  * Reduction helpers are defined for accumulator types (f32/f64), not storage
  * types. fp16/bf16 kernels upcast with READ_F16/READ_BF16 and use float
@@ -334,6 +350,15 @@ __device__ __inline__ void atomic_add_f64(double* addr, double val) {
  * Uses native atomicAdd on sm_70+ (Volta and newer).
  * Falls back to CAS-based emulation on older architectures.
  *
+ * PRECONDITION (pre-sm_70 emulation path only): @p addr must lie within a
+ * buffer whose enclosing 4-byte word is fully owned by the allocation, i.e.
+ * half buffers must be 4-byte aligned and even-length (padded).  The emulation
+ * rounds @p addr down to a 4-byte boundary and performs a 32-bit atomicCAS,
+ * which reads AND writes the adjacent 2 bytes; for the last element of an
+ * odd-length buffer at an allocation boundary that is a 2-byte out-of-bounds
+ * read-modify-write and can corrupt a neighbouring allocation (M16).  On
+ * sm_70+ the native path is used and this restriction does not apply.
+ *
  * @param addr  Pointer to memory location
  * @param val   Value to add (float32, will be converted to float16)
  */
@@ -341,7 +366,9 @@ __device__ __inline__ void atomic_add_f16(__half* addr, float val) {
 #if __CUDA_ARCH__ >= 700
     atomicAdd(addr, __float2half(val));
 #else
-    // Emulate with CAS on older architectures
+    // Emulate with CAS on older architectures.
+    // WARNING: touches the neighbouring 2 bytes - see the M16 precondition above
+    // (half buffers must be 4-byte aligned and even-length / padded).
     unsigned int* base = reinterpret_cast<unsigned int*>(
         reinterpret_cast<size_t>(addr) & ~(size_t)2
     );
@@ -365,6 +392,12 @@ __device__ __inline__ void atomic_add_f16(__half* addr, float val) {
  * Uses native atomicAdd on sm_80+ (Ampere and newer).
  * Falls back to CAS-based emulation on older architectures.
  *
+ * PRECONDITION (pre-sm_80 emulation path only): same as atomic_add_f16 - @p addr
+ * must lie in a 4-byte-aligned, even-length (padded) bf16 buffer.  The 32-bit
+ * atomicCAS reads AND writes the adjacent 2 bytes, so the last element of an
+ * odd-length buffer at an allocation boundary is a 2-byte out-of-bounds
+ * read-modify-write (M16).  On sm_80+ the native path is used.
+ *
  * @param addr  Pointer to memory location
  * @param val   Value to add (float32, will be converted to bfloat16)
  */
@@ -372,7 +405,9 @@ __device__ __inline__ void atomic_add_bf16(__nv_bfloat16* addr, float val) {
 #if __CUDA_ARCH__ >= 800
     atomicAdd(addr, __float2bfloat16(val));
 #else
-    // Emulate with CAS on older architectures
+    // Emulate with CAS on older architectures.
+    // WARNING: touches the neighbouring 2 bytes - see the M16 precondition above
+    // (bf16 buffers must be 4-byte aligned and even-length / padded).
     unsigned int* base = reinterpret_cast<unsigned int*>(
         reinterpret_cast<size_t>(addr) & ~(size_t)2
     );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,12 @@ dependencies = [
     'numpy>=1.15',
     'brainunit>=0.0.8',
     'absl-py',
-    'jax>=0.5.0',
+    # Upper-bounded because the XLA FFI ABI (XLA_FFI_API_MINOR, ffi.h layout)
+    # used by the compiled kernels can change across minor releases; an
+    # incompatible jaxlib otherwise surfaces only as a runtime load/compile
+    # failure instead of at install time.  jax and jaxlib ship in lockstep, so
+    # bounding jax bounds jaxlib (L16).
+    'jax>=0.5.0,<0.11',
 ]
 
 
@@ -102,10 +107,12 @@ brainevent = "brainevent._cli:main"
 
 
 [project.optional-dependencies]
-cpu = ['jax[cpu]>=0.7.2', 'numba']
-cuda12 = ['jax[cuda12]>=0.7.2']
-cuda13 = ['jax[cuda13]>=0.7.2']
-tpu = ['jax[tpu]>=0.7.2']
+# Upper bound mirrors the core 'jax' pin above: the FFI ABI is only tested
+# through the 0.9.x/0.10.x line (L16).
+cpu = ['jax[cpu]>=0.7.2,<0.11', 'numba']
+cuda12 = ['jax[cuda12]>=0.7.2,<0.11']
+cuda13 = ['jax[cuda13]>=0.7.2,<0.11']
+tpu = ['jax[tpu]>=0.7.2,<0.11']
 testing = ['pytest', 'pytest-cov']
 
 


### PR DESCRIPTION
## Summary

A senior JAX + CUDA audit of `brainevent/_op` (the JAX custom-op / FFI
infrastructure) and `brainevent/include` (the C++/CUDA FFI headers) found
~30 defects. Most produced **silent wrong answers or process death**
rather than a clean Python error. This PR fixes all of them; every
Critical/High fix ships with a reproduction test.

## Critical

| ID | Defect | Fix |
|----|--------|-----|
| C1 | numba CPU & CUDA callbacks swallowed exceptions and returned `OkStatus` (NULL) → silent uninitialised output | build a real `XLA_FFI_Error*` and return it; JAX raises |
| C2 | fp16/bf16/complex broke the dtype map; a `None` map entry was used as a dtype | raw byte-views + `ml_dtypes.bfloat16` + hard error on unmapped/None codes |
| C3 | GPU callback built device arrays/stream without binding the XLA device → multi-GPU race | resolve the device ordinal and bind `cuda.gpus[ordinal]` first |
| H3 | `BE_CHECK`/`BE_CUDA_CHECK` called `abort()` → `SIGABRT` killed the host process | throw `BE::CheckError`/`CudaError` on host (`printf`+`__trap` on device); codegen `try/catch` → `xla::ffi::Error` |

## High

- **H1** — FFI targets re-registered every call → memoised per `(kernel, shapes, dtypes, platform, launch-config)` under a lock.
- **H2** — `util.py` used removed jax internals (`ad.standard_jvp`) and asserted on user returns → inlined single-result JVP, all-`None` batching short-circuit, validated rule return.
- **H4** — cache key ignored `extra_include_paths`, jaxlib version, and header byte-contents → now hashes every injected `brainevent` header + jaxlib `ffi.h` + include paths, so any header edit rebuilds.
- **H5/H6** — toolchain ignored the `nvcc` returncode and missed `CUDA_PATH`; both handled, real driver error preserved.
- **H8** — kernel/attr names interpolated into C++ unchecked → validated as C identifiers (`KernelError`).

## Medium / Low

Empty/zero launch guard (M3), input/output layouts pinned (M4),
idempotent-but-safe registration that refuses a conflicting module (M5),
subprocess utf-8 decoding (M12), backend-mismatch **warning** instead of
silent fallback (M13), `tensor.h` rank-0 `numel()` + bounds guards
(M14/M15), `cuda_common.h` half-atomic alignment + warp-reduce mask
preconditions (M16/M17), `dtypes.h` `Invalid` → loud error,
`apply_primitive` import shim (L3), jaxlib upper bound (L16),
`Dict`/`List` → builtins, docstring corrections.

## Two cross-cutting mechanisms

1. **Shared XLA-FFI error infrastructure** — both bridges now build and
   return real `XLA_FFI_Error*` pointers (fixes C1 + the dtype/`None`
   handling for C2/M7); the metadata handshake reports the real
   `XLA_FFI_API_MAJOR/MINOR`.
2. **C++ exception propagation instead of `abort()`** — `check.h` throws on
   the host and `kernix_codegen` wraps the generated call in `try/catch`,
   turning a thrown `BE::CudaError` into an `xla::ffi::Error` the Python
   side raises (fixes H3). Device code keeps `printf`+`__trap`.

## Verification

- Full `brainevent/_op` suite green on **GPU + CPU + compile backends**:
  `297 passed, 2 skipped`.
- New `*_audit_test.py` / `*_propagation_test.py` reproduce each
  Critical/High before fixing (TDD); the `check.h` throw path is verified
  end-to-end through real `g++` compilation (no `SIGABRT`, process
  survives).
- mypy ratchet clean (`new: 0`) in a CI-equivalent deps-free env.
- `_event`/`_fcn` downstream smoke: `466 passed`. The 8 failing
  `binary_fcnmm[...cuda_raw]` cases are a **pre-existing** transposed-output
  bug in `_fcn` (out of audit scope) — verified to reproduce identically on
  the base commit `3478221` with none of these changes applied.

Full audit write-up: `dev/superpowers/2026-06-13-op-issues.md` (gitignored).
