### PR TITLE
test(jitc): align allclose tolerances with saiunit unit contract

### DIFF
--- a/brainevent/_jit_normal/main_test.py
+++ b/brainevent/_jit_normal/main_test.py
@@ -280,10 +280,10 @@ class Test_JITC_Operator_Behavior:
         r3 = left_vec @ mat
         r4 = left_vec @ dense
         assert u.math.allclose(r1, r2,
-                               rtol=1e-4 * u.get_unit(r2),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r2))
         assert u.math.allclose(r3, r4,
-                               rtol=1e-4 * u.get_unit(r4),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r4))
         jax.block_until_ready((right_vec, left_vec))
 

--- a/brainevent/_jit_scalar/main_test.py
+++ b/brainevent/_jit_scalar/main_test.py
@@ -274,10 +274,10 @@ class Test_JITC_Operator_Behavior:
         r3 = left_vec @ mat
         r4 = left_vec @ dense
         assert u.math.allclose(r1, r2,
-                               rtol=1e-4 * u.get_unit(r2),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r2))
         assert u.math.allclose(r3, r4,
-                               rtol=1e-4 * u.get_unit(r4),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r4))
         jax.block_until_ready((right_vec, left_vec))
 

--- a/brainevent/_jit_uniform/main_test.py
+++ b/brainevent/_jit_uniform/main_test.py
@@ -279,13 +279,13 @@ class Test_JITC_Operator_Behavior:
         assert u.math.allclose(
             r1,
             r2,
-            rtol=1e-4 * u.get_unit(r2),
+            rtol=1e-4,
             atol=1e-4 * u.get_unit(r2),
         )
         assert u.math.allclose(
             r3,
             r4,
-            rtol=1e-4 * u.get_unit(r4),
+            rtol=1e-4,
             atol=1e-4 * u.get_unit(r4),
         )
         jax.block_until_ready((right_vec, left_vec))


### PR DESCRIPTION
## Summary

Fixes the 6 failing CI tests in the JITC operator unit-behavior suite:

- `_jit_normal/main_test.py::Test_JITC_Operator_Behavior::test_jitc_normal_unit_operator_behavior[JITCNormalR|JITCNormalC]`
- `_jit_scalar/main_test.py::Test_JITC_Operator_Behavior::test_jitc_scalar_unit_operator_behavior[JITCScalarR|JITCScalarC]`
- `_jit_uniform/main_test.py::Test_JITC_Operator_Behavior::test_jitc_uniform_unit_operator_behavior[JITCUniformR|JITCUniformC]`

## Root cause

`saiunit`'s `allclose` contract (saiunit >= 0.4, including the 0.7.2 / 0.8.0 / 0.9.0 matrix in Daily CI) treats:

- **`rtol` as dimensionless** — it multiplies `|y|`, so it is mathematically unitless.
- **`atol` as carrying the data's unit** — it is compared directly against the data.

The tests passed `rtol=1e-4 * u.get_unit(...)` (i.e. `1e-4 mV`), which now raises:

```
saiunit.UnitMismatchError: Cannot convert to a unit with different dimensions. (units are mV and 1).
```

The JITC operators themselves preserve units correctly (verified: `mat @ vec` and `vec @ mat` return `mV`); only the test assertions used the outdated tolerance convention.

## Fix

Pass `rtol` dimensionless and keep the unit only on `atol`. 6 lines across 3 test files.

## Verification

```
$ pytest <the 6 tests> -m ''
6 passed in 14.04s
```