### PR TITLE
Fix indptr and csc building

### DIFF
--- a/brainevent/_csr/add pytest.md
+++ b/brainevent/_csr/add pytest.md
@@ -1,0 +1,301 @@
+Run mypy brainevent/ > mypy-report.txt || true
+  mypy brainevent/ > mypy-report.txt || true
+  mypy-baseline filter --allow-unsynced --baseline-path mypy-baseline.txt < mypy-report.txt
+  shell: /usr/bin/bash -e {0}
+  env:
+    pythonLocation: /opt/hostedtoolcache/Python/3.13.13/x64
+    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.13.13/x64/lib/pkgconfig
+    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.13/x64
+    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.13/x64
+    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.13/x64
+    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.13/x64/lib
+brainevent/_misc.py:1543: error: Unsupported target for indexed assignment ("Any | None")  [index]
+Found 52 errors in 9 files (checked 78 source files)
+
+total errors:
+  fixed: 41
+  new: 1
+  unresolved: 61
+
+errors by error code:
+  union-attr                40  -3
+  note                      26 -18
+  assignment                18 -14
+  arg-type                   4
+  return-value               3  -3
+  misc                       3  -3
+  index                      3  +1
+  var-annotated              2
+  annotation-unchecked       2
+  return                     1
+  name-defined               1
+
+
+
+def _check_csr_cuda_structure_dtypes(indices_info, indptr_info) -> None:
++     """Validate the raw CUDA CSR ABI: int32 indices and int32/int64 indptr."""
++     indices_dtype = jnp.dtype(indices_info.dtype)
++     indptr_dtype = jnp.dtype(indptr_info.dtype)
++     if indices_dtype != jnp.dtype(jnp.int32):
++         raise TypeError(
++             "CSR cuda_raw kernels require indices with dtype int32; "
++             f"got indices dtype {indices_dtype}."
++         )
++     if indptr_dtype not in _CSR_SIGNED_INDEX_DTYPES:
++         raise TypeError(
++             "CSR cuda_raw kernels require indptr with dtype int32 or int64; "
++             f"got indptr dtype {indptr_dtype}."
++         )
++ 
+
++ def _csr_to_csc_index_numpy(
++     csr_indptr: Union[jax.Array, np.ndarray],
++     csr_indices: Union[jax.Array, np.ndarray],
++     *,
++     shape: Tuple[int, int],
++     include_perm: bool = True,
++ ):
++     """Convert CSR indices to CSC on CPU with NumPy, then restore array type."""
++     n_post = shape[1]
++     coord_dtype = _coordinate_index_dtype(getattr(csr_indices, 'dtype', np.int32))
++     nse = getattr(csr_indices, 'size', None)
++     if nse is None:
++         nse = len(csr_indices)
++     offset_dtype = _offset_index_dtype(nse, getattr(csr_indptr, 'dtype', None))
++ 
++     csr_indptr_np = np.asarray(csr_indptr)
++     csr_indices_np = np.asarray(csr_indices)
++ 
++     counts = np.bincount(csr_indices_np, minlength=n_post).astype(offset_dtype, copy=False)
++     csc_indptr_np = np.empty(n_post + 1, dtype=offset_dtype)
++     csc_indptr_np[0] = 0
++     np.cumsum(counts, dtype=offset_dtype, out=csc_indptr_np[1:])
++ 
++     order_np = np.argsort(csr_indices_np, kind='stable')
++     order_np = np.asarray(order_np, dtype=offset_dtype)
++     csc_indices_np = np.searchsorted(csr_indptr_np, order_np, side='right') - 1
++     csc_indices_np = np.asarray(csc_indices_np, dtype=coord_dtype)
++     perm_np = order_np if include_perm else None
++ 
++     if isinstance(csr_indptr, np.ndarray) and isinstance(csr_indices, np.ndarray):
++         return csc_indptr_np, csc_indices_np, perm_np
++ 
++     old_x64 = jax.config.jax_enable_x64
++     needs_x64 = _normalize_dtype(offset_dtype) == np.dtype(np.int64)
++     if needs_x64 and not old_x64:
++         jax.config.update('jax_enable_x64', True)
++     try:
++         csc_indptr = jnp.asarray(csc_indptr_np)
++         csc_indices = jnp.asarray(csc_indices_np)
++         perm = None if perm_np is None else jnp.asarray(perm_np)
++         return csc_indptr, csc_indices, perm
++     finally:
++         if needs_x64 and not old_x64:
++             jax.config.update('jax_enable_x64', False)
+
++ def _load_csr_to_csc_cuda_module():
++     global _CSR_TO_CSC_CUDA_MODULE
++     if _CSR_TO_CSC_CUDA_MODULE is None:
++         from pathlib import Path
++ 
++         from ._op import load_cuda_file
++ 
++         _CSR_TO_CSC_CUDA_MODULE = load_cuda_file(
++             Path(__file__).resolve().parent / "_csr" / "csr_to_csc.cu",
++             name="csr_to_csc",
++         )
++     return _CSR_TO_CSC_CUDA_MODULE
++ 
++ 
++ def _csr_to_csc_index_gpu_column_block(
++     csr_indptr: Union[jax.Array, np.ndarray],
++     csr_indices: Union[jax.Array, np.ndarray],
++     *,
++     shape: Tuple[int, int],
++     include_perm: bool = True,
++     column_block_size: int = 4096,
++ ):
++     """Convert CSR indices to CSC using CUDA column blocks and CPU stitching."""
++     n_post = shape[1]
++     try:
++         column_block_size = int(column_block_size)
++     except (TypeError, ValueError) as exc:
++         raise ValueError("column_block_size must be a positive integer") from exc
++     if column_block_size <= 0:
++         raise ValueError("column_block_size must be a positive integer")
++ 
++     coord_dtype = _coordinate_index_dtype(getattr(csr_indices, 'dtype', np.int32))
++     nse = getattr(csr_indices, 'size', None)
++     if nse is None:
++         nse = len(csr_indices)
++     nse = int(nse)
++     offset_dtype = _offset_index_dtype(nse, getattr(csr_indptr, 'dtype', None))
++ 
++     old_x64 = jax.config.jax_enable_x64
++     needs_x64 = (
++         _normalize_dtype(offset_dtype) == np.dtype(np.int64) or
++         _normalize_dtype(coord_dtype) == np.dtype(np.int64)
++     )
++     if needs_x64 and not old_x64:
++         jax.config.update('jax_enable_x64', True)
++ 
++     try:
++         try:
++             gpu_device = jax.devices("gpu")[0]
++             _load_csr_to_csc_cuda_module()
++         except Exception:
++             return _csr_to_csc_index_numpy(
++                 csr_indptr,
++                 csr_indices,
++                 shape=shape,
++                 include_perm=include_perm,
++             )
++ 
++         csr_indices_dev = jax.device_put(
++             jnp.asarray(csr_indices, dtype=coord_dtype),
++             gpu_device,
++         )
++         csr_indptr_dev = jax.device_put(
++             jnp.asarray(csr_indptr, dtype=offset_dtype),
++             gpu_device,
++         )
++ 
++         counts_dev = jax.ffi.ffi_call(
++             "csr_to_csc.csr_to_csc_count",
++             jax.ShapeDtypeStruct((n_post,), offset_dtype),
++         )(csr_indices_dev, csr_indptr_dev)
++         counts_np = np.asarray(counts_dev, dtype=offset_dtype)
++ 
++         csc_indptr_np = np.empty(n_post + 1, dtype=offset_dtype)
++         csc_indptr_np[0] = 0
++         np.cumsum(counts_np, dtype=offset_dtype, out=csc_indptr_np[1:])
++ 
++         if int(csc_indptr_np[-1]) != nse:
++             raise RuntimeError(
++                 "CUDA CSR-to-CSC count produced an unexpected nnz total: "
++                 f"{int(csc_indptr_np[-1])} != {nse}"
++             )
++ 
++         csc_indices_np = np.empty(nse, dtype=coord_dtype)
++         perm_np = np.empty(nse, dtype=offset_dtype) if include_perm else None
++ 
++         for col_start in range(0, n_post, column_block_size):
++             col_end = min(col_start + column_block_size, n_post)
++             base = int(csc_indptr_np[col_start])
++             end = int(csc_indptr_np[col_end])
++             block_nnz = end - base
++             block_ncols = col_end - col_start
++ 
++             if block_nnz == 0:
++                 continue
++ 
++             local_indptr_np = (
++                 csc_indptr_np[col_start:col_end + 1] -
++                 csc_indptr_np[col_start]
++             ).astype(offset_dtype, copy=False)
++             initial_pos_dev = jax.device_put(
++                 jnp.asarray(local_indptr_np[:-1], dtype=offset_dtype),
++                 gpu_device,
++             )
++ 
++             scratch_info = jax.ShapeDtypeStruct((block_ncols,), offset_dtype)
++             rows_info = jax.ShapeDtypeStruct((block_nnz,), coord_dtype)
++             perm_info = jax.ShapeDtypeStruct((block_nnz,), offset_dtype)
++             _, local_rows_dev, local_perm_dev = jax.ffi.ffi_call(
++                 "csr_to_csc.csr_to_csc_fill_block",
++                 (scratch_info, rows_info, perm_info),
++             )(
++                 csr_indices_dev,
++                 csr_indptr_dev,
++                 initial_pos_dev,
++                 col_start=np.int64(col_start),
++                 col_end=np.int64(col_end),
++             )
++ 
++             csc_indices_np[base:end] = np.asarray(local_rows_dev, dtype=coord_dtype)
++             if include_perm:
++                 perm_np[base:end] = np.asarray(local_perm_dev, dtype=offset_dtype)
++ 
++         if isinstance(csr_indptr, np.ndarray) and isinstance(csr_indices, np.ndarray):
++             return csc_indptr_np, csc_indices_np, perm_np
++ 
++         csc_indptr = jax.device_put(csc_indptr_np, gpu_device)
++         csc_indices = jax.device_put(csc_indices_np, gpu_device)
++         perm = None if perm_np is None else jax.device_put(perm_np, gpu_device)
++         return csc_indptr, csc_indices, perm
++     finally:
++         if needs_x64 and not old_x64:
++             jax.config.update('jax_enable_x64', False)
++ 
+
++     elif method == "gpu_column_block":
++         csc_indptr, csc_indices, post_positions = _csr_to_csc_index_gpu_column_block(
+
+
+-     """cuSPARSE-backed kernel for binary CSR SpMV via jax.experimental.sparse (GPU only)."""
++     """cuSPARSE-backed kernel for binary CSR SpMV via BCOO/BCSR sparse arrays."""
+      import jax.experimental.sparse as jsparse
+      m, k = shape
+      is_homo = (weight_info.size == 1)
+
++ def _binary_csrmv_jax_exp_csrmv_kernel(
++     weight_info: jax.ShapeDtypeStruct,
++     vector_info: jax.ShapeDtypeStruct,
++     shape: MatrixShape,
++     transpose: bool,
++     **kwargs,
++ ):
++     """JAX experimental CSR-backed binary CSR SpMV reference kernel."""
++     import jax.experimental.sparse as jsparse
++     m, k = shape
++     is_homo = (weight_info.size == 1)
++     is_bool = (vector_info.dtype == jnp.bool_)
++     nse = kwargs['indices_info'].size
++     out_dtype = kwargs['outs'][0].dtype
++ 
++     def kernel(weights, indices, indptr, vector):
++         events = vector.astype(out_dtype) if is_bool else (vector > 0.).astype(out_dtype)
++         indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
++         if is_homo:
++             data = jnp.ones(nse, dtype=out_dtype)
++             mat = jsparse.CSR((data, indices, indptr), shape=(m, k))
++             return (jsparse.csr_matvec(mat, events, transpose=transpose) * weights[0].astype(out_dtype),)
++         mat = jsparse.CSR((weights.astype(out_dtype), indices, indptr), shape=(m, k))
++         return (jsparse.csr_matvec(mat, events, transpose=transpose),)
++ 
++     return kernel
+
++     _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
+      load_cuda_file(
+          Path(__file__).parent.joinpath('binary_csrmv.cu'),
+
++     _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
+      load_cuda_file(
+
++     _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
+      is_homo = (weight_info.size == 1)
+      if is_homo:
+          load_cuda_file(
+
+      else:
+          def kernel(weights, indices, indptr, vector):
++             indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
++             vector = vector.astype(weight_info.dtype) if vector.dtype != weight_info.dtype else vector
+              return csr_matvec_p.bind(weights, indices, indptr, vector, shape=kwargs['shape'], transpose=transpose),
+  
+      return kernel
+
++     _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
+      is_homo = (weight_info.size == 1)
+      if is_homo:
+          load_cuda_file(
+
+      else:
+          def kernel(weights, indices, indptr, B):
++             indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
++             B = B.astype(weight_info.dtype) if B.dtype != weight_info.dtype else B
+              return csr_matmat_p.bind(weights, indices, indptr, B, shape=kwargs['shape'], transpose=transpose),
+  
+      return kernel
+
+

--- a/brainevent/_csr/binary.py
+++ b/brainevent/_csr/binary.py
@@ -22,7 +22,12 @@ import jax.numpy as jnp
 import numpy as np
 from jax.interpreters import ad
 
-from brainevent._misc import _csr_to_coo, namescope
+from brainevent._misc import (
+    _check_csr_cuda_structure_dtypes,
+    _check_csr_structure_dtypes,
+    _csr_to_coo,
+    namescope,
+)
 from brainevent._op import load_cuda_file
 from brainevent._op import numba_kernel, XLACustomKernel, general_batching_rule
 from brainevent._op.benchmark import BenchmarkConfig
@@ -431,14 +436,14 @@ def _binary_csrmv_jax_kernel(
     return kernel
 
 
-def _binary_csrmv_cusparse_kernel(
+def _binary_csrmv_bcoo_cusparse_kernel(
     weight_info: jax.ShapeDtypeStruct,
     vector_info: jax.ShapeDtypeStruct,
     shape: MatrixShape,
     transpose: bool,
     **kwargs,
 ):
-    """cuSPARSE-backed kernel for binary CSR SpMV via jax.experimental.sparse (GPU only)."""
+    """cuSPARSE-backed kernel for binary CSR SpMV via BCOO/BCSR sparse arrays."""
     import jax.experimental.sparse as jsparse
     m, k = shape
     is_homo = (weight_info.size == 1)
@@ -475,12 +480,41 @@ def _binary_csrmv_cusparse_kernel(
     return kernel
 
 
+def _binary_csrmv_jax_exp_csrmv_kernel(
+    weight_info: jax.ShapeDtypeStruct,
+    vector_info: jax.ShapeDtypeStruct,
+    shape: MatrixShape,
+    transpose: bool,
+    **kwargs,
+):
+    """JAX experimental CSR-backed binary CSR SpMV reference kernel."""
+    import jax.experimental.sparse as jsparse
+    m, k = shape
+    is_homo = (weight_info.size == 1)
+    is_bool = (vector_info.dtype == jnp.bool_)
+    nse = kwargs['indices_info'].size
+    out_dtype = kwargs['outs'][0].dtype
+
+    def kernel(weights, indices, indptr, vector):
+        events = vector.astype(out_dtype) if is_bool else (vector > 0.).astype(out_dtype)
+        indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
+        if is_homo:
+            data = jnp.ones(nse, dtype=out_dtype)
+            mat = jsparse.CSR((data, indices, indptr), shape=(m, k))
+            return (jsparse.csr_matvec(mat, events, transpose=transpose) * weights[0].astype(out_dtype),)
+        mat = jsparse.CSR((weights.astype(out_dtype), indices, indptr), shape=(m, k))
+        return (jsparse.csr_matvec(mat, events, transpose=transpose),)
+
+    return kernel
+
+
 def _binary_csrmv_cuda_kernel(
     weight_info: jax.ShapeDtypeStruct,
     vector_info: jax.ShapeDtypeStruct,
     transpose: bool,
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     load_cuda_file(
         Path(__file__).parent.joinpath('binary_csrmv.cu'),
         name='csr_binary_csrmv',
@@ -756,11 +790,9 @@ def binary_csrmv_p_call(
         ...     weights, indices, indptr, vector,
         ...     shape=(2, 3), transpose=False)
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     if transpose:
         assert shape[0] == vector.shape[0], "Shape mismatch for transpose operation."
     else:
@@ -831,7 +863,8 @@ binary_csrmv_p.def_cuda_raw_kernel(_binary_csrmv_cuda_kernel, asdefault=True)
 binary_csrmv_p.def_kernel('jax_raw', 'cpu', _binary_csrmv_jax_kernel)
 binary_csrmv_p.def_kernel('jax_raw', 'gpu', _binary_csrmv_jax_kernel)
 binary_csrmv_p.def_kernel('jax_raw', 'tpu', _binary_csrmv_jax_kernel)
-binary_csrmv_p.def_kernel('cusparse', 'gpu', _binary_csrmv_cusparse_kernel)
+binary_csrmv_p.def_kernel('BCOO_cusparse', 'gpu', _binary_csrmv_bcoo_cusparse_kernel)
+binary_csrmv_p.def_kernel('JAX_cusparse', 'gpu', _binary_csrmv_jax_exp_csrmv_kernel)
 binary_csrmv_p.def_jvp_rule2(_csrmv_jvp_weights, None, None, _csrmv_jvp_v)
 binary_csrmv_p.def_transpose_rule(_csrmv_transpose_rule)
 binary_csrmv_p.def_batching_rule(_csrmv_batching)
@@ -1063,6 +1096,7 @@ def _binary_csrmm_cuda_kernel(
     transpose: bool,
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     load_cuda_file(
         Path(__file__).parent.joinpath('binary_csrmm.cu'),
         name='csr_binary_csrmm',
@@ -1316,11 +1350,9 @@ def binary_csrmm_p_call(
         ...     weights, indices, indptr, B,
         ...     shape=(2, 3), transpose=False)
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     if transpose:
         assert shape[0] == B.shape[0], "Shape mismatch for transpose operation."
     else:

--- a/brainevent/_csr/binary_backend_test.py
+++ b/brainevent/_csr/binary_backend_test.py
@@ -1,0 +1,24 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from brainevent._csr.binary import binary_csrmv_p
+
+
+def test_binary_csrmv_gpu_cusparse_backend_names():
+    backends = binary_csrmv_p.available_backends('gpu')
+
+    assert 'BCOO_cusparse' in backends
+    assert 'JAX_cusparse' in backends
+    assert 'cusparse' not in backends

--- a/brainevent/_csr/binary_csrmm.cu
+++ b/brainevent/_csr/binary_csrmm.cu
@@ -55,10 +55,11 @@
 
 #define DEFINE_CSRMM_NT_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                    READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                      \
     const int32_t*  __restrict__ indices,                                      \
-    const int32_t*  __restrict__ indptr,                                       \
+    const IndptrT*  __restrict__ indptr,                                       \
     const SPIKE_T*  __restrict__ B,                                            \
     WEIGHT_T*       __restrict__ C,                                            \
     int m, int n                                                               \
@@ -73,9 +74,9 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                              \
     for (int base = blockIdx.x * rpb; base < m; base += gridDim.x * rpb) {    \
         int row = base + warp_id;                                              \
         if (row >= m) continue;                                                \
-        int start = indptr[row], end = indptr[row + 1];                        \
+        IndptrT start = indptr[row], end = indptr[row + 1];                        \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                \
-        int j = start;                                                         \
+        IndptrT j = start;                                                         \
         _Pragma("unroll 4")                                                    \
         for (; j + 1 < end; j += 2) {                                          \
             ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);           \
@@ -93,10 +94,11 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                              \
 
 #define DEFINE_CSRMM_NT_BLOCK_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                     READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                       \
     const int32_t*  __restrict__ indices,                                       \
-    const int32_t*  __restrict__ indptr,                                        \
+    const IndptrT*  __restrict__ indptr,                                        \
     const SPIKE_T*  __restrict__ B,                                             \
     WEIGHT_T*       __restrict__ C,                                             \
     int m, int n                                                                \
@@ -108,11 +110,11 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              
     int strip     = threadIdx.x >> 5;                                           \
     int c         = col_start + lane;                                           \
     for (int row = blockIdx.x; row < m; row += gridDim.x) {                    \
-        int start = indptr[row], end = indptr[row + 1];                        \
+        IndptrT start = indptr[row], end = indptr[row + 1];                        \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                \
         if (c < n) {                                                            \
             ACC_T w = READ_W(weights[0]);                                      \
-            int j = start + strip;                                              \
+            IndptrT j = start + strip;                                              \
             _Pragma("unroll 4")                                                \
             for (; j + 8 < end; j += 16) {                                     \
                 ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);       \
@@ -139,10 +141,11 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              
 
 #define DEFINE_CSRMM_T_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                   READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                     \
     const int32_t*  __restrict__ indices,                                     \
-    const int32_t*  __restrict__ indptr,                                      \
+    const IndptrT*  __restrict__ indptr,                                      \
     const SPIKE_T*  __restrict__ B,                                           \
     WEIGHT_T*       __restrict__ C,                                           \
     int m, int n                                                              \
@@ -152,9 +155,9 @@ __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                              \
     int c         = col_start + (int)threadIdx.x;                             \
     if (row >= m || c >= n) return;                                           \
     if (!IS_ACTIVE(B[row * n + c])) return;                                  \
-    int start = indptr[row], end = indptr[row + 1];                          \
+    IndptrT start = indptr[row], end = indptr[row + 1];                          \
     WEIGHT_T w_out = weights[0];                                              \
-    for (int j = start; j < end; j++) {                                       \
+    for (IndptrT j = start; j < end; j++) {                                       \
         atomicAdd(&C[indices[j] * n + c], w_out);                            \
     }                                                                         \
 }
@@ -165,10 +168,11 @@ __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                              \
 
 #define DEFINE_CSRMM_NT_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                      READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_warp_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                        \
     const int32_t*  __restrict__ indices,                                        \
-    const int32_t*  __restrict__ indptr,                                         \
+    const IndptrT*  __restrict__ indptr,                                         \
     const SPIKE_T*  __restrict__ B,                                              \
     WEIGHT_T*       __restrict__ C,                                              \
     int m, int n                                                                 \
@@ -182,9 +186,9 @@ __global__ void _csrmm_nt_warp_hetero_kern##SUFFIX(                             
     for (int base = blockIdx.x * rpb; base < m; base += gridDim.x * rpb) {      \
         int row = base + warp_id;                                                \
         if (row >= m) continue;                                                  \
-        int start = indptr[row], end = indptr[row + 1];                          \
+        IndptrT start = indptr[row], end = indptr[row + 1];                          \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                  \
-        int j = start;                                                           \
+        IndptrT j = start;                                                           \
         _Pragma("unroll 4")                                                      \
         for (; j + 1 < end; j += 2) {                                            \
             ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);             \
@@ -202,10 +206,11 @@ __global__ void _csrmm_nt_warp_hetero_kern##SUFFIX(                             
 
 #define DEFINE_CSRMM_NT_BLOCK_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                       READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                         \
     const int32_t*  __restrict__ indices,                                         \
-    const int32_t*  __restrict__ indptr,                                          \
+    const IndptrT*  __restrict__ indptr,                                          \
     const SPIKE_T*  __restrict__ B,                                               \
     WEIGHT_T*       __restrict__ C,                                               \
     int m, int n                                                                  \
@@ -217,10 +222,10 @@ __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                            
     int strip     = threadIdx.x >> 5;                                             \
     int c         = col_start + lane;                                             \
     for (int row = blockIdx.x; row < m; row += gridDim.x) {                      \
-        int start = indptr[row], end = indptr[row + 1];                          \
+        IndptrT start = indptr[row], end = indptr[row + 1];                          \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                  \
         if (c < n) {                                                              \
-            int j = start + strip;                                                \
+            IndptrT j = start + strip;                                                \
             _Pragma("unroll 4")                                                  \
             for (; j + 8 < end; j += 16) {                                       \
                 ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);         \
@@ -247,10 +252,11 @@ __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                            
 
 #define DEFINE_CSRMM_T_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                     READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_t_warp_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                       \
     const int32_t*  __restrict__ indices,                                       \
-    const int32_t*  __restrict__ indptr,                                        \
+    const IndptrT*  __restrict__ indptr,                                        \
     const SPIKE_T*  __restrict__ B,                                             \
     WEIGHT_T*       __restrict__ C,                                             \
     int m, int n                                                                \
@@ -260,8 +266,8 @@ __global__ void _csrmm_t_warp_hetero_kern##SUFFIX(                              
     int c         = col_start + (int)threadIdx.x;                               \
     if (row >= m || c >= n) return;                                             \
     if (!IS_ACTIVE(B[row * n + c])) return;                                    \
-    int start = indptr[row], end = indptr[row + 1];                            \
-    for (int j = start; j < end; j++) {                                         \
+    IndptrT start = indptr[row], end = indptr[row + 1];                            \
+    for (IndptrT j = start; j < end; j++) {                                         \
         atomicAdd(&C[indices[j] * n + c], weights[j]);                         \
     }                                                                           \
 }
@@ -396,6 +402,7 @@ void binary_csrmm_nt_warp_homo##SUFFIX(                                    \
     const BE::Tensor indptr,  const BE::Tensor B,                          \
     BE::Tensor C,       int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -405,13 +412,15 @@ void binary_csrmm_nt_warp_homo##SUFFIX(                                    \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                    \
     if (gx < 1) gx = 1;                                                   \
     dim3 grid(gx, c_blocks);                                               \
-    _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(           \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                            \
-        m, n);                                                             \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(       \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                        \
+            m, n);                                                         \
+    });                                                                    \
 }
 
 #define FFI_CSRMM_NT_BLOCK_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE)  \
@@ -420,6 +429,7 @@ void binary_csrmm_nt_block_homo##SUFFIX(                                   \
     const BE::Tensor indptr,  const BE::Tensor B,                          \
     BE::Tensor C,       int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -428,13 +438,15 @@ void binary_csrmm_nt_block_homo##SUFFIX(                                   \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                    \
     if (gx < 1) gx = 1;                                                   \
     dim3 grid(gx, c_blocks);                                               \
-    _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                            \
-        m, n);                                                             \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                        \
+            m, n);                                                         \
+    });                                                                    \
 }
 
 #define FFI_CSRMM_NT_AUTO_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE)         \
@@ -443,6 +455,7 @@ void binary_csrmm_nt_auto_homo##SUFFIX(                                         
     const BE::Tensor indptr,  const BE::Tensor B,                               \
     BE::Tensor C,       int64_t stream                                          \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);                  \
     int m        = static_cast<int>(indptr.size(0)) - 1;                        \
     int n        = static_cast<int>(B.size(1));                                 \
@@ -451,25 +464,27 @@ void binary_csrmm_nt_auto_homo##SUFFIX(                                         
     int c_blocks = (n + 31) / 32;                                               \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const SPIKE_C_T*  d_b = static_cast<const SPIKE_C_T*>(B.data_ptr());        \
     WEIGHT_C_T*       d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    if (avg_nnz <= 512) {                                                       \
-        int rpb = CSRMM_WARP_RPB;                                               \
-        int gx  = (m + rpb - 1) / rpb;                                          \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(             \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    } else {                                                                    \
-        int gx = m;                                                             \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(          \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 512) {                                                   \
+            int rpb = CSRMM_WARP_RPB;                                           \
+            int gx  = (m + rpb - 1) / rpb;                                      \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(         \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        } else {                                                                \
+            int gx = m;                                                         \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(      \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMM_T_WARP_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)              \
@@ -478,6 +493,7 @@ void binary_csrmm_t_warp_homo##SUFFIX(                                     \
     const BE::Tensor indptr,  const BE::Tensor B,                          \
     BE::Tensor C,       int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -486,12 +502,14 @@ void binary_csrmm_t_warp_homo##SUFFIX(                                     \
     dim3 grid(m, c_blocks);                                                \
     WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
     cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(                  \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        d_c, m, n);                                                        \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(              \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            d_c, m, n);                                                    \
+    });                                                                    \
 }
 
 // =========================================================================
@@ -504,6 +522,7 @@ void binary_csrmm_nt_warp_hetero##SUFFIX(                                  \
     const BE::Tensor indptr,  const BE::Tensor B,                          \
     BE::Tensor C,       int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -513,13 +532,15 @@ void binary_csrmm_nt_warp_hetero##SUFFIX(                                  \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                    \
     if (gx < 1) gx = 1;                                                   \
     dim3 grid(gx, c_blocks);                                               \
-    _csrmm_nt_warp_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(         \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                            \
-        m, n);                                                             \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_nt_warp_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(     \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                        \
+            m, n);                                                         \
+    });                                                                    \
 }
 
 #define FFI_CSRMM_NT_BLOCK_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
@@ -528,6 +549,7 @@ void binary_csrmm_nt_block_hetero##SUFFIX(                                  \
     const BE::Tensor indptr,  const BE::Tensor B,                           \
     BE::Tensor C,       int64_t stream                                      \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);              \
     int m        = static_cast<int>(indptr.size(0)) - 1;                    \
     int n        = static_cast<int>(B.size(1));                             \
@@ -536,13 +558,15 @@ void binary_csrmm_nt_block_hetero##SUFFIX(                                  \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                     \
     if (gx < 1) gx = 1;                                                    \
     dim3 grid(gx, c_blocks);                                                \
-    _csrmm_nt_block_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(       \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                 \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                        \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                             \
-        m, n);                                                              \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                      \
+        _csrmm_nt_block_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(   \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),             \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                    \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                         \
+            m, n);                                                          \
+    });                                                                     \
 }
 
 #define FFI_CSRMM_NT_AUTO_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE)       \
@@ -551,6 +575,7 @@ void binary_csrmm_nt_auto_hetero##SUFFIX(                                       
     const BE::Tensor indptr,  const BE::Tensor B,                               \
     BE::Tensor C,       int64_t stream                                          \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);                  \
     int m        = static_cast<int>(indptr.size(0)) - 1;                        \
     int n        = static_cast<int>(B.size(1));                                 \
@@ -559,25 +584,27 @@ void binary_csrmm_nt_auto_hetero##SUFFIX(                                       
     int c_blocks = (n + 31) / 32;                                               \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const SPIKE_C_T*  d_b = static_cast<const SPIKE_C_T*>(B.data_ptr());        \
     WEIGHT_C_T*       d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    if (avg_nnz <= 512) {                                                       \
-        int rpb = CSRMM_WARP_RPB;                                               \
-        int gx  = (m + rpb - 1) / rpb;                                          \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_warp_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(           \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    } else {                                                                    \
-        int gx = m;                                                             \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_block_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(        \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 512) {                                                   \
+            int rpb = CSRMM_WARP_RPB;                                           \
+            int gx  = (m + rpb - 1) / rpb;                                      \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_warp_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(       \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        } else {                                                                \
+            int gx = m;                                                         \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_block_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(    \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMM_T_WARP_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)            \
@@ -586,6 +613,7 @@ void binary_csrmm_t_warp_hetero##SUFFIX(                                   \
     const BE::Tensor indptr,  const BE::Tensor B,                          \
     BE::Tensor C,       int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -594,12 +622,14 @@ void binary_csrmm_t_warp_hetero##SUFFIX(                                   \
     dim3 grid(m, c_blocks);                                                \
     WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
     cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    _csrmm_t_warp_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(                \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        d_c, m, n);                                                        \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_t_warp_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(            \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            d_c, m, n);                                                    \
+    });                                                                    \
 }
 
 // =========================================================================

--- a/brainevent/_csr/binary_csrmv.cu
+++ b/brainevent/_csr/binary_csrmv.cu
@@ -44,22 +44,23 @@
 
 #define DEFINE_CSRMV_NT_THREAD_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                      READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_thread_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                        \
     const int32_t*  __restrict__ indices,                                        \
-    const int32_t*  __restrict__ indptr,                                         \
+    const IndptrT*  __restrict__ indptr,                                         \
     const SPIKE_T*  __restrict__ vector,                                         \
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
 ) {                                                                              \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                             \
     if (row >= m) return;                                                        \
-    int start = indptr[row], end = indptr[row + 1];                              \
+    IndptrT start = indptr[row], end = indptr[row + 1];                              \
     if (start == end) { output[row] = WRITE_W(ACC_ZERO); return; }               \
     ACC_T acc = ACC_ZERO;                                                        \
     ACC_T w = READ_W(weights[0]);                                                \
     _Pragma("unroll 4")                                                          \
-    for (int j = start; j < end; j++) {                                          \
+    for (IndptrT j = start; j < end; j++) {                                          \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                       \
         acc += w * mask;                                                         \
     }                                                                            \
@@ -68,17 +69,18 @@ __global__ void _csrmv_nt_thread_homo_kern##SUFFIX(                             
 
 #define DEFINE_CSRMV_NT_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                    READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_warp_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                      \
     const int32_t*  __restrict__ indices,                                      \
-    const int32_t*  __restrict__ indptr,                                       \
+    const IndptrT*  __restrict__ indptr,                                       \
     const SPIKE_T*  __restrict__ vector,                                       \
     WEIGHT_T*       __restrict__ output,                                       \
     int m                                                                      \
 ) {                                                                            \
     int row = blockIdx.x;                                                      \
     if (row >= m) return;                                                      \
-    int start = indptr[row], end = indptr[row + 1];                            \
+    IndptrT start = indptr[row], end = indptr[row + 1];                            \
     if (start == end) {                                                        \
         if (threadIdx.x == 0) output[row] = WRITE_W(ACC_ZERO);                 \
         return;                                                                \
@@ -86,7 +88,7 @@ __global__ void _csrmv_nt_warp_homo_kern##SUFFIX(                              \
     ACC_T acc = ACC_ZERO;                                                      \
     ACC_T w = READ_W(weights[0]);                                              \
     _Pragma("unroll 2")                                                        \
-    for (int j = start + (int)threadIdx.x; j < end; j += 32) {                 \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                 \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                     \
         acc += w * mask;                                                       \
     }                                                                          \
@@ -96,10 +98,11 @@ __global__ void _csrmv_nt_warp_homo_kern##SUFFIX(                              \
 
 #define DEFINE_CSRMV_NT_BLOCK_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                     READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_block_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                       \
     const int32_t*  __restrict__ indices,                                       \
-    const int32_t*  __restrict__ indptr,                                        \
+    const IndptrT*  __restrict__ indptr,                                        \
     const SPIKE_T*  __restrict__ vector,                                        \
     WEIGHT_T*       __restrict__ output,                                        \
     int m                                                                       \
@@ -108,7 +111,7 @@ __global__ void _csrmv_nt_block_homo_kern##SUFFIX(                              
     ACC_T* smem_red = reinterpret_cast<ACC_T*>(_smem_bytes);                    \
     int row = blockIdx.x;                                                       \
     if (row >= m) return;                                                       \
-    int start = indptr[row], end = indptr[row + 1];                             \
+    IndptrT start = indptr[row], end = indptr[row + 1];                             \
     if (start == end) {                                                         \
         if (threadIdx.x == 0) output[row] = WRITE_W(ACC_ZERO);                  \
         return;                                                                 \
@@ -116,7 +119,7 @@ __global__ void _csrmv_nt_block_homo_kern##SUFFIX(                              
     ACC_T acc = ACC_ZERO;                                                       \
     ACC_T w = READ_W(weights[0]);                                               \
     _Pragma("unroll 2")                                                         \
-    for (int j = start + (int)threadIdx.x; j < end; j += blockDim.x) {          \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += blockDim.x) {          \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                      \
         acc += w * mask;                                                        \
     }                                                                           \
@@ -133,10 +136,11 @@ __global__ void _csrmv_nt_block_homo_kern##SUFFIX(                              
 
 #define DEFINE_CSRMV_T_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                   READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmv_t_warp_homo_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                     \
     const int32_t*  __restrict__ indices,                                     \
-    const int32_t*  __restrict__ indptr,                                      \
+    const IndptrT*  __restrict__ indptr,                                      \
     const SPIKE_T*  __restrict__ vector,                                      \
     WEIGHT_T*       __restrict__ output,                                      \
     int m                                                                     \
@@ -144,11 +148,11 @@ __global__ void _csrmv_t_warp_homo_kern##SUFFIX(                              \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                          \
     if (row >= m) return;                                                     \
     if (!IS_ACTIVE(vector[row])) return;                                      \
-    int start = indptr[row], end = indptr[row + 1];                           \
+    IndptrT start = indptr[row], end = indptr[row + 1];                           \
     if (start == end) return;                                                 \
     ACC_T w = READ_W(weights[0]);                                             \
     WEIGHT_T w_out = WRITE_W(w);                                              \
-    for (int j = start; j < end; j++) {                                       \
+    for (IndptrT j = start; j < end; j++) {                                       \
         atomicAdd(&output[indices[j]], w_out);                                \
     }                                                                         \
 }
@@ -159,21 +163,22 @@ __global__ void _csrmv_t_warp_homo_kern##SUFFIX(                              \
 
 #define DEFINE_CSRMV_NT_THREAD_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                        READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_thread_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                          \
     const int32_t*  __restrict__ indices,                                          \
-    const int32_t*  __restrict__ indptr,                                           \
+    const IndptrT*  __restrict__ indptr,                                           \
     const SPIKE_T*  __restrict__ vector,                                           \
     WEIGHT_T*       __restrict__ output,                                           \
     int m                                                                          \
 ) {                                                                                \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                               \
     if (row >= m) return;                                                          \
-    int start = indptr[row], end = indptr[row + 1];                                \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                \
     if (start == end) { output[row] = WRITE_W(ACC_ZERO); return; }                 \
     ACC_T acc = ACC_ZERO;                                                          \
     _Pragma("unroll 4")                                                            \
-    for (int j = start; j < end; j++) {                                            \
+    for (IndptrT j = start; j < end; j++) {                                            \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                         \
         acc += READ_W(weights[j]) * mask;                                          \
     }                                                                              \
@@ -182,24 +187,25 @@ __global__ void _csrmv_nt_thread_hetero_kern##SUFFIX(                           
 
 #define DEFINE_CSRMV_NT_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                      READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_warp_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                        \
     const int32_t*  __restrict__ indices,                                        \
-    const int32_t*  __restrict__ indptr,                                         \
+    const IndptrT*  __restrict__ indptr,                                         \
     const SPIKE_T*  __restrict__ vector,                                         \
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
 ) {                                                                              \
     int row = blockIdx.x;                                                        \
     if (row >= m) return;                                                        \
-    int start = indptr[row], end = indptr[row + 1];                              \
+    IndptrT start = indptr[row], end = indptr[row + 1];                              \
     if (start == end) {                                                          \
         if (threadIdx.x == 0) output[row] = WRITE_W(ACC_ZERO);                   \
         return;                                                                  \
     }                                                                            \
     ACC_T acc = ACC_ZERO;                                                        \
     _Pragma("unroll 2")                                                          \
-    for (int j = start + (int)threadIdx.x; j < end; j += 32) {                   \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                   \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                       \
         acc += READ_W(weights[j]) * mask;                                        \
     }                                                                            \
@@ -209,10 +215,11 @@ __global__ void _csrmv_nt_warp_hetero_kern##SUFFIX(                             
 
 #define DEFINE_CSRMV_NT_BLOCK_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                       READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_block_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                         \
     const int32_t*  __restrict__ indices,                                         \
-    const int32_t*  __restrict__ indptr,                                          \
+    const IndptrT*  __restrict__ indptr,                                          \
     const SPIKE_T*  __restrict__ vector,                                          \
     WEIGHT_T*       __restrict__ output,                                          \
     int m                                                                         \
@@ -221,14 +228,14 @@ __global__ void _csrmv_nt_block_hetero_kern##SUFFIX(                            
     ACC_T* smem_red = reinterpret_cast<ACC_T*>(_smem_bytes);                      \
     int row = blockIdx.x;                                                         \
     if (row >= m) return;                                                         \
-    int start = indptr[row], end = indptr[row + 1];                               \
+    IndptrT start = indptr[row], end = indptr[row + 1];                               \
     if (start == end) {                                                           \
         if (threadIdx.x == 0) output[row] = WRITE_W(ACC_ZERO);                    \
         return;                                                                   \
     }                                                                             \
     ACC_T acc = ACC_ZERO;                                                         \
     _Pragma("unroll 2")                                                           \
-    for (int j = start + (int)threadIdx.x; j < end; j += blockDim.x) {            \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += blockDim.x) {            \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                        \
         acc += READ_W(weights[j]) * mask;                                         \
     }                                                                             \
@@ -245,10 +252,11 @@ __global__ void _csrmv_nt_block_hetero_kern##SUFFIX(                            
 
 #define DEFINE_CSRMV_T_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                     READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmv_t_warp_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                       \
     const int32_t*  __restrict__ indices,                                       \
-    const int32_t*  __restrict__ indptr,                                        \
+    const IndptrT*  __restrict__ indptr,                                        \
     const SPIKE_T*  __restrict__ vector,                                        \
     WEIGHT_T*       __restrict__ output,                                        \
     int m                                                                       \
@@ -256,9 +264,9 @@ __global__ void _csrmv_t_warp_hetero_kern##SUFFIX(                              
     int row = blockIdx.x * blockDim.x + threadIdx.x;                            \
     if (row >= m) return;                                                       \
     if (!IS_ACTIVE(vector[row])) return;                                        \
-    int start = indptr[row], end = indptr[row + 1];                             \
+    IndptrT start = indptr[row], end = indptr[row + 1];                             \
     if (start == end) return;                                                   \
-    for (int j = start; j < end; j++) {                                         \
+    for (IndptrT j = start; j < end; j++) {                                         \
         atomicAdd(&output[indices[j]], WRITE_W(READ_W(weights[j])));            \
     }                                                                           \
 }
@@ -425,15 +433,18 @@ void binary_csrmv_nt_thread_homo##SUFFIX(                       \
     const BE::Tensor indptr,  const BE::Tensor vector,          \
     BE::Tensor output,  int64_t stream                          \
 ) {                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                        \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);    \
     int m          = static_cast<int>(indptr.size(0)) - 1;      \
     int blocks     = (m + 255) / 256;                           \
-    _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(  \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),     \
-        static_cast<const int32_t*>(indices.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),         \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),       \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);        \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {           \
+        _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()), \
+            static_cast<const int32_t*>(indices.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),     \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),   \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);    \
+    });                                                         \
 }
 
 #define FFI_CSRMV_NT_WARP_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T) \
@@ -442,14 +453,17 @@ void binary_csrmv_nt_warp_homo##SUFFIX(                       \
     const BE::Tensor indptr,  const BE::Tensor vector,        \
     BE::Tensor output,  int64_t stream                        \
 ) {                                                           \
+    BE_CHECK_CSR_INDICES_INT32(indices);                      \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);  \
     int m          = static_cast<int>(indptr.size(0)) - 1;    \
-    _csrmv_nt_warp_homo_kern##SUFFIX<<<m, 32, 0, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
-        static_cast<const int32_t*>(indices.data_ptr()),      \
-        static_cast<const int32_t*>(indptr.data_ptr()),       \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),     \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);      \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {         \
+        _csrmv_nt_warp_homo_kern##SUFFIX<<<m, 32, 0, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()), \
+            static_cast<const int32_t*>(indices.data_ptr()),  \
+            static_cast<const IndptrT*>(indptr.data_ptr()),   \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()), \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);  \
+    });                                                       \
 }
 
 #define FFI_CSRMV_NT_BLOCK_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
@@ -458,14 +472,17 @@ void binary_csrmv_nt_block_homo##SUFFIX(                                 \
     const BE::Tensor indptr,  const BE::Tensor vector,                   \
     BE::Tensor output,  int64_t stream                                   \
 ) {                                                                      \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                 \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);             \
     int m          = static_cast<int>(indptr.size(0)) - 1;               \
-    _csrmv_nt_block_homo_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(          \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),              \
-        static_cast<const int32_t*>(indices.data_ptr()),                 \
-        static_cast<const int32_t*>(indptr.data_ptr()),                  \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);                 \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                   \
+        _csrmv_nt_block_homo_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(      \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),          \
+            static_cast<const int32_t*>(indices.data_ptr()),             \
+            static_cast<const IndptrT*>(indptr.data_ptr()),              \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);             \
+    });                                                                  \
 }
 
 #define FFI_CSRMV_NT_AUTO_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE)         \
@@ -474,23 +491,26 @@ void binary_csrmv_nt_auto_homo##SUFFIX(                                         
     const BE::Tensor indptr,  const BE::Tensor vector,                          \
     BE::Tensor output,  int64_t stream                                          \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);                    \
     int m          = static_cast<int>(indptr.size(0)) - 1;                      \
     int nse        = static_cast<int>(indices.size(0));                         \
     int avg_nnz    = (m > 0) ? (nse / m) : 0;                                   \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const SPIKE_C_T*  d_v = static_cast<const SPIKE_C_T*>(vector.data_ptr());   \
     WEIGHT_C_T*       d_o = static_cast<WEIGHT_C_T*>(output.data_ptr());        \
-    if (avg_nnz <= 512) {                                                       \
-        int blocks = (m + 255) / 256;                                           \
-        _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(              \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    } else {                                                                    \
-        _csrmv_nt_block_homo_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(             \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 512) {                                                   \
+            int blocks = (m + 255) / 256;                                       \
+            _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else {                                                                \
+            _csrmv_nt_block_homo_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(         \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMV_T_WARP_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)         \
@@ -499,18 +519,21 @@ void binary_csrmv_t_warp_homo##SUFFIX(                               \
     const BE::Tensor indptr,  const BE::Tensor vector,               \
     BE::Tensor output,  int64_t stream                               \
 ) {                                                                  \
+    BE_CHECK_CSR_INDICES_INT32(indices);                             \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);      \
     int m             = static_cast<int>(indptr.size(0)) - 1;        \
     int k             = static_cast<int>(output.size(0));            \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
     int blocks = (m + 255) / 256;                                    \
-    _csrmv_t_warp_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),          \
-        static_cast<const int32_t*>(indices.data_ptr()),             \
-        static_cast<const int32_t*>(indptr.data_ptr()),              \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),            \
-        d_out, m);                                                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
+        _csrmv_t_warp_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(      \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
+            static_cast<const int32_t*>(indices.data_ptr()),         \
+            static_cast<const IndptrT*>(indptr.data_ptr()),          \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),        \
+            d_out, m);                                               \
+    });                                                              \
 }
 
 // =========================================================================
@@ -523,15 +546,18 @@ void binary_csrmv_nt_thread_hetero##SUFFIX(                       \
     const BE::Tensor indptr,  const BE::Tensor vector,            \
     BE::Tensor output,  int64_t stream                            \
 ) {                                                               \
+    BE_CHECK_CSR_INDICES_INT32(indices);                          \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);      \
     int m          = static_cast<int>(indptr.size(0)) - 1;        \
     int blocks     = (m + 255) / 256;                             \
-    _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(  \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),       \
-        static_cast<const int32_t*>(indices.data_ptr()),          \
-        static_cast<const int32_t*>(indptr.data_ptr()),           \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),         \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);          \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {             \
+        _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
+            static_cast<const int32_t*>(indices.data_ptr()),      \
+            static_cast<const IndptrT*>(indptr.data_ptr()),       \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),     \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);      \
+    });                                                           \
 }
 
 #define FFI_CSRMV_NT_WARP_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T) \
@@ -540,14 +566,17 @@ void binary_csrmv_nt_warp_hetero##SUFFIX(                       \
     const BE::Tensor indptr,  const BE::Tensor vector,          \
     BE::Tensor output,  int64_t stream                          \
 ) {                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                        \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);    \
     int m          = static_cast<int>(indptr.size(0)) - 1;      \
-    _csrmv_nt_warp_hetero_kern##SUFFIX<<<m, 32, 0, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),     \
-        static_cast<const int32_t*>(indices.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),         \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),       \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);        \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {           \
+        _csrmv_nt_warp_hetero_kern##SUFFIX<<<m, 32, 0, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()), \
+            static_cast<const int32_t*>(indices.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),     \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),   \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);    \
+    });                                                         \
 }
 
 #define FFI_CSRMV_NT_BLOCK_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
@@ -556,14 +585,17 @@ void binary_csrmv_nt_block_hetero##SUFFIX(                                 \
     const BE::Tensor indptr,  const BE::Tensor vector,                     \
     BE::Tensor output,  int64_t stream                                     \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);               \
     int m          = static_cast<int>(indptr.size(0)) - 1;                 \
-    _csrmv_nt_block_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(          \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),                  \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmv_nt_block_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(      \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),              \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);               \
+    });                                                                    \
 }
 
 #define FFI_CSRMV_NT_AUTO_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE)       \
@@ -572,23 +604,26 @@ void binary_csrmv_nt_auto_hetero##SUFFIX(                                       
     const BE::Tensor indptr,  const BE::Tensor vector,                          \
     BE::Tensor output,  int64_t stream                                          \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);                    \
     int m          = static_cast<int>(indptr.size(0)) - 1;                      \
     int nse        = static_cast<int>(indices.size(0));                         \
     int avg_nnz    = (m > 0) ? (nse / m) : 0;                                   \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const SPIKE_C_T*  d_v = static_cast<const SPIKE_C_T*>(vector.data_ptr());   \
     WEIGHT_C_T*       d_o = static_cast<WEIGHT_C_T*>(output.data_ptr());        \
-    if (avg_nnz <= 512) {                                                       \
-        int blocks = (m + 255) / 256;                                           \
-        _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(            \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    } else {                                                                    \
-        _csrmv_nt_block_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(           \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 512) {                                                   \
+            int blocks = (m + 255) / 256;                                       \
+            _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(        \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else {                                                                \
+            _csrmv_nt_block_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(       \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMV_T_WARP_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)       \
@@ -597,18 +632,21 @@ void binary_csrmv_t_warp_hetero##SUFFIX(                             \
     const BE::Tensor indptr,  const BE::Tensor vector,               \
     BE::Tensor output,  int64_t stream                               \
 ) {                                                                  \
+    BE_CHECK_CSR_INDICES_INT32(indices);                             \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);      \
     int m             = static_cast<int>(indptr.size(0)) - 1;        \
     int k             = static_cast<int>(output.size(0));            \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
     int blocks = (m + 255) / 256;                                    \
-    _csrmv_t_warp_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),          \
-        static_cast<const int32_t*>(indices.data_ptr()),             \
-        static_cast<const int32_t*>(indptr.data_ptr()),              \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),            \
-        d_out, m);                                                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
+        _csrmv_t_warp_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
+            static_cast<const int32_t*>(indices.data_ptr()),         \
+            static_cast<const IndptrT*>(indptr.data_ptr()),          \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),        \
+            d_out, m);                                               \
+    });                                                              \
 }
 
 // =========================================================================

--- a/brainevent/_csr/binary_indexed.py
+++ b/brainevent/_csr/binary_indexed.py
@@ -36,7 +36,12 @@ import jax.numpy as jnp
 import numpy as np
 from jax.interpreters import ad
 
-from brainevent._misc import _csr_to_coo, namescope
+from brainevent._misc import (
+    _check_csr_cuda_structure_dtypes,
+    _check_csr_structure_dtypes,
+    _csr_to_coo,
+    namescope,
+)
 from brainevent._op import numba_kernel, XLACustomKernel, general_batching_rule, load_cuda_file
 from brainevent._sddmm import sddmm_coo_indices
 from brainevent._typing import Data, Indptr, Index, MatrixShape
@@ -278,6 +283,7 @@ def _binary_csrmv_indexed_cuda_kernel(
     weights ignore ``perm`` entirely, so they reuse the plain homogeneous kernels
     (called without ``perm``).
     """
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     out_info = kwargs['outs']
     is_homo = (weight_info.size == 1)
 
@@ -354,14 +360,12 @@ def binary_csrmv_indexed_p_call(
     list of jax.Array
         Single-element list with the result vector.
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert perm.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "perm must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
     assert perm.ndim == 1, "perm must be 1D."
     assert perm.shape == indices.shape, "perm must have the same shape as indices."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     if transpose:
         assert shape[0] == vector.shape[0], "Shape mismatch for transpose operation."
     else:
@@ -709,6 +713,7 @@ def _binary_csrmm_indexed_cuda_kernel(
     ``weights[perm[j]]`` and pass ``perm`` as an extra tensor.  Homogeneous
     weights reuse the plain homogeneous kernels (called without ``perm``).
     """
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     out_info = kwargs['outs']
     is_homo = (weight_info.size == 1)
     spk_suffix = '_bool' if vector_info.dtype == jnp.bool_ else '_float'
@@ -764,14 +769,12 @@ def binary_csrmm_indexed_p_call(
     Validates inputs and dispatches ``binary_csrmm_indexed_p``.  See
     :func:`binary_csrmm_indexed` for the math.
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert perm.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "perm must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
     assert perm.ndim == 1, "perm must be 1D."
     assert perm.shape == indices.shape, "perm must have the same shape as indices."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     assert B.ndim == 2, "B must be 2D."
     if transpose:
         assert shape[0] == B.shape[0], "Shape mismatch for transpose operation."

--- a/brainevent/_csr/binary_indexed_csrmm.cu
+++ b/brainevent/_csr/binary_indexed_csrmm.cu
@@ -57,10 +57,11 @@
 
 #define DEFINE_CSRMM_NT_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                           READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_warp_perm_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                            \
     const int32_t*  __restrict__ indices,                                            \
-    const int32_t*  __restrict__ indptr,                                             \
+    const IndptrT*  __restrict__ indptr,                                             \
     const int32_t*  __restrict__ perm,                                               \
     const SPIKE_T*  __restrict__ B,                                                  \
     WEIGHT_T*       __restrict__ C,                                                  \
@@ -75,9 +76,9 @@ __global__ void _csrmm_nt_warp_perm_hetero_kern##SUFFIX(                        
     for (int base = blockIdx.x * rpb; base < m; base += gridDim.x * rpb) {          \
         int row = base + warp_id;                                                    \
         if (row >= m) continue;                                                      \
-        int start = indptr[row], end = indptr[row + 1];                              \
+        IndptrT start = indptr[row], end = indptr[row + 1];                              \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                      \
-        int j = start;                                                               \
+        IndptrT j = start;                                                               \
         _Pragma("unroll 4")                                                          \
         for (; j + 1 < end; j += 2) {                                                \
             ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);                 \
@@ -95,10 +96,11 @@ __global__ void _csrmm_nt_warp_perm_hetero_kern##SUFFIX(                        
 
 #define DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                            READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                             \
     const int32_t*  __restrict__ indices,                                             \
-    const int32_t*  __restrict__ indptr,                                              \
+    const IndptrT*  __restrict__ indptr,                                              \
     const int32_t*  __restrict__ perm,                                                \
     const SPIKE_T*  __restrict__ B,                                                   \
     WEIGHT_T*       __restrict__ C,                                                   \
@@ -111,10 +113,10 @@ __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                       
     int strip     = threadIdx.x >> 5;                                                 \
     int c         = col_start + lane;                                                 \
     for (int row = blockIdx.x; row < m; row += gridDim.x) {                          \
-        int start = indptr[row], end = indptr[row + 1];                              \
+        IndptrT start = indptr[row], end = indptr[row + 1];                              \
         ACC_T acc0 = ACC_ZERO, acc1 = ACC_ZERO;                                      \
         if (c < n) {                                                                  \
-            int j = start + strip;                                                    \
+            IndptrT j = start + strip;                                                    \
             _Pragma("unroll 4")                                                      \
             for (; j + 8 < end; j += 16) {                                           \
                 ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);             \
@@ -141,10 +143,11 @@ __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                       
 
 #define DEFINE_CSRMM_T_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                          READ_W, WRITE_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_t_warp_perm_hetero_kern##SUFFIX(                              \
     const WEIGHT_T* __restrict__ weights,                                           \
     const int32_t*  __restrict__ indices,                                           \
-    const int32_t*  __restrict__ indptr,                                            \
+    const IndptrT*  __restrict__ indptr,                                            \
     const int32_t*  __restrict__ perm,                                              \
     const SPIKE_T*  __restrict__ B,                                                 \
     WEIGHT_T*       __restrict__ C,                                                 \
@@ -155,8 +158,8 @@ __global__ void _csrmm_t_warp_perm_hetero_kern##SUFFIX(                         
     int c         = col_start + (int)threadIdx.x;                                   \
     if (row >= m || c >= n) return;                                                 \
     if (!IS_ACTIVE(B[row * n + c])) return;                                        \
-    int start = indptr[row], end = indptr[row + 1];                                \
-    for (int j = start; j < end; j++) {                                             \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                \
+    for (IndptrT j = start; j < end; j++) {                                             \
         atomicAdd(&C[indices[j] * n + c], weights[perm[j]]);                       \
     }                                                                               \
 }
@@ -231,6 +234,7 @@ void binary_csrmm_nt_warp_perm_hetero##SUFFIX(                             \
     const BE::Tensor indptr,  const BE::Tensor perm,                       \
     const BE::Tensor B,       BE::Tensor C,       int64_t stream           \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -240,14 +244,16 @@ void binary_csrmm_nt_warp_perm_hetero##SUFFIX(                             \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                    \
     if (gx < 1) gx = 1;                                                   \
     dim3 grid(gx, c_blocks);                                               \
-    _csrmm_nt_warp_perm_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(    \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const int32_t*>(perm.data_ptr()),                      \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                            \
-        m, n);                                                             \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_nt_warp_perm_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const int32_t*>(perm.data_ptr()),                  \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                        \
+            m, n);                                                         \
+    });                                                                    \
 }
 
 #define FFI_CSRMM_NT_BLOCK_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
@@ -256,6 +262,7 @@ void binary_csrmm_nt_block_perm_hetero##SUFFIX(                             \
     const BE::Tensor indptr,  const BE::Tensor perm,                        \
     const BE::Tensor B,       BE::Tensor C,       int64_t stream            \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);              \
     int m        = static_cast<int>(indptr.size(0)) - 1;                    \
     int n        = static_cast<int>(B.size(1));                             \
@@ -264,14 +271,16 @@ void binary_csrmm_nt_block_perm_hetero##SUFFIX(                             \
     if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                     \
     if (gx < 1) gx = 1;                                                    \
     dim3 grid(gx, c_blocks);                                                \
-    _csrmm_nt_block_perm_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(  \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                 \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(perm.data_ptr()),                       \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                        \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                             \
-        m, n);                                                              \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                      \
+        _csrmm_nt_block_perm_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),             \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(perm.data_ptr()),                   \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                    \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                         \
+            m, n);                                                          \
+    });                                                                     \
 }
 
 #define FFI_CSRMM_NT_AUTO_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
@@ -280,6 +289,7 @@ void binary_csrmm_nt_auto_perm_hetero##SUFFIX(                                  
     const BE::Tensor indptr,  const BE::Tensor perm,                            \
     const BE::Tensor B,       BE::Tensor C,       int64_t stream                \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);                  \
     int m        = static_cast<int>(indptr.size(0)) - 1;                        \
     int n        = static_cast<int>(B.size(1));                                 \
@@ -288,26 +298,28 @@ void binary_csrmm_nt_auto_perm_hetero##SUFFIX(                                  
     int c_blocks = (n + 31) / 32;                                               \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const int32_t*    d_perm = static_cast<const int32_t*>(perm.data_ptr());    \
     const SPIKE_C_T*  d_b = static_cast<const SPIKE_C_T*>(B.data_ptr());        \
     WEIGHT_C_T*       d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    if (avg_nnz <= 512) {                                                       \
-        int rpb = CSRMM_WARP_RPB;                                               \
-        int gx  = (m + rpb - 1) / rpb;                                          \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_warp_perm_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(      \
-            d_w, d_i, d_p, d_perm, d_b, d_c, m, n);                             \
-    } else {                                                                    \
-        int gx = m;                                                             \
-        if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                      \
-        if (gx < 1) gx = 1;                                                     \
-        dim3 grid(gx, c_blocks);                                                \
-        _csrmm_nt_block_perm_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(   \
-            d_w, d_i, d_p, d_perm, d_b, d_c, m, n);                             \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 512) {                                                   \
+            int rpb = CSRMM_WARP_RPB;                                           \
+            int gx  = (m + rpb - 1) / rpb;                                      \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_warp_perm_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>(  \
+                d_w, d_i, d_p, d_perm, d_b, d_c, m, n);                         \
+        } else {                                                                \
+            int gx = m;                                                         \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                  \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 grid(gx, c_blocks);                                            \
+            _csrmm_nt_block_perm_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>( \
+                d_w, d_i, d_p, d_perm, d_b, d_c, m, n);                         \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMM_T_WARP_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)       \
@@ -316,6 +328,7 @@ void binary_csrmm_t_warp_perm_hetero##SUFFIX(                              \
     const BE::Tensor indptr,  const BE::Tensor perm,                       \
     const BE::Tensor B,       BE::Tensor C,       int64_t stream           \
 ) {                                                                        \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
     cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
     int m        = static_cast<int>(indptr.size(0)) - 1;                   \
     int n        = static_cast<int>(B.size(1));                            \
@@ -324,13 +337,15 @@ void binary_csrmm_t_warp_perm_hetero##SUFFIX(                              \
     dim3 grid(m, c_blocks);                                                \
     WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
     cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    _csrmm_t_warp_perm_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(           \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                \
-        static_cast<const int32_t*>(indices.data_ptr()),                   \
-        static_cast<const int32_t*>(indptr.data_ptr()),                    \
-        static_cast<const int32_t*>(perm.data_ptr()),                      \
-        static_cast<const SPIKE_C_T*>(B.data_ptr()),                       \
-        d_c, m, n);                                                        \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
+        _csrmm_t_warp_perm_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(       \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
+            static_cast<const int32_t*>(indices.data_ptr()),               \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                \
+            static_cast<const int32_t*>(perm.data_ptr()),                  \
+            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
+            d_c, m, n);                                                    \
+    });                                                                    \
 }
 
 // =========================================================================

--- a/brainevent/_csr/binary_indexed_csrmv.cu
+++ b/brainevent/_csr/binary_indexed_csrmv.cu
@@ -48,10 +48,11 @@
 
 #define DEFINE_CSRMV_NT_THREAD_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                             READ_W, WRITE_W, ACC_ZERO)                   \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_thread_perm_hetero_kern##SUFFIX(                               \
     const WEIGHT_T* __restrict__ weights,                                               \
     const int32_t*  __restrict__ indices,                                               \
-    const int32_t*  __restrict__ indptr,                                                \
+    const IndptrT*  __restrict__ indptr,                                                \
     const int32_t*  __restrict__ perm,                                                  \
     const SPIKE_T*  __restrict__ vector,                                                \
     WEIGHT_T*       __restrict__ output,                                                \
@@ -59,11 +60,11 @@ __global__ void _csrmv_nt_thread_perm_hetero_kern##SUFFIX(                      
 ) {                                                                                     \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                                    \
     if (row >= m) return;                                                               \
-    int start = indptr[row], end = indptr[row + 1];                                     \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                     \
     if (start == end) { output[row] = WRITE_W(ACC_ZERO); return; }                      \
     ACC_T acc = ACC_ZERO;                                                               \
     _Pragma("unroll 4")                                                                 \
-    for (int j = start; j < end; j++) {                                                 \
+    for (IndptrT j = start; j < end; j++) {                                                 \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                              \
         acc += READ_W(weights[perm[j]]) * mask;                                         \
     }                                                                                   \
@@ -72,10 +73,11 @@ __global__ void _csrmv_nt_thread_perm_hetero_kern##SUFFIX(                      
 
 #define DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                            READ_W, WRITE_W, WARP_RED, ACC_ZERO)         \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_block_perm_hetero_kern##SUFFIX(                               \
     const WEIGHT_T* __restrict__ weights,                                              \
     const int32_t*  __restrict__ indices,                                              \
-    const int32_t*  __restrict__ indptr,                                               \
+    const IndptrT*  __restrict__ indptr,                                               \
     const int32_t*  __restrict__ perm,                                                 \
     const SPIKE_T*  __restrict__ vector,                                               \
     WEIGHT_T*       __restrict__ output,                                               \
@@ -85,14 +87,14 @@ __global__ void _csrmv_nt_block_perm_hetero_kern##SUFFIX(                       
     ACC_T* smem_red = reinterpret_cast<ACC_T*>(_smem_bytes);                           \
     int row = blockIdx.x;                                                              \
     if (row >= m) return;                                                              \
-    int start = indptr[row], end = indptr[row + 1];                                    \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                    \
     if (start == end) {                                                                \
         if (threadIdx.x == 0) output[row] = WRITE_W(ACC_ZERO);                         \
         return;                                                                        \
     }                                                                                  \
     ACC_T acc = ACC_ZERO;                                                              \
     _Pragma("unroll 2")                                                                \
-    for (int j = start + (int)threadIdx.x; j < end; j += blockDim.x) {                 \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += blockDim.x) {                 \
         ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                             \
         acc += READ_W(weights[perm[j]]) * mask;                                        \
     }                                                                                  \
@@ -109,10 +111,11 @@ __global__ void _csrmv_nt_block_perm_hetero_kern##SUFFIX(                       
 
 #define DEFINE_CSRMV_T_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                          READ_W, WRITE_W, ACC_ZERO)                   \
+template <typename IndptrT> \
 __global__ void _csrmv_t_warp_perm_hetero_kern##SUFFIX(                               \
     const WEIGHT_T* __restrict__ weights,                                            \
     const int32_t*  __restrict__ indices,                                            \
-    const int32_t*  __restrict__ indptr,                                             \
+    const IndptrT*  __restrict__ indptr,                                             \
     const int32_t*  __restrict__ perm,                                               \
     const SPIKE_T*  __restrict__ vector,                                             \
     WEIGHT_T*       __restrict__ output,                                             \
@@ -121,9 +124,9 @@ __global__ void _csrmv_t_warp_perm_hetero_kern##SUFFIX(                         
     int row = blockIdx.x * blockDim.x + threadIdx.x;                                 \
     if (row >= m) return;                                                            \
     if (!IS_ACTIVE(vector[row])) return;                                             \
-    int start = indptr[row], end = indptr[row + 1];                                  \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                  \
     if (start == end) return;                                                        \
-    for (int j = start; j < end; j++) {                                              \
+    for (IndptrT j = start; j < end; j++) {                                              \
         atomicAdd(&output[indices[j]], WRITE_W(READ_W(weights[perm[j]])));           \
     }                                                                                \
 }
@@ -194,24 +197,27 @@ void binary_csrmv_nt_auto_perm_hetero##SUFFIX(                                  
     const BE::Tensor indptr,  const BE::Tensor perm,                                \
     const BE::Tensor vector,  BE::Tensor output,  int64_t stream                    \
 ) {                                                                                  \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                             \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);                        \
     int m          = static_cast<int>(indptr.size(0)) - 1;                          \
     int nse        = static_cast<int>(indices.size(0));                             \
     int avg_nnz    = (m > 0) ? (nse / m) : 0;                                       \
     const WEIGHT_C_T* d_w    = static_cast<const WEIGHT_C_T*>(weights.data_ptr());  \
     const int32_t*    d_i    = static_cast<const int32_t*>(indices.data_ptr());     \
-    const int32_t*    d_p    = static_cast<const int32_t*>(indptr.data_ptr());      \
     const int32_t*    d_perm = static_cast<const int32_t*>(perm.data_ptr());        \
     const SPIKE_C_T*  d_v    = static_cast<const SPIKE_C_T*>(vector.data_ptr());    \
     WEIGHT_C_T*       d_o    = static_cast<WEIGHT_C_T*>(output.data_ptr());         \
-    if (avg_nnz <= 512) {                                                           \
-        int blocks = (m + 255) / 256;                                              \
-        _csrmv_nt_thread_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(           \
-            d_w, d_i, d_p, d_perm, d_v, d_o, m);                                    \
-    } else {                                                                        \
-        _csrmv_nt_block_perm_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(          \
-            d_w, d_i, d_p, d_perm, d_v, d_o, m);                                    \
-    }                                                                               \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                               \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());        \
+        if (avg_nnz <= 512) {                                                       \
+            int blocks = (m + 255) / 256;                                          \
+            _csrmv_nt_thread_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(       \
+                d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
+        } else {                                                                    \
+            _csrmv_nt_block_perm_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(      \
+                d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
+        }                                                                           \
+    });                                                                             \
 }
 
 #define FFI_CSRMV_T_WARP_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)  \
@@ -220,19 +226,22 @@ void binary_csrmv_t_warp_perm_hetero##SUFFIX(                        \
     const BE::Tensor indptr,  const BE::Tensor perm,                \
     const BE::Tensor vector,  BE::Tensor output,  int64_t stream    \
 ) {                                                                 \
+    BE_CHECK_CSR_INDICES_INT32(indices);                            \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);     \
     int m             = static_cast<int>(indptr.size(0)) - 1;       \
     int k             = static_cast<int>(output.size(0));           \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr());\
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);   \
     int blocks = (m + 255) / 256;                                   \
-    _csrmv_t_warp_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(  \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),         \
-        static_cast<const int32_t*>(indices.data_ptr()),            \
-        static_cast<const int32_t*>(indptr.data_ptr()),             \
-        static_cast<const int32_t*>(perm.data_ptr()),               \
-        static_cast<const SPIKE_C_T*>(vector.data_ptr()),           \
-        d_out, m);                                                  \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {               \
+        _csrmv_t_warp_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),     \
+            static_cast<const int32_t*>(indices.data_ptr()),        \
+            static_cast<const IndptrT*>(indptr.data_ptr()),         \
+            static_cast<const int32_t*>(perm.data_ptr()),           \
+            static_cast<const SPIKE_C_T*>(vector.data_ptr()),       \
+            d_out, m);                                              \
+    });                                                             \
 }
 
 // float32 perm heterogeneous

--- a/brainevent/_csr/binary_indexed_test.py
+++ b/brainevent/_csr/binary_indexed_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from contextlib import contextmanager
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -24,6 +26,16 @@ from brainevent._csr.binary_indexed import (
     binary_csrmv_indexed_p_call,
     binary_csrmm_indexed,
 )
+
+
+@contextmanager
+def _jax_x64_enabled():
+    old_x64 = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", old_x64)
 
 
 def _structure(rng, m, k, nse):
@@ -38,6 +50,64 @@ def _structure(rng, m, k, nse):
     indptr = np.concatenate([[0], np.cumsum(rows)]).astype(np.int32)
     perm = rng.permutation(nse).astype(np.int32)
     return jnp.asarray(indices), jnp.asarray(indptr), jnp.asarray(perm)
+
+
+def test_indexed_mv_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([10.0, 20.0, 30.0, 40.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        perm = jnp.array([2, 0, 3, 1], dtype=jnp.int32)
+        events = jnp.array([True, False, True])
+
+        got = binary_csrmv_indexed(
+            weights, indices, indptr, perm, events, shape=(2, 3), backend='jax_raw'
+        )
+
+        assert jnp.allclose(got, jnp.array([40.0, 20.0], dtype=jnp.float32))
+
+
+def test_indexed_mv_rejects_int64_indices_with_int32_indptr():
+    with _jax_x64_enabled():
+        weights = jnp.ones(2, dtype=jnp.float32)
+        indices = jnp.array([0, 1], dtype=jnp.int64)
+        indptr = jnp.array([0, 2], dtype=jnp.int32)
+        perm = jnp.array([0, 1], dtype=jnp.int32)
+        events = jnp.ones(2, dtype=bool)
+
+        with pytest.raises(AssertionError, match="same dtype"):
+            binary_csrmv_indexed(
+                weights, indices, indptr, perm, events, shape=(1, 2), backend='jax_raw'
+            )
+
+
+def test_indexed_mm_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([10.0, 20.0, 30.0, 40.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        perm = jnp.array([2, 0, 3, 1], dtype=jnp.int32)
+        events = jnp.array([[True, False], [False, True], [True, True]])
+
+        got = binary_csrmm_indexed(
+            weights, indices, indptr, perm, events, shape=(2, 3), backend='jax_raw'
+        )
+        expected = jnp.array([[40.0, 10.0], [20.0, 60.0]], dtype=jnp.float32)
+
+        assert jnp.allclose(got, expected)
+
+
+def test_indexed_mm_rejects_unsigned_structure_dtype():
+    weights = jnp.ones(2, dtype=jnp.float32)
+    indices = jnp.array([0, 1], dtype=jnp.uint32)
+    indptr = jnp.array([0, 2], dtype=jnp.uint32)
+    perm = jnp.array([0, 1], dtype=jnp.int32)
+    events = jnp.ones((2, 1), dtype=bool)
+
+    with pytest.raises(AssertionError, match="signed int32 or int64"):
+        binary_csrmm_indexed(
+            weights, indices, indptr, perm, events, shape=(1, 2), backend='jax_raw'
+        )
 
 
 @pytest.mark.parametrize("transpose", [True, False])

--- a/brainevent/_csr/binary_test.py
+++ b/brainevent/_csr/binary_test.py
@@ -23,7 +23,13 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from brainevent._csr.binary import binary_csrmv, binary_csrmv_p, binary_csrmm, binary_csrmm_p
+from brainevent._csr.binary import (
+    _binary_csrmv_jax_exp_csrmv_kernel,
+    binary_csrmv,
+    binary_csrmv_p,
+    binary_csrmm,
+    binary_csrmm_p,
+)
 from brainevent._csr.test_util import get_csr, vector_csr, matrix_csr, csr_vector, csr_matrix
 
 # Every test loops over all native backends (incl. ``numba``), which compile per test and
@@ -95,6 +101,48 @@ def test_binary_csrmm_rejects_unsigned_structure_dtype():
 
     with pytest.raises(AssertionError, match="signed int32 or int64"):
         binary_csrmm(weights, indices, indptr, events, shape=(1, 2), backend='jax_raw')
+
+
+def test_binary_csrmv_jax_csr_kernel_homo_bool_casts_indices_to_indptr_dtype():
+    with _jax_x64_enabled():
+        kernel = _binary_csrmv_jax_exp_csrmv_kernel(
+            jax.ShapeDtypeStruct((1,), jnp.float32),
+            jax.ShapeDtypeStruct((3,), jnp.bool_),
+            (2, 3),
+            False,
+            indices_info=jax.ShapeDtypeStruct((4,), jnp.int32),
+            outs=[jax.ShapeDtypeStruct((2,), jnp.float32)],
+        )
+
+        got = kernel(
+            jnp.array([2.0], dtype=jnp.float32),
+            jnp.array([0, 2, 1, 2], dtype=jnp.int32),
+            jnp.array([0, 2, 4], dtype=jnp.int64),
+            jnp.array([True, False, True]),
+        )[0]
+
+        assert jnp.allclose(got, jnp.array([4.0, 2.0], dtype=jnp.float32))
+
+
+def test_binary_csrmv_jax_csr_kernel_hetero_float_transpose():
+    with _jax_x64_enabled():
+        kernel = _binary_csrmv_jax_exp_csrmv_kernel(
+            jax.ShapeDtypeStruct((4,), jnp.float32),
+            jax.ShapeDtypeStruct((2,), jnp.float32),
+            (2, 3),
+            True,
+            indices_info=jax.ShapeDtypeStruct((4,), jnp.int32),
+            outs=[jax.ShapeDtypeStruct((3,), jnp.float32)],
+        )
+
+        got = kernel(
+            jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32),
+            jnp.array([0, 2, 1, 2], dtype=jnp.int32),
+            jnp.array([0, 2, 4], dtype=jnp.int64),
+            jnp.array([1.0, -1.0], dtype=jnp.float32),
+        )[0]
+
+        assert jnp.allclose(got, jnp.array([1.0, 0.0, 2.0], dtype=jnp.float32))
 
 
 def _vector_csr_api(x, data, indices, indptr, shape, implementation):

--- a/brainevent/_csr/binary_test.py
+++ b/brainevent/_csr/binary_test.py
@@ -15,6 +15,8 @@
 # -*- coding: utf-8 -*-
 
 
+from contextlib import contextmanager
+
 import brainstate
 import braintools
 import jax
@@ -34,9 +36,65 @@ CSRMV_IMPLEMENTATIONS = tuple(binary_csrmv_p.available_backends(platform))
 CSRMM_IMPLEMENTATIONS = tuple(binary_csrmm_p.available_backends(platform))
 
 
+@contextmanager
+def _jax_x64_enabled():
+    old_x64 = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", old_x64)
+
+
 def _require_implementations(implementations, op_name: str):
     if not implementations:
         pytest.skip(f'No {op_name} implementation on platform={platform}')
+
+
+def test_binary_csrmv_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        events = jnp.array([True, False, True])
+
+        got = binary_csrmv(weights, indices, indptr, events, shape=(2, 3), backend='jax_raw')
+
+        assert jnp.allclose(got, jnp.array([3.0, 4.0], dtype=jnp.float32))
+
+
+def test_binary_csrmv_rejects_int64_indices_with_int32_indptr():
+    with _jax_x64_enabled():
+        weights = jnp.ones(2, dtype=jnp.float32)
+        indices = jnp.array([0, 1], dtype=jnp.int64)
+        indptr = jnp.array([0, 2], dtype=jnp.int32)
+        events = jnp.ones(2, dtype=bool)
+
+        with pytest.raises(AssertionError, match="same dtype"):
+            binary_csrmv(weights, indices, indptr, events, shape=(1, 2), backend='jax_raw')
+
+
+def test_binary_csrmm_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        events = jnp.array([[True, False], [False, True], [True, True]])
+
+        got = binary_csrmm(weights, indices, indptr, events, shape=(2, 3), backend='jax_raw')
+        expected = jnp.array([[3.0, 2.0], [4.0, 7.0]], dtype=jnp.float32)
+
+        assert jnp.allclose(got, expected)
+
+
+def test_binary_csrmm_rejects_unsigned_structure_dtype():
+    weights = jnp.ones(2, dtype=jnp.float32)
+    indices = jnp.array([0, 1], dtype=jnp.uint32)
+    indptr = jnp.array([0, 2], dtype=jnp.uint32)
+    events = jnp.ones((2, 1), dtype=bool)
+
+    with pytest.raises(AssertionError, match="signed int32 or int64"):
+        binary_csrmm(weights, indices, indptr, events, shape=(1, 2), backend='jax_raw')
 
 
 def _vector_csr_api(x, data, indices, indptr, shape, implementation):

--- a/brainevent/_csr/csr_to_csc.cu
+++ b/brainevent/_csr/csr_to_csc.cu
@@ -1,0 +1,199 @@
+// Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+/*
+ * csr_to_csc.cu -- Column-block CSR to CSC construction kernels
+ * =============================================================================
+ *
+ * This file provides CUDA-side primitives for streaming a CSR matrix into CSC
+ * column blocks.  The caller owns CPU/GPU orchestration: run a global count,
+ * prefix-sum counts into CSC starts, initialize each block's next_pos, run fill,
+ * copy the block back to host, then append it to the final CSC arrays.
+ *
+ * Column order inside a block is grouped by column through atomic positions, but
+ * row order inside each column is intentionally not stable.
+ */
+
+#include "cuda_common.h"
+#include "brainevent/common.h"
+
+namespace
+{
+
+    constexpr int kThreadsPerBlock = 256;
+    constexpr int kWarpSize = 32;
+    constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
+
+    template <typename OffsetT>
+    __device__ __forceinline__ OffsetT atomic_add_offset(OffsetT *addr, OffsetT val);
+
+    template <>
+    __device__ __forceinline__ int32_t atomic_add_offset<int32_t>(
+        int32_t *addr,
+        int32_t val)
+    {
+        return atomicAdd(addr, val);
+    }
+
+    template <>
+    __device__ __forceinline__ int64_t atomic_add_offset<int64_t>(
+        int64_t *addr,
+        int64_t val)
+    {
+        return static_cast<int64_t>(
+            atomicAdd(
+                reinterpret_cast<unsigned long long int *>(addr),
+                static_cast<unsigned long long int>(val)));
+    }
+
+    template <typename IndexT, typename OffsetT>
+    __global__ void _csr_to_csc_count_warp_kern(
+        const IndexT *__restrict__ indices,
+        const OffsetT *__restrict__ indptr,
+        OffsetT *__restrict__ counts,
+        int64_t n_rows)
+    {
+        int warp_in_block = threadIdx.x / kWarpSize;
+        int lane = threadIdx.x & (kWarpSize - 1);
+        int64_t row = static_cast<int64_t>(blockIdx.x) * kWarpsPerBlock + warp_in_block;
+        if (row >= n_rows)
+            return;
+
+        OffsetT start = indptr[row];
+        OffsetT end = indptr[row + 1];
+        for (OffsetT j = start + static_cast<OffsetT>(lane); j < end; j += kWarpSize)
+        {
+            IndexT col = indices[j];
+            atomic_add_offset(counts + col, static_cast<OffsetT>(1));
+        }
+    }
+
+    template <typename IndexT, typename OffsetT>
+    __global__ void _csr_to_csc_fill_block_thread_kern(
+        const IndexT *__restrict__ indices,
+        const OffsetT *__restrict__ indptr,
+        OffsetT *__restrict__ next_pos,
+        IndexT *__restrict__ local_rows,
+        OffsetT *__restrict__ local_perm,
+        int64_t n_rows,
+        IndexT col_start,
+        IndexT col_end)
+    {
+        int64_t row = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+        if (row >= n_rows)
+            return;
+
+        OffsetT start = indptr[row];
+        OffsetT end = indptr[row + 1];
+        for (OffsetT j = start; j < end; ++j)
+        {
+            IndexT col = indices[j];
+            if (col >= col_start && col < col_end)
+            {
+                IndexT local_col = col - col_start;
+                OffsetT dst = atomic_add_offset(next_pos + local_col, static_cast<OffsetT>(1));
+                local_rows[dst] = static_cast<IndexT>(row);
+                local_perm[dst] = j;
+            }
+        }
+    }
+
+    inline int64_t csr_num_rows(const BE::Tensor &indptr)
+    {
+        return indptr.shape(0) - 1;
+    }
+
+    inline int launch_blocks(int64_t n_rows)
+    {
+        return static_cast<int>((n_rows + kThreadsPerBlock - 1) / kThreadsPerBlock);
+    }
+
+    inline int launch_warp_row_blocks(int64_t n_rows)
+    {
+        return static_cast<int>((n_rows + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    }
+
+} // namespace
+
+// @BE csr_to_csc_count arg arg ret stream
+void csr_to_csc_count(
+    const BE::Tensor indices,
+    const BE::Tensor indptr,
+    BE::Tensor counts,
+    int64_t stream)
+{
+    int64_t n_rows = csr_num_rows(indptr);
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    BE_DISPATCH_SIGNED_INDEX_PAIR(indices.dtype(), indptr.dtype(), IndexT, OffsetT, {
+        cudaMemsetAsync(
+            counts.data_ptr(),
+            0,
+            static_cast<size_t>(counts.numel()) * sizeof(OffsetT),
+            s);
+
+        if (n_rows <= 0)
+            return;
+
+        _csr_to_csc_count_warp_kern<IndexT, OffsetT>
+            <<<launch_warp_row_blocks(n_rows), kThreadsPerBlock, 0, s>>>(
+                static_cast<const IndexT *>(indices.data_ptr()),
+                static_cast<const OffsetT *>(indptr.data_ptr()),
+                static_cast<OffsetT *>(counts.data_ptr()),
+                n_rows);
+    });
+}
+
+// @BE csr_to_csc_fill_block arg arg arg ret ret ret attr.col_start:int64 attr.col_end:int64 stream
+void csr_to_csc_fill_block(
+    const BE::Tensor indices,
+    const BE::Tensor indptr,
+    const BE::Tensor initial_pos,
+    BE::Tensor scratch_pos,
+    BE::Tensor local_rows,
+    BE::Tensor local_perm,
+    int64_t col_start,
+    int64_t col_end,
+    int64_t stream)
+{
+    if (col_end <= col_start)
+        return;
+
+    int64_t n_rows = csr_num_rows(indptr);
+    if (n_rows <= 0)
+        return;
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    BE_DISPATCH_SIGNED_INDEX_PAIR(indices.dtype(), indptr.dtype(), IndexT, OffsetT, {
+        cudaMemcpyAsync(
+            scratch_pos.data_ptr(),
+            initial_pos.data_ptr(),
+            static_cast<size_t>(scratch_pos.numel()) * sizeof(OffsetT),
+            cudaMemcpyDeviceToDevice,
+            s);
+
+        _csr_to_csc_fill_block_thread_kern<IndexT, OffsetT>
+            <<<launch_blocks(n_rows), kThreadsPerBlock, 0, s>>>(
+                static_cast<const IndexT *>(indices.data_ptr()),
+                static_cast<const OffsetT *>(indptr.data_ptr()),
+                static_cast<OffsetT *>(scratch_pos.data_ptr()),
+                static_cast<IndexT *>(local_rows.data_ptr()),
+                static_cast<OffsetT *>(local_perm.data_ptr()),
+                n_rows,
+                static_cast<IndexT>(col_start),
+                static_cast<IndexT>(col_end));
+    });
+}

--- a/brainevent/_csr/cuda_int64_indptr_test.py
+++ b/brainevent/_csr/cuda_int64_indptr_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+from contextlib import contextmanager
 from pathlib import Path
 
 import jax
@@ -50,6 +51,16 @@ def _shape(dtype, shape=(2,)):
     return jax.ShapeDtypeStruct(shape, dtype)
 
 
+@contextmanager
+def _jax_x64_enabled():
+    old_x64 = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", old_x64)
+
+
 def _cuda_kwargs(indices_dtype=jnp.int64, indptr_dtype=jnp.int64, nse=2):
     return {
         'outs': [_shape(jnp.float32)],
@@ -57,6 +68,19 @@ def _cuda_kwargs(indices_dtype=jnp.int64, indptr_dtype=jnp.int64, nse=2):
         'indices_info': _shape(indices_dtype, (nse,)),
         'indptr_info': _shape(indptr_dtype, (2,)),
     }
+
+
+def _recording_ffi_call(calls):
+    def ffi_call(name, out_info, **ffi_kwargs):
+        def call(*args, **kwargs):
+            calls.append((name, out_info, ffi_kwargs, args, kwargs))
+            if isinstance(out_info, (tuple, list)):
+                return tuple(jnp.zeros(info.shape, info.dtype) for info in out_info)
+            return jnp.zeros(out_info.shape, out_info.dtype)
+
+        return call
+
+    return ffi_call
 
 
 @pytest.mark.parametrize(
@@ -162,6 +186,242 @@ def test_plasticity_post_cuda_rejects_int64_weight_indices_before_loading_cuda()
             _shape(jnp.int32),
             **kwargs,
         )
+
+
+def test_float_cuda_generators_accept_int64_indptr_without_real_cuda(monkeypatch):
+    ffi_calls = []
+    load_calls = []
+
+    monkeypatch.setattr(float_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(float_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+
+    with _jax_x64_enabled():
+        indices = jnp.array([0, 1], dtype=jnp.int32)
+        indptr = jnp.array([0, 2], dtype=jnp.int64)
+
+        mv_kernel = float_mod._csrmv_cuda_kernel(
+            _shape(jnp.float32, (1,)),
+            False,
+            **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+        )
+        mv_kernel(
+            jnp.array([2.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            jnp.array([1.0, 3.0], dtype=jnp.float64),
+        )
+
+        mm_kernel = float_mod._csrmm_cuda_kernel(
+            _shape(jnp.float32, (1,)),
+            True,
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'outs': [_shape(jnp.float32, (2, 1))],
+            },
+        )
+        mm_kernel(
+            jnp.array([2.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            jnp.array([[1.0], [3.0]], dtype=jnp.float32),
+        )
+
+    assert [name for _, name in load_calls] == ['csr_float_csrmv', 'csr_float_csrmm']
+    assert [call[0] for call in ffi_calls] == [
+        'csr_float_csrmv.csrmv_nt_auto_f32',
+        'csr_float_csrmm.csrmm_t_warp_homo_f32',
+    ]
+
+
+def test_binary_cuda_generators_accept_int64_indptr_without_real_cuda(monkeypatch):
+    ffi_calls = []
+    load_calls = []
+
+    monkeypatch.setattr(binary_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(binary_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+
+    with _jax_x64_enabled():
+        indices = jnp.array([0, 1], dtype=jnp.int32)
+        indptr = jnp.array([0, 2], dtype=jnp.int64)
+
+        mv_kernel = binary_mod._binary_csrmv_cuda_kernel(
+            _shape(jnp.float32, (1,)),
+            _shape(jnp.bool_, (2,)),
+            False,
+            **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+        )
+        mv_kernel(
+            jnp.array([2.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            jnp.array([True, False]),
+        )
+
+        mm_kernel = binary_mod._binary_csrmm_cuda_kernel(
+            _shape(jnp.float32, (2,)),
+            _shape(jnp.float32, (2, 1)),
+            True,
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'outs': [_shape(jnp.float32, (2, 1))],
+            },
+        )
+        mm_kernel(
+            jnp.array([2.0, 3.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            jnp.array([[1.0], [0.0]], dtype=jnp.float32),
+        )
+
+    assert [name for _, name in load_calls] == ['csr_binary_csrmv', 'csr_binary_csrmm']
+    assert [call[0] for call in ffi_calls] == [
+        'csr_binary_csrmv.binary_csrmv_nt_auto_homo_f32_bool',
+        'csr_binary_csrmm.binary_csrmm_t_warp_hetero_f32_float',
+    ]
+
+
+def test_binary_indexed_cuda_generators_accept_int64_indptr_without_real_cuda(monkeypatch):
+    ffi_calls = []
+    load_calls = []
+
+    monkeypatch.setattr(binary_indexed_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(binary_indexed_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+
+    with _jax_x64_enabled():
+        indices = jnp.array([0, 1], dtype=jnp.int32)
+        indptr = jnp.array([0, 2], dtype=jnp.int64)
+        perm = jnp.array([1, 0], dtype=jnp.int32)
+
+        mv_kernel = binary_indexed_mod._binary_csrmv_indexed_cuda_kernel(
+            _shape(jnp.float32, (2,)),
+            _shape(jnp.bool_, (2,)),
+            False,
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'perm_info': _shape(jnp.int32, (2,)),
+            },
+        )
+        mv_kernel(
+            jnp.array([2.0, 3.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            perm,
+            jnp.array([True, False]),
+        )
+
+        mm_kernel = binary_indexed_mod._binary_csrmm_indexed_cuda_kernel(
+            _shape(jnp.float32, (1,)),
+            _shape(jnp.bool_, (2, 1)),
+            True,
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'outs': [_shape(jnp.float32, (2, 1))],
+                'perm_info': _shape(jnp.int32, (2,)),
+            },
+        )
+        mm_kernel(
+            jnp.array([2.0], dtype=jnp.float32),
+            indices,
+            indptr,
+            perm,
+            jnp.array([[True], [False]]),
+        )
+
+    assert [name for _, name in load_calls] == ['csr_binary_indexed_csrmv', 'csr_binary_csrmm']
+    assert [call[0] for call in ffi_calls] == [
+        'csr_binary_indexed_csrmv.binary_csrmv_nt_auto_perm_hetero_f32_bool',
+        'csr_binary_csrmm.binary_csrmm_t_warp_homo_f32_bool',
+    ]
+
+
+def test_slice_yw2y_and_plasticity_cuda_generators_accept_int64_indptr_without_real_cuda(monkeypatch):
+    ffi_calls = []
+    load_calls = []
+
+    monkeypatch.setattr(slice_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(slice_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+    monkeypatch.setattr(yw2y_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(yw2y_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+    monkeypatch.setattr(plasticity_mod, "load_cuda_file", lambda path, name: load_calls.append((path, name)))
+    monkeypatch.setattr(plasticity_mod.jax.ffi, "ffi_call", _recording_ffi_call(ffi_calls))
+
+    with _jax_x64_enabled():
+        indices = jnp.array([0, 1], dtype=jnp.int32)
+        indptr = jnp.array([0, 2], dtype=jnp.int64)
+
+        slice_kernel = slice_mod._csr_slice_rows_cuda_kernel_generator(
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'outs': [_shape(jnp.float32, (1, 2))],
+                'data_info': _shape(jnp.float32, (2,)),
+                'row_indices_info': _shape(jnp.int32, (1,)),
+            }
+        )
+        slice_kernel(jnp.array([1.0, 2.0]), indices, indptr, jnp.array([0], dtype=jnp.int32))
+
+        slice_grad_kernel = slice_mod._csr_slice_rows_grad_cuda_kernel_generator(
+            **{
+                **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+                'outs': [_shape(jnp.float32, (2,))],
+                'ct_info': _shape(jnp.float32, (1, 2)),
+                'row_indices_info': _shape(jnp.int32, (1,)),
+            }
+        )
+        slice_grad_kernel(jnp.array([[1.0, 2.0]]), indices, indptr, jnp.array([0], dtype=jnp.int32))
+
+        yw2y_kernel = yw2y_mod._csrmv_yw2y_cuda_kernel(
+            False,
+            _shape(jnp.float32, (2,)),
+            **_cuda_kwargs(indices_dtype=jnp.int32, indptr_dtype=jnp.int64),
+        )
+        yw2y_kernel(jnp.array([1.0]), jnp.array([2.0, 3.0]), indices, indptr)
+
+        pre_kernel = plasticity_mod._csr_on_pre_cuda_kernel(
+            _shape(jnp.float32, (2,)),
+            _shape(jnp.bool_, (1,)),
+            _shape(jnp.int32, (2,)),
+            outs=[_shape(jnp.float32, (2,))],
+            indptr_info=_shape(jnp.int64, (2,)),
+        )
+        pre_kernel(
+            jnp.array([1.0, 2.0]),
+            indices,
+            indptr,
+            jnp.array([True]),
+            jnp.array([0.5, 1.5]),
+        )
+
+        post_kernel = plasticity_mod._csr2csc_on_post_cuda_kernel(
+            _shape(jnp.float32, (2,)),
+            _shape(jnp.float32, (2,)),
+            _shape(jnp.int32, (2,)),
+            outs=[_shape(jnp.float32, (2,))],
+            indptr_info=_shape(jnp.int64, (2,)),
+            weight_indices_info=_shape(jnp.int32, (2,)),
+        )
+        post_kernel(
+            jnp.array([1.0, 2.0]),
+            indices,
+            indptr,
+            jnp.array([0, 1], dtype=jnp.int32),
+            jnp.array([0.5]),
+            jnp.array([1.0, -1.0]),
+        )
+
+    assert [name for _, name in load_calls] == [
+        'csr_slice_rows',
+        'csr_slice_rows',
+        'csrmv_yw2y',
+        'csr_plasticity_binary_pre',
+        'csr_plasticity_binary_post',
+    ]
+    assert [call[0] for call in ffi_calls] == [
+        'csr_slice_rows.csr_slice_rows_fwd_hetero_auto_f32',
+        'csr_slice_rows.csr_slice_rows_grad_auto_f32',
+        'csrmv_yw2y.csrmv_yw2y_nt_auto_f32',
+        'csr_plasticity_binary_pre.update_csr_on_pre_f32_bool',
+        'csr_plasticity_binary_post.update_csr_on_post_f32_float',
+    ]
 
 
 @requires_gpu

--- a/brainevent/_csr/cuda_int64_indptr_test.py
+++ b/brainevent/_csr/cuda_int64_indptr_test.py
@@ -1,0 +1,224 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from brainevent._csr.binary import binary_csrmm, binary_csrmv
+from brainevent._csr.binary_indexed import binary_csrmm_indexed, binary_csrmv_indexed
+from brainevent._csr.float import csrmm, csrmv
+from brainevent._csr.plasticity_binary import update_csr_on_binary_post, update_csr_on_binary_pre
+from brainevent._csr.slice import csr_slice_rows, csr_slice_rows_grad
+from brainevent._csr.yw2y import csrmv_yw2y
+
+
+requires_gpu = pytest.mark.skipif(
+    jax.default_backend() != 'gpu',
+    reason='CUDA int64 indptr tests require a GPU backend',
+)
+
+
+def _structure(indptr_dtype):
+    weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+    indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+    indptr = jnp.array([0, 2, 4], dtype=indptr_dtype)
+    return weights, indices, indptr
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+@pytest.mark.parametrize('homo', [False, True])
+def test_float_csrmv_cuda_accepts_int64_indptr(transpose, homo):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    data = weights if not homo else jnp.array([2.0], dtype=jnp.float32)
+    vector = jnp.array([1.0, 2.0], dtype=jnp.float32) if transpose else jnp.array([1.0, 2.0, 3.0])
+
+    got = csrmv(data, indices, indptr64, vector, shape=(2, 3), transpose=transpose, backend='cuda_raw')
+    expected = csrmv(data, indices, indptr32, vector, shape=(2, 3), transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+@pytest.mark.parametrize('homo', [False, True])
+def test_float_csrmm_cuda_accepts_int64_indptr(transpose, homo):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    data = weights if not homo else jnp.array([2.0], dtype=jnp.float32)
+    matrix = (
+        jnp.array([[1.0, 0.5], [2.0, 1.5]], dtype=jnp.float32)
+        if transpose else
+        jnp.array([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dtype=jnp.float32)
+    )
+
+    got = csrmm(data, indices, indptr64, matrix, shape=(2, 3), transpose=transpose, backend='cuda_raw')
+    expected = csrmm(data, indices, indptr32, matrix, shape=(2, 3), transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+@pytest.mark.parametrize('homo', [False, True])
+def test_binary_csrmv_cuda_accepts_int64_indptr(transpose, homo):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    data = weights if not homo else jnp.array([2.0], dtype=jnp.float32)
+    vector = jnp.array([True, False], dtype=jnp.bool_) if transpose else jnp.array([True, False, True])
+
+    got = binary_csrmv(data, indices, indptr64, vector, shape=(2, 3), transpose=transpose, backend='cuda_raw')
+    expected = binary_csrmv(data, indices, indptr32, vector, shape=(2, 3), transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+@pytest.mark.parametrize('homo', [False, True])
+def test_binary_csrmm_cuda_accepts_int64_indptr(transpose, homo):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    data = weights if not homo else jnp.array([2.0], dtype=jnp.float32)
+    matrix = (
+        jnp.array([[True, False], [False, True]], dtype=jnp.bool_)
+        if transpose else
+        jnp.array([[True, False], [False, True], [True, True]], dtype=jnp.bool_)
+    )
+
+    got = binary_csrmm(data, indices, indptr64, matrix, shape=(2, 3), transpose=transpose, backend='cuda_raw')
+    expected = binary_csrmm(data, indices, indptr32, matrix, shape=(2, 3), transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+def test_binary_indexed_cuda_accepts_int64_indptr(transpose):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    perm = jnp.array([2, 0, 3, 1], dtype=jnp.int32)
+    vector = jnp.array([True, False], dtype=jnp.bool_) if transpose else jnp.array([True, False, True])
+
+    got = binary_csrmv_indexed(weights, indices, indptr64, perm, vector, shape=(2, 3),
+                               transpose=transpose, backend='cuda_raw')
+    expected = binary_csrmv_indexed(weights, indices, indptr32, perm, vector, shape=(2, 3),
+                                    transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@pytest.mark.parametrize('transpose', [False, True])
+def test_binary_indexed_csrmm_cuda_accepts_int64_indptr(transpose):
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    perm = jnp.array([2, 0, 3, 1], dtype=jnp.int32)
+    matrix = (
+        jnp.array([[True, False], [False, True]], dtype=jnp.bool_)
+        if transpose else
+        jnp.array([[True, False], [False, True], [True, True]], dtype=jnp.bool_)
+    )
+
+    got = binary_csrmm_indexed(weights, indices, indptr64, perm, matrix, shape=(2, 3),
+                               transpose=transpose, backend='cuda_raw')
+    expected = binary_csrmm_indexed(weights, indices, indptr32, perm, matrix, shape=(2, 3),
+                                    transpose=transpose, backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+def test_slice_cuda_accepts_int64_indptr():
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    rows = jnp.array([1, 0], dtype=jnp.int32)
+
+    got = csr_slice_rows(
+        weights, indices, indptr64, rows, shape=(2, 3), backend='cuda_raw'
+    )
+    expected = jnp.array([[0.0, 3.0, 4.0], [1.0, 0.0, 2.0]], dtype=jnp.float32)
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+def test_slice_grad_cuda_accepts_int64_indptr():
+    _, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    rows = jnp.array([1, 0], dtype=jnp.int32)
+    ct = jnp.array([[10.0, 20.0, 30.0], [1.0, 2.0, 3.0]], dtype=jnp.float32)
+
+    got = csr_slice_rows_grad(ct, indices, indptr64, rows, shape=(2, 3), backend='cuda_raw')
+    expected = jnp.array([1.0, 3.0, 20.0, 30.0], dtype=jnp.float32)
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+def test_yw2y_cuda_accepts_int64_indptr():
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    y = jnp.array([1.0, 2.0], dtype=jnp.float32)
+
+    got = csrmv_yw2y(y, weights, indices, indptr64, shape=(2, 3), backend='cuda_raw')
+    expected = csrmv_yw2y(y, weights, indices, indptr32, shape=(2, 3), backend='jax_raw')
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+def test_plasticity_pre_cuda_accepts_int64_indptr():
+    weights, indices, indptr32 = _structure(jnp.int32)
+    indptr64 = indptr32.astype(jnp.int64)
+    pre_spike = jnp.array([True, False])
+    post_trace = jnp.array([0.5, 1.5, 2.5], dtype=jnp.float32)
+
+    got = update_csr_on_binary_pre(
+        weights, indices, indptr64, pre_spike, post_trace, shape=(2, 3), backend='cuda_raw'
+    )
+    expected = jnp.array([1.5, 4.5, 3.0, 4.0], dtype=jnp.float32)
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+def test_plasticity_post_cuda_accepts_int64_indptr():
+    weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+    indices = jnp.array([0, 1, 0, 1], dtype=jnp.int32)
+    indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+    weight_indices = jnp.array([0, 2, 1, 3], dtype=jnp.int32)
+    pre_trace = jnp.array([0.5, 1.5], dtype=jnp.float32)
+    post_spike = jnp.array([False, True])
+
+    got = update_csr_on_binary_post(
+        weights, indices, indptr, weight_indices, pre_trace, post_spike, shape=(2, 2), backend='cuda_raw'
+    )
+    expected = jnp.array([1.0, 2.5, 3.0, 5.5], dtype=jnp.float32)
+
+    assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_csr_cuda_sources_do_not_cast_indptr_to_int32():
+    csr_dir = Path(__file__).parent
+    for path in csr_dir.glob('*.cu'):
+        text = path.read_text()
+        assert 'static_cast<const int32_t*>(indptr.data_ptr())' not in text, path.name
+        assert 'const int32_t*  __restrict__ indptr' not in text, path.name
+        assert 'const int32_t*   __restrict__ indptr' not in text, path.name

--- a/brainevent/_csr/cuda_int64_indptr_test.py
+++ b/brainevent/_csr/cuda_int64_indptr_test.py
@@ -19,6 +19,12 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+import brainevent._csr.binary as binary_mod
+import brainevent._csr.binary_indexed as binary_indexed_mod
+import brainevent._csr.float as float_mod
+import brainevent._csr.plasticity_binary as plasticity_mod
+import brainevent._csr.slice as slice_mod
+import brainevent._csr.yw2y as yw2y_mod
 from brainevent._csr.binary import binary_csrmm, binary_csrmv
 from brainevent._csr.binary_indexed import binary_csrmm_indexed, binary_csrmv_indexed
 from brainevent._csr.float import csrmm, csrmv
@@ -38,6 +44,124 @@ def _structure(indptr_dtype):
     indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
     indptr = jnp.array([0, 2, 4], dtype=indptr_dtype)
     return weights, indices, indptr
+
+
+def _shape(dtype, shape=(2,)):
+    return jax.ShapeDtypeStruct(shape, dtype)
+
+
+def _cuda_kwargs(indices_dtype=jnp.int64, indptr_dtype=jnp.int64, nse=2):
+    return {
+        'outs': [_shape(jnp.float32)],
+        'shape': (1, 2),
+        'indices_info': _shape(indices_dtype, (nse,)),
+        'indptr_info': _shape(indptr_dtype, (2,)),
+    }
+
+
+@pytest.mark.parametrize(
+    'factory,args,kwargs',
+    [
+        (
+            float_mod._csrmv_cuda_kernel,
+            (_shape(jnp.float32), False),
+            {'outs': [_shape(jnp.float32)]},
+        ),
+        (
+            float_mod._csrmm_cuda_kernel,
+            (_shape(jnp.float32), False),
+            {'outs': [_shape(jnp.float32, (1, 1))]},
+        ),
+        (
+            binary_mod._binary_csrmv_cuda_kernel,
+            (_shape(jnp.float32), _shape(jnp.bool_), False),
+            {'outs': [_shape(jnp.float32)]},
+        ),
+        (
+            binary_mod._binary_csrmm_cuda_kernel,
+            (_shape(jnp.float32), _shape(jnp.bool_, (2, 1)), False),
+            {'outs': [_shape(jnp.float32, (1, 1))]},
+        ),
+        (
+            binary_indexed_mod._binary_csrmv_indexed_cuda_kernel,
+            (_shape(jnp.float32), _shape(jnp.bool_), False),
+            {'outs': [_shape(jnp.float32)], 'perm_info': _shape(jnp.int32)},
+        ),
+        (
+            binary_indexed_mod._binary_csrmm_indexed_cuda_kernel,
+            (_shape(jnp.float32), _shape(jnp.bool_, (2, 1)), False),
+            {'outs': [_shape(jnp.float32, (1, 1))], 'perm_info': _shape(jnp.int32)},
+        ),
+        (
+            slice_mod._csr_slice_rows_cuda_kernel_generator,
+            (),
+            {
+                'outs': [_shape(jnp.float32, (1, 2))],
+                'data_info': _shape(jnp.float32),
+                'row_indices_info': _shape(jnp.int32, (1,)),
+            },
+        ),
+        (
+            slice_mod._csr_slice_rows_grad_cuda_kernel_generator,
+            (),
+            {
+                'outs': [_shape(jnp.float32)],
+                'ct_info': _shape(jnp.float32, (1, 2)),
+                'row_indices_info': _shape(jnp.int32, (1,)),
+            },
+        ),
+        (
+            yw2y_mod._csrmv_yw2y_cuda_kernel,
+            (False, _shape(jnp.float32)),
+            {'outs': [_shape(jnp.float32)]},
+        ),
+    ],
+)
+def test_cuda_kernel_generators_reject_int64_indices_before_loading_cuda(factory, args, kwargs):
+    call_kwargs = _cuda_kwargs()
+    call_kwargs.update(kwargs)
+
+    with pytest.raises(TypeError, match="indices with dtype int32"):
+        factory(*args, **call_kwargs)
+
+
+def test_plasticity_pre_cuda_rejects_int64_indices_before_loading_cuda():
+    with pytest.raises(TypeError, match="indices with dtype int32"):
+        plasticity_mod._csr_on_pre_cuda_kernel(
+            _shape(jnp.float32),
+            _shape(jnp.bool_),
+            _shape(jnp.int64),
+            outs=[_shape(jnp.float32)],
+            indptr_info=_shape(jnp.int64),
+        )
+
+
+def test_plasticity_post_cuda_rejects_int64_indices_before_loading_cuda():
+    with pytest.raises(TypeError, match="indices with dtype int32"):
+        plasticity_mod._csr2csc_on_post_cuda_kernel(
+            _shape(jnp.float32),
+            _shape(jnp.bool_),
+            _shape(jnp.int64),
+            outs=[_shape(jnp.float32)],
+            indptr_info=_shape(jnp.int64),
+            weight_indices_info=_shape(jnp.int32),
+        )
+
+
+def test_plasticity_post_cuda_rejects_int64_weight_indices_before_loading_cuda():
+    kwargs = {
+        'outs': [_shape(jnp.float32)],
+        'indptr_info': _shape(jnp.int64),
+        'weight_indices_info': _shape(jnp.int64),
+    }
+
+    with pytest.raises(TypeError, match="weight_indices with dtype int32"):
+        plasticity_mod._csr2csc_on_post_cuda_kernel(
+            _shape(jnp.float32),
+            _shape(jnp.bool_),
+            _shape(jnp.int32),
+            **kwargs,
+        )
 
 
 @requires_gpu

--- a/brainevent/_csr/float.py
+++ b/brainevent/_csr/float.py
@@ -23,7 +23,12 @@ import numpy as np
 from jax.experimental.sparse import csr_matvec_p, csr_matmat_p
 from jax.interpreters import ad
 
-from brainevent._misc import _csr_to_coo, namescope
+from brainevent._misc import (
+    _check_csr_cuda_structure_dtypes,
+    _check_csr_structure_dtypes,
+    _csr_to_coo,
+    namescope,
+)
 from brainevent._op import load_cuda_file
 from brainevent._op import numba_kernel, XLACustomKernel, general_batching_rule
 from brainevent._op.benchmark import BenchmarkConfig
@@ -206,6 +211,7 @@ def _csrmv_cuda_kernel(
     transpose: bool,
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     is_homo = (weight_info.size == 1)
     if is_homo:
         load_cuda_file(
@@ -233,6 +239,8 @@ def _csrmv_cuda_kernel(
 
     else:
         def kernel(weights, indices, indptr, vector):
+            indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
+            vector = vector.astype(weight_info.dtype) if vector.dtype != weight_info.dtype else vector
             return csr_matvec_p.bind(weights, indices, indptr, vector, shape=kwargs['shape'], transpose=transpose),
 
     return kernel
@@ -482,11 +490,9 @@ def csrmv_p_call(
         ...     weights, indices, indptr, vector,
         ...     shape=(2, 3), transpose=False)
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     if transpose:
         assert shape[0] == vector.shape[0], "Shape mismatch for transpose operation."
     else:
@@ -748,6 +754,7 @@ def _csrmm_cuda_kernel(
     transpose: bool,
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     is_homo = (weight_info.size == 1)
     if is_homo:
         load_cuda_file(
@@ -779,6 +786,8 @@ def _csrmm_cuda_kernel(
 
     else:
         def kernel(weights, indices, indptr, B):
+            indices = indices.astype(indptr.dtype) if indices.dtype != indptr.dtype else indices
+            B = B.astype(weight_info.dtype) if B.dtype != weight_info.dtype else B
             return csr_matmat_p.bind(weights, indices, indptr, B, shape=kwargs['shape'], transpose=transpose),
 
     return kernel
@@ -1040,11 +1049,9 @@ def csrmm_p_call(
         ...             weights, indices, indptr, B,
         ...             shape=(2, 3), transpose=False)
     """
-    assert indices.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indices must be int32 or int64."
-    assert indptr.dtype in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64], "Indptr must be int32 or int64."
     assert indptr.ndim == 1, "Indptr must be 1D."
     assert indices.ndim == 1, "Indices must be 1D."
-    assert indptr.dtype == indices.dtype, "Indices and indptr must have the same dtype."
+    _check_csr_structure_dtypes(indices, indptr)
     if transpose:
         assert shape[0] == B.shape[0], "Shape mismatch for transpose operation."
     else:

--- a/brainevent/_csr/float_csrmm.cu
+++ b/brainevent/_csr/float_csrmm.cu
@@ -67,10 +67,11 @@
 
 #define DEFINE_CSRMM_NT_WARP_HOMO(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, \
                                    ACC_ZERO)                                \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                           \
     const WEIGHT_T* __restrict__ weights,                                   \
     const int32_t*  __restrict__ indices,                                   \
-    const int32_t*  __restrict__ indptr,                                    \
+    const IndptrT*  __restrict__ indptr,                                    \
     const WEIGHT_T* __restrict__ B,                                         \
     WEIGHT_T*       __restrict__ C,                                         \
     int m, int n                                                            \
@@ -79,10 +80,10 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                           \
     int col_start = blockIdx.y * 32;                                        \
     int c         = col_start + (int)threadIdx.x;                           \
     if (row >= m || c >= n) return;                                         \
-    int start = indptr[row], end = indptr[row + 1];                         \
+    IndptrT start = indptr[row], end = indptr[row + 1];                         \
     ACC_T w   = READ_W(weights[0]);                                         \
     ACC_T acc = ACC_ZERO;                                                   \
-    for (int j = start; j < end; j++) {                                     \
+    for (IndptrT j = start; j < end; j++) {                                     \
         acc += w * READ_W(B[indices[j] * n + c]);                           \
     }                                                                       \
     C[row * n + c] = WRITE_W(acc);                                          \
@@ -90,10 +91,11 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                           \
 
 #define DEFINE_CSRMM_NT_BLOCK_HOMO(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, \
                                     ACC_ZERO)                                \
+template <typename IndptrT> \
 __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                           \
     const WEIGHT_T* __restrict__ weights,                                    \
     const int32_t*  __restrict__ indices,                                    \
-    const int32_t*  __restrict__ indptr,                                     \
+    const IndptrT*  __restrict__ indptr,                                     \
     const WEIGHT_T* __restrict__ B,                                          \
     WEIGHT_T*       __restrict__ C,                                          \
     int m, int n                                                             \
@@ -106,11 +108,11 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                           \
     int strip     = threadIdx.x >> 5;                                        \
     int c         = col_start + lane;                                        \
     if (row >= m) return;                                                    \
-    int start = indptr[row], end = indptr[row + 1];                          \
+    IndptrT start = indptr[row], end = indptr[row + 1];                          \
     ACC_T w   = READ_W(weights[0]);                                          \
     ACC_T acc = ACC_ZERO;                                                    \
     if (c < n) {                                                             \
-        for (int j = start + strip; j < end; j += 8) {                       \
+        for (IndptrT j = start + strip; j < end; j += 8) {                       \
             acc += w * READ_W(B[indices[j] * n + c]);                        \
         }                                                                    \
     }                                                                        \
@@ -125,10 +127,11 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                           \
 
 #define DEFINE_CSRMM_T_WARP_HOMO(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, \
                                   ATOMIC_ADD_W, ACC_ZERO)                  \
+template <typename IndptrT> \
 __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                           \
     const WEIGHT_T* __restrict__ weights,                                  \
     const int32_t*  __restrict__ indices,                                  \
-    const int32_t*  __restrict__ indptr,                                   \
+    const IndptrT*  __restrict__ indptr,                                   \
     const WEIGHT_T* __restrict__ B,                                        \
     WEIGHT_T*       __restrict__ C,                                        \
     int m, int n                                                           \
@@ -140,8 +143,8 @@ __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                           \
     ACC_T b_val   = READ_W(B[row * n + c]);                                \
     ACC_T w       = READ_W(weights[0]);                                    \
     ACC_T contrib = w * b_val;                                             \
-    int start = indptr[row], end = indptr[row + 1];                        \
-    for (int j = start; j < end; j++) {                                    \
+    IndptrT start = indptr[row], end = indptr[row + 1];                        \
+    for (IndptrT j = start; j < end; j++) {                                    \
         ATOMIC_ADD_W(&C[indices[j] * n + c], contrib);                     \
     }                                                                      \
 }
@@ -188,18 +191,21 @@ void csrmm_nt_warp_homo##SUFFIX(                              \
     const BE::Tensor indptr,  const BE::Tensor B,             \
     BE::Tensor C,       int64_t stream                  \
 ) {                                                           \
+    BE_CHECK_CSR_INDICES_INT32(indices);                      \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream); \
     int m           = static_cast<int>(indptr.size(0)) - 1;   \
     int n           = static_cast<int>(B.size(1));            \
     int c_blocks    = (n + 31) / 32;                          \
     dim3 grid(m, c_blocks);                                   \
-    _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(     \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
-        static_cast<const int32_t*>(indices.data_ptr()),      \
-        static_cast<const int32_t*>(indptr.data_ptr()),       \
-        static_cast<const WEIGHT_C_T*>(B.data_ptr()),         \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),               \
-        m, n);                                                \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {         \
+        _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()), \
+            static_cast<const int32_t*>(indices.data_ptr()),  \
+            static_cast<const IndptrT*>(indptr.data_ptr()),   \
+            static_cast<const WEIGHT_C_T*>(B.data_ptr()),     \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),           \
+            m, n);                                            \
+    });                                                       \
 }
 
 #define FFI_CSRMM_NT_BLOCK_HOMO(SUFFIX, WEIGHT_C_T, SHM_SIZE)      \
@@ -208,18 +214,21 @@ void csrmm_nt_block_homo##SUFFIX(                                  \
     const BE::Tensor indptr,  const BE::Tensor B,                  \
     BE::Tensor C,       int64_t stream                       \
 ) {                                                                \
+    BE_CHECK_CSR_INDICES_INT32(indices);                           \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);      \
     int m           = static_cast<int>(indptr.size(0)) - 1;        \
     int n           = static_cast<int>(B.size(1));                 \
     int c_blocks    = (n + 31) / 32;                               \
     dim3 grid(m, c_blocks);                                        \
-    _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>( \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),        \
-        static_cast<const int32_t*>(indices.data_ptr()),           \
-        static_cast<const int32_t*>(indptr.data_ptr()),            \
-        static_cast<const WEIGHT_C_T*>(B.data_ptr()),              \
-        static_cast<WEIGHT_C_T*>(C.data_ptr()),                    \
-        m, n);                                                     \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {              \
+        _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>( \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),    \
+            static_cast<const int32_t*>(indices.data_ptr()),       \
+            static_cast<const IndptrT*>(indptr.data_ptr()),        \
+            static_cast<const WEIGHT_C_T*>(B.data_ptr()),          \
+            static_cast<WEIGHT_C_T*>(C.data_ptr()),                \
+            m, n);                                                 \
+    });                                                            \
 }
 
 #define FFI_CSRMM_NT_AUTO_HOMO(SUFFIX, WEIGHT_C_T, SHM_SIZE)                    \
@@ -228,6 +237,7 @@ void csrmm_nt_auto_homo##SUFFIX(                                                
     const BE::Tensor indptr,  const BE::Tensor B,                               \
     BE::Tensor C,       int64_t stream                                    \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);                   \
     int m           = static_cast<int>(indptr.size(0)) - 1;                     \
     int nse         = static_cast<int>(indices.size(0));                        \
@@ -237,16 +247,18 @@ void csrmm_nt_auto_homo##SUFFIX(                                                
     dim3 grid(m, c_blocks);                                                     \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const WEIGHT_C_T* d_b = static_cast<const WEIGHT_C_T*>(B.data_ptr());       \
     WEIGHT_C_T*       d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    if (avg_nnz <= 64) {                                                        \
-        _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(                   \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    } else {                                                                    \
-        _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(          \
-            d_w, d_i, d_p, d_b, d_c, m, n);                                     \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz <= 64) {                                                    \
+            _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(               \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        } else {                                                                \
+            _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(      \
+                d_w, d_i, d_p, d_b, d_c, m, n);                                 \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMM_T_WARP_HOMO(SUFFIX, WEIGHT_C_T)                           \
@@ -255,6 +267,7 @@ void csrmm_t_warp_homo##SUFFIX(                                             \
     const BE::Tensor indptr,  const BE::Tensor B,                           \
     BE::Tensor C,       int64_t stream                                \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);               \
     int m           = static_cast<int>(indptr.size(0)) - 1;                 \
     int n           = static_cast<int>(B.size(1));                          \
@@ -263,12 +276,14 @@ void csrmm_t_warp_homo##SUFFIX(                                             \
     cudaMemsetAsync(d_c, 0, (size_t)k * (size_t)n * sizeof(WEIGHT_C_T), s); \
     int c_blocks    = (n + 31) / 32;                                        \
     dim3 grid(m, c_blocks);                                                 \
-    _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(                    \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),                 \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const WEIGHT_C_T*>(B.data_ptr()),                       \
-        d_c, m, n);                                                         \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(                \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),             \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const WEIGHT_C_T*>(B.data_ptr()),                   \
+            d_c, m, n);                                                     \
+    });                                                                     \
 }
 
 // =========================================================================

--- a/brainevent/_csr/float_csrmv.cu
+++ b/brainevent/_csr/float_csrmv.cu
@@ -54,40 +54,42 @@
 // =========================================================================
 
 #define DEFINE_CSRMV_NT_THREAD(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, ACC_ZERO) \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_thread_kern##SUFFIX(                                     \
     const WEIGHT_T* __restrict__ weights,                                          \
     const int32_t*  __restrict__ indices,                                          \
-    const int32_t*  __restrict__ indptr,                                           \
+    const IndptrT*  __restrict__ indptr,                                           \
     const WEIGHT_T* __restrict__ vector,                                           \
     WEIGHT_T*       __restrict__ output,                                           \
     int m                                                                          \
 ) {                                                                                \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                               \
     if (row >= m) return;                                                          \
-    int start = indptr[row], end = indptr[row + 1];                                \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                \
     ACC_T acc = ACC_ZERO;                                                          \
     ACC_T w   = READ_W(weights[0]);                                                \
-    for (int j = start; j < end; j++) {                                            \
+    for (IndptrT j = start; j < end; j++) {                                            \
         acc += w * READ_W(vector[indices[j]]);                                     \
     }                                                                              \
     output[row] = WRITE_W(acc);                                                    \
 }
 
 #define DEFINE_CSRMV_NT_WARP(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, WARP_RED, ACC_ZERO) \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_warp_kern##SUFFIX(                                               \
     const WEIGHT_T* __restrict__ weights,                                                  \
     const int32_t*  __restrict__ indices,                                                  \
-    const int32_t*  __restrict__ indptr,                                                   \
+    const IndptrT*  __restrict__ indptr,                                                   \
     const WEIGHT_T* __restrict__ vector,                                                   \
     WEIGHT_T*       __restrict__ output,                                                   \
     int m                                                                                  \
 ) {                                                                                        \
     int row = blockIdx.x;                                                                  \
     if (row >= m) return;                                                                  \
-    int start = indptr[row], end = indptr[row + 1];                                        \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                        \
     ACC_T acc = ACC_ZERO;                                                                  \
     ACC_T w   = READ_W(weights[0]);                                                        \
-    for (int j = start + (int)threadIdx.x; j < end; j += 32) {                             \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                             \
         acc += w * READ_W(vector[indices[j]]);                                             \
     }                                                                                      \
     acc = WARP_RED(acc);                                                                   \
@@ -95,10 +97,11 @@ __global__ void _csrmv_nt_warp_kern##SUFFIX(                                    
 }
 
 #define DEFINE_CSRMV_NT_BLOCK(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, WARP_RED, ACC_ZERO) \
+template <typename IndptrT> \
 __global__ void _csrmv_nt_block_kern##SUFFIX(                                               \
     const WEIGHT_T* __restrict__ weights,                                                   \
     const int32_t*  __restrict__ indices,                                                   \
-    const int32_t*  __restrict__ indptr,                                                    \
+    const IndptrT*  __restrict__ indptr,                                                    \
     const WEIGHT_T* __restrict__ vector,                                                    \
     WEIGHT_T*       __restrict__ output,                                                    \
     int m                                                                                   \
@@ -107,10 +110,10 @@ __global__ void _csrmv_nt_block_kern##SUFFIX(                                   
     ACC_T* smem_red = reinterpret_cast<ACC_T*>(_smem_bytes);                                \
     int row = blockIdx.x;                                                                   \
     if (row >= m) return;                                                                   \
-    int start = indptr[row], end = indptr[row + 1];                                         \
+    IndptrT start = indptr[row], end = indptr[row + 1];                                         \
     ACC_T acc = ACC_ZERO;                                                                   \
     ACC_T w   = READ_W(weights[0]);                                                         \
-    for (int j = start + (int)threadIdx.x; j < end; j += blockDim.x) {                      \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += blockDim.x) {                      \
         acc += w * READ_W(vector[indices[j]]);                                              \
     }                                                                                       \
     int lane   = threadIdx.x & 31;                                                          \
@@ -125,10 +128,11 @@ __global__ void _csrmv_nt_block_kern##SUFFIX(                                   
 }
 
 #define DEFINE_CSRMV_T_WARP(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, ACC_ZERO)  \
+template <typename IndptrT> \
 __global__ void _csrmv_t_warp_kern##SUFFIX(                                      \
     const WEIGHT_T* __restrict__ weights,                                        \
     const int32_t*  __restrict__ indices,                                        \
-    const int32_t*  __restrict__ indptr,                                         \
+    const IndptrT*  __restrict__ indptr,                                         \
     const WEIGHT_T* __restrict__ vector,                                         \
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
@@ -136,9 +140,9 @@ __global__ void _csrmv_t_warp_kern##SUFFIX(                                     
     int row = blockIdx.x;                                                        \
     if (row >= m) return;                                                        \
     ACC_T v_val = READ_W(vector[row]);                                           \
-    int start = indptr[row], end = indptr[row + 1];                              \
+    IndptrT start = indptr[row], end = indptr[row + 1];                              \
     WEIGHT_T contrib = WRITE_W(READ_W(weights[0]) * v_val);                      \
-    for (int j = start + (int)threadIdx.x; j < end; j += 32) {                   \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                   \
         atomicAdd(&output[indices[j]], contrib);                                 \
     }                                                                            \
 }
@@ -168,15 +172,18 @@ void csrmv_nt_thread##SUFFIX(                                     \
     const BE::Tensor indptr,  const BE::Tensor vector,            \
     BE::Tensor output,  int64_t stream                            \
 ) {                                                               \
+    BE_CHECK_CSR_INDICES_INT32(indices);                          \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);     \
     int m           = static_cast<int>(indptr.size(0)) - 1;       \
     int blocks      = (m + 255) / 256;                            \
-    _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(         \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),       \
-        static_cast<const int32_t*>(indices.data_ptr()),          \
-        static_cast<const int32_t*>(indptr.data_ptr()),           \
-        static_cast<const WEIGHT_C_T*>(vector.data_ptr()),        \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);          \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {             \
+        _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(     \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
+            static_cast<const int32_t*>(indices.data_ptr()),      \
+            static_cast<const IndptrT*>(indptr.data_ptr()),       \
+            static_cast<const WEIGHT_C_T*>(vector.data_ptr()),    \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);      \
+    });                                                           \
 }
 
 #define FFI_CSRMV_NT_WARP(SUFFIX, WEIGHT_C_T)                     \
@@ -185,14 +192,17 @@ void csrmv_nt_warp##SUFFIX(                                       \
     const BE::Tensor indptr,  const BE::Tensor vector,            \
     BE::Tensor output,  int64_t stream                            \
 ) {                                                               \
+    BE_CHECK_CSR_INDICES_INT32(indices);                          \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);     \
     int m           = static_cast<int>(indptr.size(0)) - 1;       \
-    _csrmv_nt_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                 \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),       \
-        static_cast<const int32_t*>(indices.data_ptr()),          \
-        static_cast<const int32_t*>(indptr.data_ptr()),           \
-        static_cast<const WEIGHT_C_T*>(vector.data_ptr()),        \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);          \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {             \
+        _csrmv_nt_warp_kern##SUFFIX<<<m, 32, 0, s>>>(             \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
+            static_cast<const int32_t*>(indices.data_ptr()),      \
+            static_cast<const IndptrT*>(indptr.data_ptr()),       \
+            static_cast<const WEIGHT_C_T*>(vector.data_ptr()),    \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);      \
+    });                                                           \
 }
 
 #define FFI_CSRMV_NT_BLOCK(SUFFIX, WEIGHT_C_T, SHM_SIZE)          \
@@ -201,14 +211,17 @@ void csrmv_nt_block##SUFFIX(                                      \
     const BE::Tensor indptr,  const BE::Tensor vector,            \
     BE::Tensor output,  int64_t stream                            \
 ) {                                                               \
+    BE_CHECK_CSR_INDICES_INT32(indices);                          \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);     \
     int m           = static_cast<int>(indptr.size(0)) - 1;       \
-    _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),       \
-        static_cast<const int32_t*>(indices.data_ptr()),          \
-        static_cast<const int32_t*>(indptr.data_ptr()),           \
-        static_cast<const WEIGHT_C_T*>(vector.data_ptr()),        \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);          \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {             \
+        _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),   \
+            static_cast<const int32_t*>(indices.data_ptr()),      \
+            static_cast<const IndptrT*>(indptr.data_ptr()),       \
+            static_cast<const WEIGHT_C_T*>(vector.data_ptr()),    \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m);      \
+    });                                                           \
 }
 
 #define FFI_CSRMV_NT_AUTO(SUFFIX, WEIGHT_C_T, SHM_SIZE)                         \
@@ -217,26 +230,29 @@ void csrmv_nt_auto##SUFFIX(                                                     
     const BE::Tensor indptr,  const BE::Tensor vector,                          \
     BE::Tensor output,  int64_t stream                                          \
 ) {                                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                        \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);                   \
     int m           = static_cast<int>(indptr.size(0)) - 1;                     \
     int nse         = static_cast<int>(indices.size(0));                        \
     int avg_nnz     = (m > 0) ? (nse / m) : 0;                                  \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
-    const int32_t*    d_p = static_cast<const int32_t*>(indptr.data_ptr());     \
     const WEIGHT_C_T* d_v = static_cast<const WEIGHT_C_T*>(vector.data_ptr());  \
     WEIGHT_C_T*       d_o = static_cast<WEIGHT_C_T*>(output.data_ptr());        \
-    if (avg_nnz < 8) {                                                          \
-        int blocks = (m + 255) / 256;                                           \
-        _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(                   \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    } else if (avg_nnz < 512) {                                                 \
-        _csrmv_nt_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                           \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    } else {                                                                    \
-        _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(                  \
-            d_w, d_i, d_p, d_v, d_o, m);                                        \
-    }                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
+        const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
+        if (avg_nnz < 8) {                                                      \
+            int blocks = (m + 255) / 256;                                       \
+            _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(               \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else if (avg_nnz < 512) {                                             \
+            _csrmv_nt_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                       \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else {                                                                \
+            _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(              \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        }                                                                       \
+    });                                                                         \
 }
 
 #define FFI_CSRMV_T_WARP(SUFFIX, WEIGHT_C_T)                         \
@@ -245,17 +261,20 @@ void csrmv_t_warp##SUFFIX(                                           \
     const BE::Tensor indptr,  const BE::Tensor vector,               \
     BE::Tensor output,  int64_t stream                               \
 ) {                                                                  \
+    BE_CHECK_CSR_INDICES_INT32(indices);                             \
     cudaStream_t s  = reinterpret_cast<cudaStream_t>(stream);        \
     int m           = static_cast<int>(indptr.size(0)) - 1;          \
     int k           = static_cast<int>(output.size(0));              \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
-    _csrmv_t_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                     \
-        static_cast<const WEIGHT_C_T*>(weights.data_ptr()),          \
-        static_cast<const int32_t*>(indices.data_ptr()),             \
-        static_cast<const int32_t*>(indptr.data_ptr()),              \
-        static_cast<const WEIGHT_C_T*>(vector.data_ptr()),           \
-        d_out, m);                                                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
+        _csrmv_t_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                 \
+            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
+            static_cast<const int32_t*>(indices.data_ptr()),         \
+            static_cast<const IndptrT*>(indptr.data_ptr()),          \
+            static_cast<const WEIGHT_C_T*>(vector.data_ptr()),       \
+            d_out, m);                                               \
+    });                                                              \
 }
 
 // SpMV FFI Instantiations

--- a/brainevent/_csr/float_test.py
+++ b/brainevent/_csr/float_test.py
@@ -17,6 +17,8 @@ import os
 
 os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
 
+from contextlib import contextmanager
+
 import brainstate
 import braintools
 import jax
@@ -29,6 +31,16 @@ from brainevent._csr.test_util import get_csr, vector_csr, matrix_csr, csr_vecto
 platform = jax.default_backend()
 CSRMV_IMPLEMENTATIONS = tuple(csrmv_p.available_backends(platform))
 CSRMM_IMPLEMENTATIONS = tuple(csrmm_p.available_backends(platform))
+
+
+@contextmanager
+def _jax_x64_enabled():
+    old_x64 = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", old_x64)
 
 
 def _make_data(homo_w, shape):
@@ -89,6 +101,52 @@ def _row_ids_from_indptr(indptr):
     indptr = jnp.asarray(indptr)
     counts = jnp.diff(indptr)
     return jnp.repeat(jnp.arange(counts.shape[0], dtype=indptr.dtype), counts)
+
+
+def test_csrmv_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        vector = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+
+        got = csrmv(weights, indices, indptr, vector, shape=(2, 3), backend='jax_raw')
+
+        assert jnp.allclose(got, jnp.array([7.0, 18.0], dtype=jnp.float32))
+
+
+def test_csrmv_rejects_int64_indices_with_int32_indptr():
+    with _jax_x64_enabled():
+        weights = jnp.ones(2, dtype=jnp.float32)
+        indices = jnp.array([0, 1], dtype=jnp.int64)
+        indptr = jnp.array([0, 2], dtype=jnp.int32)
+        vector = jnp.ones(2, dtype=jnp.float32)
+
+        with pytest.raises(AssertionError, match="same dtype"):
+            csrmv(weights, indices, indptr, vector, shape=(1, 2), backend='jax_raw')
+
+
+def test_csrmm_accepts_int32_indices_with_int64_indptr_on_jax_raw():
+    with _jax_x64_enabled():
+        weights = jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32)
+        indices = jnp.array([0, 2, 1, 2], dtype=jnp.int32)
+        indptr = jnp.array([0, 2, 4], dtype=jnp.int64)
+        matrix = jnp.array([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dtype=jnp.float32)
+
+        got = csrmm(weights, indices, indptr, matrix, shape=(2, 3), backend='jax_raw')
+        expected = jnp.array([[7.0, 5.5], [18.0, 14.5]], dtype=jnp.float32)
+
+        assert jnp.allclose(got, expected)
+
+
+def test_csrmm_rejects_unsigned_structure_dtype():
+    weights = jnp.ones(2, dtype=jnp.float32)
+    indices = jnp.array([0, 1], dtype=jnp.uint32)
+    indptr = jnp.array([0, 2], dtype=jnp.uint32)
+    matrix = jnp.ones((2, 1), dtype=jnp.float32)
+
+    with pytest.raises(AssertionError, match="signed int32 or int64"):
+        csrmm(weights, indices, indptr, matrix, shape=(1, 2), backend='jax_raw')
 
 
 @pytest.mark.skipif(

--- a/brainevent/_csr/plasticity_binary.py
+++ b/brainevent/_csr/plasticity_binary.py
@@ -24,7 +24,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from brainevent._misc import namescope, csc_to_csr_index
+from brainevent._misc import _check_csr_cuda_structure_dtypes, namescope, csc_to_csr_index
 from brainevent._op import XLACustomKernel, numba_kernel
 from brainevent._op.benchmark import BenchmarkConfig
 from brainevent._typing import MatrixShape
@@ -316,15 +316,9 @@ def _csr_on_pre_cuda_kernel(
     thread-per-row, warp-per-row, and block-per-row sub-kernels at runtime
     based on avg_nnz = nse / n_pre.
 
-    Only int32 index arrays are supported.  Callers with int64 indices should
-    explicitly select ``backend='pallas'`` or ``backend='jax'``.
+    CUDA uses int32 column indices and accepts int32/int64 row pointers.
     """
-    if indices_info.dtype == jnp.int64:
-        raise TypeError(
-            "update_csr_on_binary_pre: the 'cuda_raw' backend only supports "
-            "int32 index arrays (indices / indptr).  "
-            "Use backend='pallas' or backend='jax' for int64 indices."
-        )
+    _check_csr_cuda_structure_dtypes(indices_info, kwargs['indptr_info'])
 
     load_cuda_file(
         Path(__file__).parent.joinpath('plasticity_binary_on_pre.cu'),
@@ -783,14 +777,13 @@ def _csr2csc_on_post_cuda_kernel(
     weight_indices is injective by CSC construction, no actual race conditions
     occur; atomicAdd provides a safety guarantee against malformed inputs.
 
-    Only int32 index arrays are supported.  Callers with int64 indices should
-    explicitly select ``backend='pallas'`` or ``backend='jax'``.
+    CUDA uses int32 column/weight indices and accepts int32/int64 row pointers.
     """
-    if indices_info.dtype == jnp.int64:
+    _check_csr_cuda_structure_dtypes(indices_info, kwargs['indptr_info'])
+    if jnp.dtype(kwargs['weight_indices_info'].dtype) != jnp.dtype(jnp.int32):
         raise TypeError(
-            "update_csr_on_binary_post: the 'cuda_raw' backend only supports "
-            "int32 index arrays (indices / indptr / weight_indices).  "
-            "Use backend='pallas' or backend='jax' for int64 indices."
+            "update_csr_on_binary_post cuda_raw requires weight_indices with dtype int32; "
+            f"got {jnp.dtype(kwargs['weight_indices_info'].dtype)}."
         )
 
     load_cuda_file(

--- a/brainevent/_csr/plasticity_binary_on_post.cu
+++ b/brainevent/_csr/plasticity_binary_on_post.cu
@@ -56,13 +56,14 @@
 
 #define DEFINE_CSR_ON_POST_THREAD(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                    READ_W, WRITE_W, ATOMIC_ADD)                \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                         \
 _csr_on_post_thread_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                       \
     const SPIKE_T*   __restrict__ spike,                                       \
     const WEIGHT_T*  __restrict__ trace,                                       \
     const int32_t*   __restrict__ indices,                                     \
-    const int32_t*   __restrict__ indptr,                                      \
+    const IndptrT*   __restrict__ indptr,                                      \
     const int32_t*   __restrict__ weight_indices,                              \
     int n_post                                                                 \
 ) {                                                                            \
@@ -72,9 +73,9 @@ _csr_on_post_thread_kern##SUFFIX(                                              \
     unsigned int ballot = __ballot_sync(0xFFFFFFFF, my_active);                \
     if (ballot == 0) return;                                                   \
     if (!my_active) return;                                                    \
-    int start = __ldg(&indptr[col]);                                           \
-    int end   = __ldg(&indptr[col + 1]);                                       \
-    for (int pos = start; pos < end; ++pos) {                                  \
+    IndptrT start = __ldg(&indptr[col]);                                           \
+    IndptrT end   = __ldg(&indptr[col + 1]);                                       \
+    for (IndptrT pos = start; pos < end; ++pos) {                                  \
         int idx = __ldg(&indices[pos]);                                        \
         int widx = __ldg(&weight_indices[pos]);                                \
         ACC_T delta = READ_W(__ldg(&trace[idx]));                              \
@@ -84,13 +85,14 @@ _csr_on_post_thread_kern##SUFFIX(                                              \
 
 #define DEFINE_CSR_ON_POST_WARP(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                  READ_W, WRITE_W, ATOMIC_ADD)                \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                       \
 _csr_on_post_warp_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                     \
     const SPIKE_T*   __restrict__ spike,                                     \
     const WEIGHT_T*  __restrict__ trace,                                     \
     const int32_t*   __restrict__ indices,                                   \
-    const int32_t*   __restrict__ indptr,                                    \
+    const IndptrT*   __restrict__ indptr,                                    \
     const int32_t*   __restrict__ weight_indices,                            \
     int n_post                                                               \
 ) {                                                                          \
@@ -101,9 +103,9 @@ _csr_on_post_warp_kern##SUFFIX(                                              \
     bool active = IS_ACTIVE(__ldg(&spike[warp_id]));                         \
     if (__ballot_sync(0xFFFFFFFF, active) == 0) return;                      \
     if (!active) return;                                                     \
-    int start = __ldg(&indptr[warp_id]);                                     \
-    int end   = __ldg(&indptr[warp_id + 1]);                                 \
-    for (int pos = start + lane; pos < end; pos += 32) {                     \
+    IndptrT start = __ldg(&indptr[warp_id]);                                     \
+    IndptrT end   = __ldg(&indptr[warp_id + 1]);                                 \
+    for (IndptrT pos = start + lane; pos < end; pos += 32) {                     \
         int idx = __ldg(&indices[pos]);                                      \
         int widx = __ldg(&weight_indices[pos]);                              \
         ACC_T delta = READ_W(__ldg(&trace[idx]));                            \
@@ -113,13 +115,14 @@ _csr_on_post_warp_kern##SUFFIX(                                              \
 
 #define DEFINE_CSR_ON_POST_BLOCK(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                   READ_W, WRITE_W, ATOMIC_ADD)                \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                        \
 _csr_on_post_block_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                      \
     const SPIKE_T*   __restrict__ spike,                                      \
     const WEIGHT_T*  __restrict__ trace,                                      \
     const int32_t*   __restrict__ indices,                                    \
-    const int32_t*   __restrict__ indptr,                                     \
+    const IndptrT*   __restrict__ indptr,                                     \
     const int32_t*   __restrict__ weight_indices,                             \
     int n_post                                                                \
 ) {                                                                           \
@@ -128,10 +131,10 @@ _csr_on_post_block_kern##SUFFIX(                                              \
     bool active = IS_ACTIVE(__ldg(&spike[col]));                              \
     if (__ballot_sync(0xFFFFFFFF, active) == 0) return;                       \
     if (!active) return;                                                      \
-    int start = __ldg(&indptr[col]);                                          \
-    int end   = __ldg(&indptr[col + 1]);                                      \
+    IndptrT start = __ldg(&indptr[col]);                                          \
+    IndptrT end   = __ldg(&indptr[col + 1]);                                      \
     int tid   = (int)threadIdx.x;                                             \
-    for (int pos = start + tid; pos < end; pos += 256) {                      \
+    for (IndptrT pos = start + tid; pos < end; pos += 256) {                      \
         int idx = __ldg(&indices[pos]);                                       \
         int widx = __ldg(&weight_indices[pos]);                               \
         ACC_T delta = READ_W(__ldg(&trace[idx]));                             \
@@ -180,6 +183,8 @@ void update_csr_on_post##SUFFIX(                                \
     BE::Tensor out_weight,                                \
     int64_t stream                                              \
 ) {                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                        \
+    BE_CHECK_CSR_INDICES_INT32(weight_indices);                 \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);    \
     int nse    = static_cast<int>(out_weight.size(0));          \
     int n_post = static_cast<int>(indptr.size(0)) - 1;          \
@@ -192,23 +197,25 @@ void update_csr_on_post##SUFFIX(                                \
                                    trace.data_ptr());           \
     const int32_t*    d_idx  = static_cast<const int32_t*>(     \
                                    indices.data_ptr());         \
-    const int32_t*    d_ipt  = static_cast<const int32_t*>(     \
-                                   indptr.data_ptr());          \
     const int32_t*    d_widx = static_cast<const int32_t*>(     \
                                    weight_indices.data_ptr());  \
     int avg_nnz = nse / n_post;                                 \
-    if (avg_nnz < 32) {                                         \
-        int grid = (n_post + 255) / 256;                        \
-        _csr_on_post_thread_kern##SUFFIX<<<grid, 256, 0, s>>>(  \
-            d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);    \
-    } else if (avg_nnz < 256) {                                 \
-        int grid = (n_post + 7) / 8;                            \
-        _csr_on_post_warp_kern##SUFFIX<<<grid, 256, 0, s>>>(    \
-            d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);    \
-    } else {                                                    \
-        _csr_on_post_block_kern##SUFFIX<<<n_post, 256, 0, s>>>( \
-            d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);    \
-    }                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {           \
+        const IndptrT* d_ipt = static_cast<const IndptrT*>(     \
+                                      indptr.data_ptr());       \
+        if (avg_nnz < 32) {                                     \
+            int grid = (n_post + 255) / 256;                    \
+            _csr_on_post_thread_kern##SUFFIX<<<grid, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);\
+        } else if (avg_nnz < 256) {                             \
+            int grid = (n_post + 7) / 8;                        \
+            _csr_on_post_warp_kern##SUFFIX<<<grid, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);\
+        } else {                                                \
+            _csr_on_post_block_kern##SUFFIX<<<n_post, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_idx, d_ipt, d_widx, n_post);\
+        }                                                       \
+    });                                                         \
 }
 
 // @BE update_csr_on_post_f32_bool

--- a/brainevent/_csr/plasticity_binary_on_pre.cu
+++ b/brainevent/_csr/plasticity_binary_on_pre.cu
@@ -56,13 +56,14 @@
 
 #define DEFINE_CSR_ON_PRE_THREAD(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                   READ_W, WRITE_W)                            \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                        \
 _csr_on_pre_thread_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                      \
     const SPIKE_T*   __restrict__ spike,                                      \
     const WEIGHT_T*  __restrict__ trace,                                      \
     const int32_t*   __restrict__ indices,                                    \
-    const int32_t*   __restrict__ indptr,                                     \
+    const IndptrT*   __restrict__ indptr,                                     \
     int n_pre                                                                 \
 ) {                                                                           \
     int row = (int)(blockIdx.x * (uint32_t)blockDim.x) + threadIdx.x;         \
@@ -71,9 +72,9 @@ _csr_on_pre_thread_kern##SUFFIX(                                              \
     unsigned int ballot = __ballot_sync(0xFFFFFFFF, my_active);               \
     if (ballot == 0) return;                                                  \
     if (!my_active) return;                                                   \
-    int start = __ldg(&indptr[row]);                                          \
-    int end   = __ldg(&indptr[row + 1]);                                      \
-    int pos = start;                                                          \
+    IndptrT start = __ldg(&indptr[row]);                                          \
+    IndptrT end   = __ldg(&indptr[row + 1]);                                      \
+    IndptrT pos = start;                                                          \
     if (pos + 4 <= end) {                                                     \
         int col0 = __ldg(&indices[pos]);                                      \
         int col1 = __ldg(&indices[pos + 1]);                                  \
@@ -118,13 +119,14 @@ _csr_on_pre_thread_kern##SUFFIX(                                              \
 
 #define DEFINE_CSR_ON_PRE_WARP(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                 READ_W, WRITE_W)                            \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                      \
 _csr_on_pre_warp_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                    \
     const SPIKE_T*   __restrict__ spike,                                    \
     const WEIGHT_T*  __restrict__ trace,                                    \
     const int32_t*   __restrict__ indices,                                  \
-    const int32_t*   __restrict__ indptr,                                   \
+    const IndptrT*   __restrict__ indptr,                                   \
     int n_pre                                                               \
 ) {                                                                         \
     int warp_id = (int)(blockIdx.x * (blockDim.x / 32u))                    \
@@ -134,9 +136,9 @@ _csr_on_pre_warp_kern##SUFFIX(                                              \
     bool active = IS_ACTIVE(__ldg(&spike[warp_id]));                        \
     if (__ballot_sync(0xFFFFFFFF, active) == 0) return;                     \
     if (!active) return;                                                    \
-    int start = __ldg(&indptr[warp_id]);                                    \
-    int end   = __ldg(&indptr[warp_id + 1]);                                \
-    int pos = start + lane;                                                 \
+    IndptrT start = __ldg(&indptr[warp_id]);                                    \
+    IndptrT end   = __ldg(&indptr[warp_id + 1]);                                \
+    IndptrT pos = start + lane;                                                 \
     for (; pos + 128 <= end; pos += 128) {                                  \
         int col0 = __ldg(&indices[pos]);                                    \
         int col1 = __ldg(&indices[pos + 32]);                               \
@@ -160,22 +162,23 @@ _csr_on_pre_warp_kern##SUFFIX(                                              \
 
 #define DEFINE_CSR_ON_PRE_BLOCK(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                  READ_W, WRITE_W)                            \
+template <typename IndptrT> \
 __global__ void __launch_bounds__(256)                                       \
 _csr_on_pre_block_kern##SUFFIX(                                              \
     WEIGHT_T*        __restrict__ out_w,                                     \
     const SPIKE_T*   __restrict__ spike,                                     \
     const WEIGHT_T*  __restrict__ trace,                                     \
-    const int32_t*   __restrict__ indptr,                                    \
+    const IndptrT*   __restrict__ indptr,                                    \
     const int32_t*   __restrict__ indices,                                   \
     int n_pre                                                                \
 ) {                                                                          \
     int row = (int)blockIdx.x;                                               \
     if (row >= n_pre) return;                                                \
     if (!IS_ACTIVE(__ldg(&spike[row]))) return;                              \
-    int start = __ldg(&indptr[row]);                                         \
-    int end   = __ldg(&indptr[row + 1]);                                     \
+    IndptrT start = __ldg(&indptr[row]);                                         \
+    IndptrT end   = __ldg(&indptr[row + 1]);                                     \
     int tid   = (int)threadIdx.x;                                            \
-    int pos = start + tid;                                                   \
+    IndptrT pos = start + tid;                                                   \
     for (; pos + 1024 <= end; pos += 1024) {                                 \
         int col0 = __ldg(&indices[pos]);                                     \
         int col1 = __ldg(&indices[pos + 256]);                               \
@@ -237,6 +240,7 @@ void update_csr_on_pre##SUFFIX(                               \
     BE::Tensor out_weight,                              \
     int64_t stream                                            \
 ) {                                                           \
+    BE_CHECK_CSR_INDICES_INT32(indices);                      \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);  \
     int nse   = static_cast<int>(out_weight.size(0));         \
     int n_pre = static_cast<int>(indptr.size(0)) - 1;         \
@@ -249,21 +253,23 @@ void update_csr_on_pre##SUFFIX(                               \
                                   trace.data_ptr());          \
     const int32_t*    d_idx = static_cast<const int32_t*>(    \
                                   indices.data_ptr());        \
-    const int32_t*    d_ipt = static_cast<const int32_t*>(    \
-                                  indptr.data_ptr());         \
     int avg_nnz = nse / n_pre;                                \
-    if (avg_nnz < 32) {                                       \
-        int grid = (n_pre + 255) / 256;                       \
-        _csr_on_pre_thread_kern##SUFFIX<<<grid, 256, 0, s>>>( \
-            d_w, d_spk, d_tr, d_idx, d_ipt, n_pre);           \
-    } else if (avg_nnz < 256) {                               \
-        int grid = (n_pre + 7) / 8;                           \
-        _csr_on_pre_warp_kern##SUFFIX<<<grid, 256, 0, s>>>(   \
-            d_w, d_spk, d_tr, d_idx, d_ipt, n_pre);           \
-    } else {                                                  \
-        _csr_on_pre_block_kern##SUFFIX<<<n_pre, 256, 0, s>>>( \
-            d_w, d_spk, d_tr, d_idx, d_ipt, n_pre);           \
-    }                                                         \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {         \
+        const IndptrT* d_ipt = static_cast<const IndptrT*>(   \
+                                      indptr.data_ptr());     \
+        if (avg_nnz < 32) {                                   \
+            int grid = (n_pre + 255) / 256;                   \
+            _csr_on_pre_thread_kern##SUFFIX<<<grid, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_idx, d_ipt, n_pre);       \
+        } else if (avg_nnz < 256) {                           \
+            int grid = (n_pre + 7) / 8;                       \
+            _csr_on_pre_warp_kern##SUFFIX<<<grid, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_idx, d_ipt, n_pre);       \
+        } else {                                              \
+            _csr_on_pre_block_kern##SUFFIX<<<n_pre, 256, 0, s>>>( \
+                d_w, d_spk, d_tr, d_ipt, d_idx, n_pre);       \
+        }                                                     \
+    });                                                       \
 }
 
 // @BE update_csr_on_pre_f32_bool

--- a/brainevent/_csr/slice.py
+++ b/brainevent/_csr/slice.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.interpreters import ad
 
-from brainevent._misc import namescope
+from brainevent._misc import _check_csr_cuda_structure_dtypes, namescope
 from brainevent._op import load_cuda_file
 from brainevent._op import numba_kernel, XLACustomKernel, general_batching_rule
 from brainevent._op.benchmark import BenchmarkConfig
@@ -180,6 +180,7 @@ def _csr_slice_rows_benchmark_data(*, platform):
 def _csr_slice_rows_cuda_kernel_generator(
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     load_cuda_file(
         Path(__file__).parent.joinpath('slice_csr_slice_rows.cu'),
         name='csr_slice_rows',
@@ -393,6 +394,7 @@ def _csr_slice_rows_grad_benchmark_data(*, platform):
 def _csr_slice_rows_grad_cuda_kernel_generator(
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     load_cuda_file(
         Path(__file__).parent.joinpath('slice_csr_slice_rows.cu'),
         name='csr_slice_rows',

--- a/brainevent/_csr/slice_csr_slice_rows.cu
+++ b/brainevent/_csr/slice_csr_slice_rows.cu
@@ -75,10 +75,11 @@ __device__ __forceinline__ int4 load_int4(const int32_t* __restrict__ ptr) {
 // =========================================================================
 
 #define DEFINE_SLICE_FWD_THREAD_HOMO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_thread_homo_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                  \
     const int32_t*  __restrict__ indices,                               \
-    const int32_t*  __restrict__ indptr,                                \
+    const IndptrT*  __restrict__ indptr,                                \
     const int32_t*  __restrict__ row_indices,                           \
     WEIGHT_T*       __restrict__ output,                                \
     int m, int n_cols, int num_selected                                 \
@@ -87,18 +88,19 @@ __global__ void _slice_fwd_thread_homo_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                      \
     int r = row_indices[k];                                             \
     if (r < 0 || r >= m) return;                                        \
-    int start = indptr[r], end = indptr[r + 1];                         \
+    IndptrT start = indptr[r], end = indptr[r + 1];                         \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                 \
     WEIGHT_T w = WRITE_W(READ_W(data[0]));                              \
-    for (int j = start; j < end; j++)                                   \
+    for (IndptrT j = start; j < end; j++)                                   \
         row_out[indices[j]] = w;                                        \
 }
 
 #define DEFINE_SLICE_FWD_THREAD_HETERO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_thread_hetero_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                    \
     const int32_t*  __restrict__ indices,                                 \
-    const int32_t*  __restrict__ indptr,                                  \
+    const IndptrT*  __restrict__ indptr,                                  \
     const int32_t*  __restrict__ row_indices,                             \
     WEIGHT_T*       __restrict__ output,                                  \
     int m, int n_cols, int num_selected                                   \
@@ -107,9 +109,9 @@ __global__ void _slice_fwd_thread_hetero_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                        \
     int r = row_indices[k];                                               \
     if (r < 0 || r >= m) return;                                          \
-    int start = indptr[r], end = indptr[r + 1];                           \
+    IndptrT start = indptr[r], end = indptr[r + 1];                           \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                   \
-    for (int j = start; j < end; j++)                                     \
+    for (IndptrT j = start; j < end; j++)                                     \
         row_out[indices[j]] = WRITE_W(READ_W(data[j]));                   \
 }
 
@@ -131,10 +133,11 @@ __global__ void _slice_fwd_thread_hetero_kern##SUFFIX(                    \
 // =========================================================================
 
 #define DEFINE_SLICE_FWD_WARP_HOMO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_warp_homo_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                \
     const int32_t*  __restrict__ indices,                             \
-    const int32_t*  __restrict__ indptr,                              \
+    const IndptrT*  __restrict__ indptr,                              \
     const int32_t*  __restrict__ row_indices,                         \
     WEIGHT_T*       __restrict__ output,                              \
     int m, int n_cols, int num_selected                               \
@@ -143,19 +146,20 @@ __global__ void _slice_fwd_warp_homo_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                    \
     int r = row_indices[k];                                           \
     if (r < 0 || r >= m) return;                                      \
-    int start = indptr[r], end = indptr[r + 1];                       \
+    IndptrT start = indptr[r], end = indptr[r + 1];                       \
     int lane = (int)threadIdx.x;   /* 0..31 */                        \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;               \
     WEIGHT_T w = WRITE_W(READ_W(data[0]));                            \
-    for (int j = start + lane; j < end; j += 32)                      \
+    for (IndptrT j = start + lane; j < end; j += 32)                      \
         row_out[indices[j]] = w;                                      \
 }
 
 #define DEFINE_SLICE_FWD_WARP_HETERO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_warp_hetero_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                  \
     const int32_t*  __restrict__ indices,                               \
-    const int32_t*  __restrict__ indptr,                                \
+    const IndptrT*  __restrict__ indptr,                                \
     const int32_t*  __restrict__ row_indices,                           \
     WEIGHT_T*       __restrict__ output,                                \
     int m, int n_cols, int num_selected                                 \
@@ -164,10 +168,10 @@ __global__ void _slice_fwd_warp_hetero_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                      \
     int r = row_indices[k];                                             \
     if (r < 0 || r >= m) return;                                        \
-    int start = indptr[r], end = indptr[r + 1];                         \
+    IndptrT start = indptr[r], end = indptr[r + 1];                         \
     int lane = (int)threadIdx.x;   /* 0..31 */                          \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                 \
-    for (int j = start + lane; j < end; j += 32) {                      \
+    for (IndptrT j = start + lane; j < end; j += 32) {                      \
         int col = __ldg(&indices[j]);                                   \
         WEIGHT_T val = WRITE_W(READ_W(__ldg(&data[j])));                \
         row_out[col] = val;                                             \
@@ -185,10 +189,11 @@ __global__ void _slice_fwd_warp_hetero_kern##SUFFIX(                    \
 // =========================================================================
 
 #define DEFINE_SLICE_FWD_BLOCK_HOMO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_block_homo_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                 \
     const int32_t*  __restrict__ indices,                              \
-    const int32_t*  __restrict__ indptr,                               \
+    const IndptrT*  __restrict__ indptr,                               \
     const int32_t*  __restrict__ row_indices,                          \
     WEIGHT_T*       __restrict__ output,                               \
     int m, int n_cols, int num_selected                                \
@@ -197,19 +202,20 @@ __global__ void _slice_fwd_block_homo_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                     \
     int r = row_indices[k];                                            \
     if (r < 0 || r >= m) return;                                       \
-    int start = indptr[r], end = indptr[r + 1];                        \
+    IndptrT start = indptr[r], end = indptr[r + 1];                        \
     int tid = (int)threadIdx.x;                                        \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                \
     WEIGHT_T w = WRITE_W(READ_W(data[0]));                             \
-    for (int j = start + tid; j < end; j += blockDim.x)                \
+    for (IndptrT j = start + tid; j < end; j += blockDim.x)                \
         row_out[indices[j]] = w;                                       \
 }
 
 #define DEFINE_SLICE_FWD_BLOCK_HETERO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _slice_fwd_block_hetero_kern##SUFFIX(                    \
     const WEIGHT_T* __restrict__ data,                                   \
     const int32_t*  __restrict__ indices,                                \
-    const int32_t*  __restrict__ indptr,                                 \
+    const IndptrT*  __restrict__ indptr,                                 \
     const int32_t*  __restrict__ row_indices,                            \
     WEIGHT_T*       __restrict__ output,                                 \
     int m, int n_cols, int num_selected                                  \
@@ -218,10 +224,10 @@ __global__ void _slice_fwd_block_hetero_kern##SUFFIX(                    \
     if (k >= num_selected) return;                                       \
     int r = row_indices[k];                                              \
     if (r < 0 || r >= m) return;                                         \
-    int start = indptr[r], end = indptr[r + 1];                          \
+    IndptrT start = indptr[r], end = indptr[r + 1];                          \
     int tid = (int)threadIdx.x;                                          \
     WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                  \
-    for (int j = start + tid; j < end; j += blockDim.x) {                \
+    for (IndptrT j = start + tid; j < end; j += blockDim.x) {                \
         int col = __ldg(&indices[j]);                                    \
         WEIGHT_T val = WRITE_W(READ_W(__ldg(&data[j])));                 \
         row_out[col] = val;                                              \
@@ -240,10 +246,11 @@ __global__ void _slice_fwd_block_hetero_kern##SUFFIX(                    \
 // =========================================================================
 
 #define DEFINE_SLICE_GRAD_THREAD(SUFFIX, WEIGHT_T, ATOMIC_ADD_W) \
+template <typename IndptrT> \
 __global__ void _slice_grad_thread_kern##SUFFIX(                 \
     const WEIGHT_T* __restrict__ ct,                             \
     const int32_t*  __restrict__ indices,                        \
-    const int32_t*  __restrict__ indptr,                         \
+    const IndptrT*  __restrict__ indptr,                         \
     const int32_t*  __restrict__ row_indices,                    \
     WEIGHT_T*       __restrict__ ct_data,                        \
     int m, int n_cols, int num_selected                          \
@@ -252,9 +259,9 @@ __global__ void _slice_grad_thread_kern##SUFFIX(                 \
     if (k >= num_selected) return;                               \
     int r = row_indices[k];                                      \
     if (r < 0 || r >= m) return;                                 \
-    int start = indptr[r], end = indptr[r + 1];                  \
+    IndptrT start = indptr[r], end = indptr[r + 1];                  \
     const WEIGHT_T* ct_row = ct + (ptrdiff_t)k * n_cols;         \
-    for (int j = start; j < end; j++)                            \
+    for (IndptrT j = start; j < end; j++)                            \
         ATOMIC_ADD_W(&ct_data[j], ct_row[indices[j]]);           \
 }
 
@@ -270,10 +277,11 @@ __global__ void _slice_grad_thread_kern##SUFFIX(                 \
 // =========================================================================
 
 #define DEFINE_SLICE_GRAD_WARP(SUFFIX, WEIGHT_T, ATOMIC_ADD_W) \
+template <typename IndptrT> \
 __global__ void _slice_grad_warp_kern##SUFFIX(                 \
     const WEIGHT_T* __restrict__ ct,                           \
     const int32_t*  __restrict__ indices,                      \
-    const int32_t*  __restrict__ indptr,                       \
+    const IndptrT*  __restrict__ indptr,                       \
     const int32_t*  __restrict__ row_indices,                  \
     WEIGHT_T*       __restrict__ ct_data,                      \
     int m, int n_cols, int num_selected                        \
@@ -282,10 +290,10 @@ __global__ void _slice_grad_warp_kern##SUFFIX(                 \
     if (k >= num_selected) return;                             \
     int r = row_indices[k];                                    \
     if (r < 0 || r >= m) return;                               \
-    int start = indptr[r], end = indptr[r + 1];                \
+    IndptrT start = indptr[r], end = indptr[r + 1];                \
     int lane = (int)threadIdx.x;                               \
     const WEIGHT_T* ct_row = ct + (ptrdiff_t)k * n_cols;       \
-    for (int j = start + lane; j < end; j += 32) {             \
+    for (IndptrT j = start + lane; j < end; j += 32) {             \
         int col = __ldg(&indices[j]);                          \
         WEIGHT_T val = __ldg(&ct_row[col]);                    \
         ATOMIC_ADD_W(&ct_data[j], val);                        \
@@ -382,6 +390,7 @@ void csr_slice_rows_fwd_homo_thread##SUFFIX(                                \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
@@ -389,13 +398,15 @@ void csr_slice_rows_fwd_homo_thread##SUFFIX(                                \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
     int blocks = (num_selected + 255) / 256;                                \
-    _slice_fwd_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(             \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(         \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward hetero thread ----
@@ -405,6 +416,7 @@ void csr_slice_rows_fwd_hetero_thread##SUFFIX(                              \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
@@ -412,13 +424,15 @@ void csr_slice_rows_fwd_hetero_thread##SUFFIX(                              \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
     int blocks = (num_selected + 255) / 256;                                \
-    _slice_fwd_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(           \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(       \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward homo warp ----
@@ -428,19 +442,22 @@ void csr_slice_rows_fwd_homo_warp##SUFFIX(                                  \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
     int n_cols        = static_cast<int>(output.size(1));                   \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
-    _slice_fwd_warp_homo_kern##SUFFIX<<<num_selected, 32, 0, s>>>(          \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_warp_homo_kern##SUFFIX<<<num_selected, 32, 0, s>>>(      \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward hetero warp ----
@@ -450,19 +467,22 @@ void csr_slice_rows_fwd_hetero_warp##SUFFIX(                                \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
     int n_cols        = static_cast<int>(output.size(1));                   \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
-    _slice_fwd_warp_hetero_kern##SUFFIX<<<num_selected, 32, 0, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_warp_hetero_kern##SUFFIX<<<num_selected, 32, 0, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward homo block ----
@@ -472,19 +492,22 @@ void csr_slice_rows_fwd_homo_block##SUFFIX(                                 \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
     int n_cols        = static_cast<int>(output.size(1));                   \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
-    _slice_fwd_block_homo_kern##SUFFIX<<<num_selected, 256, 0, s>>>(        \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_block_homo_kern##SUFFIX<<<num_selected, 256, 0, s>>>(    \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward hetero block ----
@@ -494,19 +517,22 @@ void csr_slice_rows_fwd_hetero_block##SUFFIX(                               \
     const BE::Tensor indptr, const BE::Tensor row_indices,                  \
     BE::Tensor output, int64_t stream                                       \
 ) {                                                                         \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);             \
     int m             = static_cast<int>(indptr.size(0)) - 1;               \
     int num_selected  = static_cast<int>(row_indices.size(0));              \
     int n_cols        = static_cast<int>(output.size(1));                   \
     size_t out_bytes  = (size_t)num_selected * n_cols * sizeof(WEIGHT_C_T); \
     cudaMemsetAsync(output.data_ptr(), 0, out_bytes, s);                    \
-    _slice_fwd_block_hetero_kern##SUFFIX<<<num_selected, 256, 0, s>>>(      \
-        static_cast<const WEIGHT_C_T*>(data.data_ptr()),                    \
-        static_cast<const int32_t*>(indices.data_ptr()),                    \
-        static_cast<const int32_t*>(indptr.data_ptr()),                     \
-        static_cast<const int32_t*>(row_indices.data_ptr()),                \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()),                        \
-        m, n_cols, num_selected);                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
+        _slice_fwd_block_hetero_kern##SUFFIX<<<num_selected, 256, 0, s>>>(  \
+            static_cast<const WEIGHT_C_T*>(data.data_ptr()),                \
+            static_cast<const int32_t*>(indices.data_ptr()),                \
+            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
+            static_cast<const int32_t*>(row_indices.data_ptr()),            \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()),                    \
+            m, n_cols, num_selected);                                       \
+    });                                                                     \
 }
 
 // ---- FFI macro: forward homo auto (selects thread/warp/block by avg_nnz) ----
@@ -516,6 +542,7 @@ void csr_slice_rows_fwd_homo_auto##SUFFIX(                                      
     const BE::Tensor indptr, const BE::Tensor row_indices,                              \
     BE::Tensor output, int64_t stream                                                   \
 ) {                                                                                     \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                                \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);                         \
     int m             = static_cast<int>(indptr.size(0)) - 1;                           \
     int nnz           = static_cast<int>(indices.size(0));                              \
@@ -526,23 +553,25 @@ void csr_slice_rows_fwd_homo_auto##SUFFIX(                                      
     float avg_nnz = (m > 0) ? (float)nnz / m : 0.0f;                                    \
     const WEIGHT_C_T* d_data     = static_cast<const WEIGHT_C_T*>(data.data_ptr());     \
     const int32_t*    d_indices  = static_cast<const int32_t*>(indices.data_ptr());     \
-    const int32_t*    d_indptr   = static_cast<const int32_t*>(indptr.data_ptr());      \
     const int32_t*    d_rows     = static_cast<const int32_t*>(row_indices.data_ptr()); \
     WEIGHT_C_T*       d_output   = static_cast<WEIGHT_C_T*>(output.data_ptr());         \
-    if (avg_nnz < 8.0f) {                                                               \
-        int blocks = (num_selected + 255) / 256;                                        \
-        _slice_fwd_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(                     \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    } else if (avg_nnz < 512.0f) {                                                      \
-        _slice_fwd_warp_homo_kern##SUFFIX<<<num_selected, 32, 0, s>>>(                  \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    } else {                                                                            \
-        _slice_fwd_block_homo_kern##SUFFIX<<<num_selected, 256, 0, s>>>(                \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    }                                                                                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                                   \
+        const IndptrT* d_indptr = static_cast<const IndptrT*>(indptr.data_ptr());       \
+        if (avg_nnz < 8.0f) {                                                           \
+            int blocks = (num_selected + 255) / 256;                                    \
+            _slice_fwd_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(                 \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        } else if (avg_nnz < 512.0f) {                                                  \
+            _slice_fwd_warp_homo_kern##SUFFIX<<<num_selected, 32, 0, s>>>(              \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        } else {                                                                        \
+            _slice_fwd_block_homo_kern##SUFFIX<<<num_selected, 256, 0, s>>>(            \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        }                                                                               \
+    });                                                                                 \
 }
 
 // ---- FFI macro: forward hetero auto (selects thread/warp/block by avg_nnz) ----
@@ -552,6 +581,7 @@ void csr_slice_rows_fwd_hetero_auto##SUFFIX(                                    
     const BE::Tensor indptr, const BE::Tensor row_indices,                              \
     BE::Tensor output, int64_t stream                                                   \
 ) {                                                                                     \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                                \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);                         \
     int m             = static_cast<int>(indptr.size(0)) - 1;                           \
     int nnz           = static_cast<int>(indices.size(0));                              \
@@ -562,23 +592,25 @@ void csr_slice_rows_fwd_hetero_auto##SUFFIX(                                    
     float avg_nnz = (m > 0) ? (float)nnz / m : 0.0f;                                    \
     const WEIGHT_C_T* d_data     = static_cast<const WEIGHT_C_T*>(data.data_ptr());     \
     const int32_t*    d_indices  = static_cast<const int32_t*>(indices.data_ptr());     \
-    const int32_t*    d_indptr   = static_cast<const int32_t*>(indptr.data_ptr());      \
     const int32_t*    d_rows     = static_cast<const int32_t*>(row_indices.data_ptr()); \
     WEIGHT_C_T*       d_output   = static_cast<WEIGHT_C_T*>(output.data_ptr());         \
-    if (avg_nnz < 8.0f) {                                                               \
-        int blocks = (num_selected + 255) / 256;                                        \
-        _slice_fwd_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(                   \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    } else if (avg_nnz < 512.0f) {                                                      \
-        _slice_fwd_warp_hetero_kern##SUFFIX<<<num_selected, 32, 0, s>>>(                \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    } else {                                                                            \
-        _slice_fwd_block_hetero_kern##SUFFIX<<<num_selected, 256, 0, s>>>(              \
-            d_data, d_indices, d_indptr, d_rows, d_output,                              \
-            m, n_cols, num_selected);                                                   \
-    }                                                                                   \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                                   \
+        const IndptrT* d_indptr = static_cast<const IndptrT*>(indptr.data_ptr());       \
+        if (avg_nnz < 8.0f) {                                                           \
+            int blocks = (num_selected + 255) / 256;                                    \
+            _slice_fwd_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(               \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        } else if (avg_nnz < 512.0f) {                                                  \
+            _slice_fwd_warp_hetero_kern##SUFFIX<<<num_selected, 32, 0, s>>>(            \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        } else {                                                                        \
+            _slice_fwd_block_hetero_kern##SUFFIX<<<num_selected, 256, 0, s>>>(          \
+                d_data, d_indices, d_indptr, d_rows, d_output,                          \
+                m, n_cols, num_selected);                                               \
+        }                                                                               \
+    });                                                                                 \
 }
 
 // ---- FFI macro: backward thread ----
@@ -588,6 +620,7 @@ void csr_slice_rows_grad_thread##SUFFIX(                        \
     const BE::Tensor indptr, const BE::Tensor row_indices,      \
     BE::Tensor ct_data, int64_t stream                    \
 ) {                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                        \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream); \
     int m             = static_cast<int>(indptr.size(0)) - 1;   \
     int num_selected  = static_cast<int>(row_indices.size(0));  \
@@ -596,13 +629,15 @@ void csr_slice_rows_grad_thread##SUFFIX(                        \
     size_t ct_bytes   = (size_t)nnz * sizeof(WEIGHT_C_T);       \
     cudaMemsetAsync(ct_data.data_ptr(), 0, ct_bytes, s);        \
     int blocks = (num_selected + 255) / 256;                    \
-    _slice_grad_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(     \
-        static_cast<const WEIGHT_C_T*>(ct.data_ptr()),          \
-        static_cast<const int32_t*>(indices.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),         \
-        static_cast<const int32_t*>(row_indices.data_ptr()),    \
-        static_cast<WEIGHT_C_T*>(ct_data.data_ptr()),           \
-        m, n_cols, num_selected);                               \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {           \
+        _slice_grad_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(ct.data_ptr()),      \
+            static_cast<const int32_t*>(indices.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),     \
+            static_cast<const int32_t*>(row_indices.data_ptr()),\
+            static_cast<WEIGHT_C_T*>(ct_data.data_ptr()),       \
+            m, n_cols, num_selected);                           \
+    });                                                         \
 }
 
 // ---- FFI macro: backward warp ----
@@ -612,6 +647,7 @@ void csr_slice_rows_grad_warp##SUFFIX(                          \
     const BE::Tensor indptr, const BE::Tensor row_indices,      \
     BE::Tensor ct_data, int64_t stream                    \
 ) {                                                             \
+    BE_CHECK_CSR_INDICES_INT32(indices);                        \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream); \
     int m             = static_cast<int>(indptr.size(0)) - 1;   \
     int num_selected  = static_cast<int>(row_indices.size(0));  \
@@ -619,13 +655,15 @@ void csr_slice_rows_grad_warp##SUFFIX(                          \
     int nnz           = static_cast<int>(ct_data.size(0));      \
     size_t ct_bytes   = (size_t)nnz * sizeof(WEIGHT_C_T);       \
     cudaMemsetAsync(ct_data.data_ptr(), 0, ct_bytes, s);        \
-    _slice_grad_warp_kern##SUFFIX<<<num_selected, 32, 0, s>>>(  \
-        static_cast<const WEIGHT_C_T*>(ct.data_ptr()),          \
-        static_cast<const int32_t*>(indices.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),         \
-        static_cast<const int32_t*>(row_indices.data_ptr()),    \
-        static_cast<WEIGHT_C_T*>(ct_data.data_ptr()),           \
-        m, n_cols, num_selected);                               \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {           \
+        _slice_grad_warp_kern##SUFFIX<<<num_selected, 32, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(ct.data_ptr()),      \
+            static_cast<const int32_t*>(indices.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),     \
+            static_cast<const int32_t*>(row_indices.data_ptr()),\
+            static_cast<WEIGHT_C_T*>(ct_data.data_ptr()),       \
+            m, n_cols, num_selected);                           \
+    });                                                         \
 }
 
 // ---- FFI macro: backward auto (selects thread/warp by avg_nnz) ----
@@ -635,6 +673,7 @@ void csr_slice_rows_grad_auto##SUFFIX(                                          
     const BE::Tensor indptr, const BE::Tensor row_indices,                             \
     BE::Tensor ct_data, int64_t stream                                           \
 ) {                                                                                    \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                               \
     cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);                        \
     int m             = static_cast<int>(indptr.size(0)) - 1;                          \
     int nnz           = static_cast<int>(indices.size(0));                             \
@@ -645,19 +684,21 @@ void csr_slice_rows_grad_auto##SUFFIX(                                          
     float avg_nnz = (m > 0) ? (float)nnz / m : 0.0f;                                   \
     const WEIGHT_C_T* d_ct      = static_cast<const WEIGHT_C_T*>(ct.data_ptr());       \
     const int32_t*    d_indices = static_cast<const int32_t*>(indices.data_ptr());     \
-    const int32_t*    d_indptr  = static_cast<const int32_t*>(indptr.data_ptr());      \
     const int32_t*    d_rows    = static_cast<const int32_t*>(row_indices.data_ptr()); \
     WEIGHT_C_T*       d_ctdata  = static_cast<WEIGHT_C_T*>(ct_data.data_ptr());        \
-    if (avg_nnz < 8.0f) {                                                              \
-        int blocks = (num_selected + 255) / 256;                                       \
-        _slice_grad_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(                        \
-            d_ct, d_indices, d_indptr, d_rows, d_ctdata,                               \
-            m, n_cols, num_selected);                                                  \
-    } else {                                                                           \
-        _slice_grad_warp_kern##SUFFIX<<<num_selected, 32, 0, s>>>(                     \
-            d_ct, d_indices, d_indptr, d_rows, d_ctdata,                               \
-            m, n_cols, num_selected);                                                  \
-    }                                                                                  \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                                  \
+        const IndptrT* d_indptr = static_cast<const IndptrT*>(indptr.data_ptr());      \
+        if (avg_nnz < 8.0f) {                                                          \
+            int blocks = (num_selected + 255) / 256;                                   \
+            _slice_grad_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(                    \
+                d_ct, d_indices, d_indptr, d_rows, d_ctdata,                           \
+                m, n_cols, num_selected);                                              \
+        } else {                                                                       \
+            _slice_grad_warp_kern##SUFFIX<<<num_selected, 32, 0, s>>>(                 \
+                d_ct, d_indices, d_indptr, d_rows, d_ctdata,                           \
+                m, n_cols, num_selected);                                              \
+        }                                                                              \
+    });                                                                                \
 }
 
 // =========================================================================

--- a/brainevent/_csr/yw2y.cu
+++ b/brainevent/_csr/yw2y.cu
@@ -102,7 +102,8 @@
 // then row = p - 1.
 // =========================================================================
 
-__device__ __inline__ int find_row_bsearch(const int32_t* __restrict__ indptr, int m, int j) {
+template <typename IndptrT>
+__device__ __inline__ int find_row_bsearch(const IndptrT* __restrict__ indptr, int m, int64_t j) {
     int lo = 0, hi = m;
     while (lo < hi) {
         int mid = (lo + hi) >> 1;
@@ -126,18 +127,19 @@ __device__ __inline__ int find_row_bsearch(const int32_t* __restrict__ indptr, i
 // =========================================================================
 
 #define DEFINE_YW2Y_NT_ROW_THREAD(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _yw2y_nt_row_thread_kern##SUFFIX(                           \
     const WEIGHT_T* __restrict__ y,                                         \
     const WEIGHT_T* __restrict__ w,                                         \
-    const int32_t*  __restrict__ indptr,                                    \
+    const IndptrT*  __restrict__ indptr,                                    \
     WEIGHT_T*       __restrict__ output,                                    \
     int m                                                                   \
 ) {                                                                         \
     int row = blockIdx.x * blockDim.x + threadIdx.x;                        \
     if (row >= m) return;                                                   \
     ACC_T y_val = READ_W(y[row]);  /* load once; reused for all row j */    \
-    int start = indptr[row], end = indptr[row + 1];                         \
-    for (int j = start; j < end; j++) {                                     \
+    IndptrT start = indptr[row], end = indptr[row + 1];                         \
+    for (IndptrT j = start; j < end; j++) {                                     \
         output[j] = WRITE_W(READ_W(w[j]) * y_val);                          \
     }                                                                       \
 }
@@ -156,10 +158,11 @@ __global__ void _yw2y_nt_row_thread_kern##SUFFIX(                           \
 // =========================================================================
 
 #define DEFINE_YW2Y_NT_ROW_WARP(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W)        \
+template <typename IndptrT> \
 __global__ void _yw2y_nt_row_warp_kern##SUFFIX(                                  \
     const WEIGHT_T* __restrict__ y,                                              \
     const WEIGHT_T* __restrict__ w,                                              \
-    const int32_t*  __restrict__ indptr,                                         \
+    const IndptrT*  __restrict__ indptr,                                         \
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
 ) {                                                                              \
@@ -169,10 +172,10 @@ __global__ void _yw2y_nt_row_warp_kern##SUFFIX(                                 
     /* On modern NVIDIA GPUs this is served from L1 with a single cache line  */ \
     /* fetch; no extra transactions compared to a single-thread read.         */ \
     ACC_T y_val = READ_W(y[row]);                                                \
-    int start = indptr[row], end = indptr[row + 1];                              \
+    IndptrT start = indptr[row], end = indptr[row + 1];                              \
     /* Warp-stride loop: threads handle j = start+tid, start+tid+32, ...      */ \
     /* Consecutive threads write consecutive output elements -> coalesced.    */ \
-    for (int j = start + (int)threadIdx.x; j < end; j += 32) {                   \
+    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                   \
         output[j] = WRITE_W(READ_W(w[j]) * y_val);                               \
     }                                                                            \
 }
@@ -224,10 +227,11 @@ __global__ void _yw2y_nt_row_warp_kern##SUFFIX(                                 
 // =========================================================================
 
 #define DEFINE_YW2Y_NT_NZ_THREAD(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W) \
+template <typename IndptrT> \
 __global__ void _yw2y_nt_nz_thread_kern##SUFFIX(                           \
     const WEIGHT_T* __restrict__ y,                                        \
     const WEIGHT_T* __restrict__ w,                                        \
-    const int32_t*  __restrict__ indptr,                                   \
+    const IndptrT*  __restrict__ indptr,                                   \
     WEIGHT_T*       __restrict__ output,                                   \
     int m, int nse                                                         \
 ) {                                                                        \
@@ -241,7 +245,7 @@ __global__ void _yw2y_nt_nz_thread_kern##SUFFIX(                           \
     /* Process up to VEC_SIZE elements, handling boundary */               \
     int row = find_row_bsearch(indptr, m, j_base);                         \
     ACC_T y_val = READ_W(y[row]);                                          \
-    int row_end = indptr[row + 1];                                         \
+    IndptrT row_end = indptr[row + 1];                                         \
                                                                            \
     _Pragma("unroll")                                                      \
     for (int i = 0; i < VEC_SIZE; i++) {                                   \
@@ -306,13 +310,16 @@ void csrmv_yw2y_nt_row_thread##SUFFIX(                       \
     BE::Tensor output,  int64_t stream                       \
 ) {                                                          \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream); \
+    BE_CHECK_CSR_INDICES_INT32(indices);                     \
     int m     = static_cast<int>(indptr.size(0)) - 1;        \
     int blocks = (m + 255) / 256;                            \
-    _yw2y_nt_row_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
-        static_cast<const WEIGHT_C_T*>(y.data_ptr()),        \
-        static_cast<const WEIGHT_C_T*>(w.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),      \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);     \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {        \
+        _yw2y_nt_row_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(y.data_ptr()),    \
+            static_cast<const WEIGHT_C_T*>(w.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),  \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m); \
+    });                                                      \
 }
 
 // ---- FFI macro: NT row-warp kernel ----
@@ -323,12 +330,15 @@ void csrmv_yw2y_nt_row_warp##SUFFIX(                         \
     BE::Tensor output,  int64_t stream                       \
 ) {                                                          \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream); \
+    BE_CHECK_CSR_INDICES_INT32(indices);                     \
     int m = static_cast<int>(indptr.size(0)) - 1;            \
-    _yw2y_nt_row_warp_kern##SUFFIX<<<m, 32, 0, s>>>(         \
-        static_cast<const WEIGHT_C_T*>(y.data_ptr()),        \
-        static_cast<const WEIGHT_C_T*>(w.data_ptr()),        \
-        static_cast<const int32_t*>(indptr.data_ptr()),      \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m);     \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {        \
+        _yw2y_nt_row_warp_kern##SUFFIX<<<m, 32, 0, s>>>(     \
+            static_cast<const WEIGHT_C_T*>(y.data_ptr()),    \
+            static_cast<const WEIGHT_C_T*>(w.data_ptr()),    \
+            static_cast<const IndptrT*>(indptr.data_ptr()),  \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m); \
+    });                                                      \
 }
 
 // ---- FFI macro: NT nz-thread kernel ----
@@ -339,6 +349,7 @@ void csrmv_yw2y_nt_nz_thread##SUFFIX(                              \
     BE::Tensor output,  int64_t stream                             \
 ) {                                                                \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);       \
+    BE_CHECK_CSR_INDICES_INT32(indices);                           \
     int m   = static_cast<int>(indptr.size(0)) - 1;                \
     int nse = static_cast<int>(w.size(0));                         \
     /* Each thread processes VEC_SIZE=4 elements */                \
@@ -346,11 +357,13 @@ void csrmv_yw2y_nt_nz_thread##SUFFIX(                              \
     const int BLOCK_SIZE = 256;                                    \
     int total_threads = (nse + VEC_SIZE - 1) / VEC_SIZE;           \
     int blocks = (total_threads + BLOCK_SIZE - 1) / BLOCK_SIZE;    \
-    _yw2y_nt_nz_thread_kern##SUFFIX<<<blocks, BLOCK_SIZE, 0, s>>>( \
-        static_cast<const WEIGHT_C_T*>(y.data_ptr()),              \
-        static_cast<const WEIGHT_C_T*>(w.data_ptr()),              \
-        static_cast<const int32_t*>(indptr.data_ptr()),            \
-        static_cast<WEIGHT_C_T*>(output.data_ptr()), m, nse);      \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {              \
+        _yw2y_nt_nz_thread_kern##SUFFIX<<<blocks, BLOCK_SIZE, 0, s>>>( \
+            static_cast<const WEIGHT_C_T*>(y.data_ptr()),          \
+            static_cast<const WEIGHT_C_T*>(w.data_ptr()),          \
+            static_cast<const IndptrT*>(indptr.data_ptr()),        \
+            static_cast<WEIGHT_C_T*>(output.data_ptr()), m, nse);  \
+    });                                                            \
 }
 
 // ---- FFI macro: NT auto-dispatch (row_thread / row_warp / nz_thread) ----
@@ -367,25 +380,27 @@ void csrmv_yw2y_nt_auto##SUFFIX(                                                
     BE::Tensor output,  int64_t stream                                                          \
 ) {                                                                                             \
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);                                    \
+    BE_CHECK_CSR_INDICES_INT32(indices);                                                        \
     int m     = static_cast<int>(indptr.size(0)) - 1;                                           \
     int nse   = static_cast<int>(w.size(0));                                                    \
     int avg_nnz = (m > 0) ? (nse / m) : 0;                                                      \
     const WEIGHT_C_T* d_y   = static_cast<const WEIGHT_C_T*>(y.data_ptr());                     \
     const WEIGHT_C_T* d_w   = static_cast<const WEIGHT_C_T*>(w.data_ptr());                     \
-    const int32_t*    d_ptr = static_cast<const int32_t*>(indptr.data_ptr());                   \
     WEIGHT_C_T*       d_out = static_cast<WEIGHT_C_T*>(output.data_ptr());                      \
-    if (avg_nnz < 8) {                                                                          \
-        int blocks = (m + 255) / 256;                                                           \
-        _yw2y_nt_row_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m);     \
-    } else if (avg_nnz < 512) {                                                                 \
-        _yw2y_nt_row_warp_kern##SUFFIX<<<m, 32, 0, s>>>(d_y, d_w, d_ptr, d_out, m);             \
-    } else {                                                                                    \
-        /* NT_nz_thread: each thread processes VEC_SIZE=4 elements */                           \
-        const int VEC_SIZE = 4;                                                                 \
-        int total_threads = (nse + VEC_SIZE - 1) / VEC_SIZE;                                    \
-        int blocks = (total_threads + 255) / 256;                                               \
-        _yw2y_nt_nz_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m, nse); \
-    }                                                                                           \
+    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                                           \
+        const IndptrT* d_ptr = static_cast<const IndptrT*>(indptr.data_ptr());                  \
+        if (avg_nnz < 8) {                                                                      \
+            int blocks = (m + 255) / 256;                                                       \
+            _yw2y_nt_row_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m); \
+        } else if (avg_nnz < 512) {                                                             \
+            _yw2y_nt_row_warp_kern##SUFFIX<<<m, 32, 0, s>>>(d_y, d_w, d_ptr, d_out, m);         \
+        } else {                                                                                \
+            const int VEC_SIZE = 4;                                                             \
+            int total_threads = (nse + VEC_SIZE - 1) / VEC_SIZE;                                \
+            int blocks = (total_threads + 255) / 256;                                           \
+            _yw2y_nt_nz_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m, nse); \
+        }                                                                                       \
+    });                                                                                         \
 }
 
 // =========================================================================

--- a/brainevent/_csr/yw2y.py
+++ b/brainevent/_csr/yw2y.py
@@ -21,7 +21,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from brainevent._misc import namescope
+from brainevent._misc import _check_csr_cuda_structure_dtypes, namescope
 from brainevent._op import load_cuda_file
 from brainevent._op import numba_kernel, XLACustomKernel
 from brainevent._op.benchmark import BenchmarkConfig
@@ -268,6 +268,7 @@ def _csrmv_yw2y_cuda_kernel(
     w_info: jax.ShapeDtypeStruct,
     **kwargs,
 ):
+    _check_csr_cuda_structure_dtypes(kwargs['indices_info'], kwargs['indptr_info'])
     # Transpose path: ``out[j] = w[j] * y[indices[j]]`` is an embarrassingly
     # parallel gather-multiply whose cost is dominated by the irreducible
     # scattered read of ``y[indices]``.  XLA's gather matches the hand-written

--- a/brainevent/_misc.py
+++ b/brainevent/_misc.py
@@ -1539,7 +1539,7 @@ def _csr_to_csc_index_gpu_column_block(
             )
 
             csc_indices_np[base:end] = np.asarray(local_rows_dev, dtype=coord_dtype)
-            if include_perm:
+            if perm_np is not None:
                 perm_np[base:end] = np.asarray(local_perm_dev, dtype=offset_dtype)
 
         if isinstance(csr_indptr, np.ndarray) and isinstance(csr_indices, np.ndarray):

--- a/brainevent/_misc.py
+++ b/brainevent/_misc.py
@@ -29,6 +29,23 @@ from ._compatible_import import Tracer
 
 # -*- coding: utf-8 -*-
 
+_INT32_MAX = np.iinfo(np.int32).max
+
+
+def _normalize_dtype(dtype):
+    return np.dtype(dtype)
+
+
+def _coordinate_index_dtype(dtype):
+    dtype = _normalize_dtype(dtype)
+    return np.int64 if dtype == np.dtype(np.int64) else np.int32
+
+
+def _offset_index_dtype(nse: int, preferred=None):
+    if preferred is not None and _normalize_dtype(preferred) == np.dtype(np.int64):
+        return np.int64
+    return np.int64 if int(nse) > _INT32_MAX else np.int32
+
 
 def is_known_type(x):
     """Check whether an object is a recognized array or event type.
@@ -179,6 +196,43 @@ def _csr_to_coo(
         Column indices in COO format (identical to *indices*).
     """
     return jnp.cumsum(jnp.zeros_like(indices).at[indptr].add(1)) - 1, indices
+
+
+_CSR_SIGNED_INDEX_DTYPES = (jnp.dtype(jnp.int32), jnp.dtype(jnp.int64))
+
+
+def _check_csr_structure_dtypes(indices, indptr) -> None:
+    """Validate public CSR structure dtypes.
+
+    CSR kernels support signed int32/int64 structure arrays.  Mixed precision is
+    allowed only as ``indices=int32, indptr=int64`` so CUDA kernels can keep
+    column indices compact while row offsets grow past int32.
+    """
+    indices_dtype = jnp.dtype(indices.dtype)
+    indptr_dtype = jnp.dtype(indptr.dtype)
+    assert indices_dtype in _CSR_SIGNED_INDEX_DTYPES, "Indices must be signed int32 or int64."
+    assert indptr_dtype in _CSR_SIGNED_INDEX_DTYPES, "Indptr must be signed int32 or int64."
+    same_dtype = indices_dtype == indptr_dtype
+    mixed_cuda_dtype = indices_dtype == jnp.dtype(jnp.int32) and indptr_dtype == jnp.dtype(jnp.int64)
+    assert same_dtype or mixed_cuda_dtype, (
+        "Indices and indptr must have the same dtype, or use indices=int32 with indptr=int64."
+    )
+
+
+def _check_csr_cuda_structure_dtypes(indices_info, indptr_info) -> None:
+    """Validate the raw CUDA CSR ABI: int32 indices and int32/int64 indptr."""
+    indices_dtype = jnp.dtype(indices_info.dtype)
+    indptr_dtype = jnp.dtype(indptr_info.dtype)
+    if indices_dtype != jnp.dtype(jnp.int32):
+        raise TypeError(
+            "CSR cuda_raw kernels require indices with dtype int32; "
+            f"got indices dtype {indices_dtype}."
+        )
+    if indptr_dtype not in _CSR_SIGNED_INDEX_DTYPES:
+        raise TypeError(
+            "CSR cuda_raw kernels require indptr with dtype int32 or int64; "
+            f"got indptr dtype {indptr_dtype}."
+        )
 
 
 def _csr_todense(
@@ -1301,18 +1355,219 @@ def fixed_conn_num_to_csc(
     return weights.reshape(-1)[perm], csc_indices, csc_indptr
 
 
+def _csr_to_csc_index_via_coo(
+    csr_indptr: Union[jax.Array, np.ndarray],
+    csr_indices: Union[jax.Array, np.ndarray],
+    *,
+    shape: Tuple[int, int],
+    include_perm: bool = True,
+):
+    """Convert CSR indices to CSC indices through the legacy COO path."""
+    pre_ids, post_ids = csr_to_coo_index(csr_indptr, csr_indices)
+    csc_indptr, csc_indices, post_positions = coo_to_csc_index(pre_ids, post_ids, shape=shape)
+    if not include_perm:
+        post_positions = None
+    return csc_indptr, csc_indices, post_positions
+
+
+def _csr_to_csc_index_numpy(
+    csr_indptr: Union[jax.Array, np.ndarray],
+    csr_indices: Union[jax.Array, np.ndarray],
+    *,
+    shape: Tuple[int, int],
+    include_perm: bool = True,
+):
+    """Convert CSR indices to CSC on CPU with NumPy, then restore array type."""
+    n_post = shape[1]
+    coord_dtype = _coordinate_index_dtype(getattr(csr_indices, 'dtype', np.int32))
+    nse = getattr(csr_indices, 'size', None)
+    if nse is None:
+        nse = len(csr_indices)
+    offset_dtype = _offset_index_dtype(nse, getattr(csr_indptr, 'dtype', None))
+
+    csr_indptr_np = np.asarray(csr_indptr)
+    csr_indices_np = np.asarray(csr_indices)
+
+    counts = np.bincount(csr_indices_np, minlength=n_post).astype(offset_dtype, copy=False)
+    csc_indptr_np = np.empty(n_post + 1, dtype=offset_dtype)
+    csc_indptr_np[0] = 0
+    np.cumsum(counts, dtype=offset_dtype, out=csc_indptr_np[1:])
+
+    order_np = np.argsort(csr_indices_np, kind='stable')
+    order_np = np.asarray(order_np, dtype=offset_dtype)
+    csc_indices_np = np.searchsorted(csr_indptr_np, order_np, side='right') - 1
+    csc_indices_np = np.asarray(csc_indices_np, dtype=coord_dtype)
+    perm_np = order_np if include_perm else None
+
+    if isinstance(csr_indptr, np.ndarray) and isinstance(csr_indices, np.ndarray):
+        return csc_indptr_np, csc_indices_np, perm_np
+
+    old_x64 = jax.config.jax_enable_x64
+    needs_x64 = _normalize_dtype(offset_dtype) == np.dtype(np.int64)
+    if needs_x64 and not old_x64:
+        jax.config.update('jax_enable_x64', True)
+    try:
+        csc_indptr = jnp.asarray(csc_indptr_np)
+        csc_indices = jnp.asarray(csc_indices_np)
+        perm = None if perm_np is None else jnp.asarray(perm_np)
+        return csc_indptr, csc_indices, perm
+    finally:
+        if needs_x64 and not old_x64:
+            jax.config.update('jax_enable_x64', False)
+
+
+_CSR_TO_CSC_CUDA_MODULE = None
+
+
+def _load_csr_to_csc_cuda_module():
+    global _CSR_TO_CSC_CUDA_MODULE
+    if _CSR_TO_CSC_CUDA_MODULE is None:
+        from pathlib import Path
+
+        from ._op import load_cuda_file
+
+        _CSR_TO_CSC_CUDA_MODULE = load_cuda_file(
+            Path(__file__).resolve().parent / "_csr" / "csr_to_csc.cu",
+            name="csr_to_csc",
+        )
+    return _CSR_TO_CSC_CUDA_MODULE
+
+
+def _csr_to_csc_index_gpu_column_block(
+    csr_indptr: Union[jax.Array, np.ndarray],
+    csr_indices: Union[jax.Array, np.ndarray],
+    *,
+    shape: Tuple[int, int],
+    include_perm: bool = True,
+    column_block_size: int = 4096,
+):
+    """Convert CSR indices to CSC using CUDA column blocks and CPU stitching."""
+    n_post = shape[1]
+    try:
+        column_block_size = int(column_block_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("column_block_size must be a positive integer") from exc
+    if column_block_size <= 0:
+        raise ValueError("column_block_size must be a positive integer")
+
+    coord_dtype = _coordinate_index_dtype(getattr(csr_indices, 'dtype', np.int32))
+    nse = getattr(csr_indices, 'size', None)
+    if nse is None:
+        nse = len(csr_indices)
+    nse = int(nse)
+    offset_dtype = _offset_index_dtype(nse, getattr(csr_indptr, 'dtype', None))
+
+    old_x64 = jax.config.jax_enable_x64
+    needs_x64 = (
+        _normalize_dtype(offset_dtype) == np.dtype(np.int64) or
+        _normalize_dtype(coord_dtype) == np.dtype(np.int64)
+    )
+    if needs_x64 and not old_x64:
+        jax.config.update('jax_enable_x64', True)
+
+    try:
+        try:
+            gpu_device = jax.devices("gpu")[0]
+            _load_csr_to_csc_cuda_module()
+        except Exception:
+            return _csr_to_csc_index_numpy(
+                csr_indptr,
+                csr_indices,
+                shape=shape,
+                include_perm=include_perm,
+            )
+
+        csr_indices_dev = jax.device_put(
+            jnp.asarray(csr_indices, dtype=coord_dtype),
+            gpu_device,
+        )
+        csr_indptr_dev = jax.device_put(
+            jnp.asarray(csr_indptr, dtype=offset_dtype),
+            gpu_device,
+        )
+
+        counts_dev = jax.ffi.ffi_call(
+            "csr_to_csc.csr_to_csc_count",
+            jax.ShapeDtypeStruct((n_post,), offset_dtype),
+        )(csr_indices_dev, csr_indptr_dev)
+        counts_np = np.asarray(counts_dev, dtype=offset_dtype)
+
+        csc_indptr_np = np.empty(n_post + 1, dtype=offset_dtype)
+        csc_indptr_np[0] = 0
+        np.cumsum(counts_np, dtype=offset_dtype, out=csc_indptr_np[1:])
+
+        if int(csc_indptr_np[-1]) != nse:
+            raise RuntimeError(
+                "CUDA CSR-to-CSC count produced an unexpected nnz total: "
+                f"{int(csc_indptr_np[-1])} != {nse}"
+            )
+
+        csc_indices_np = np.empty(nse, dtype=coord_dtype)
+        perm_np = np.empty(nse, dtype=offset_dtype) if include_perm else None
+
+        for col_start in range(0, n_post, column_block_size):
+            col_end = min(col_start + column_block_size, n_post)
+            base = int(csc_indptr_np[col_start])
+            end = int(csc_indptr_np[col_end])
+            block_nnz = end - base
+            block_ncols = col_end - col_start
+
+            if block_nnz == 0:
+                continue
+
+            local_indptr_np = (
+                csc_indptr_np[col_start:col_end + 1] -
+                csc_indptr_np[col_start]
+            ).astype(offset_dtype, copy=False)
+            initial_pos_dev = jax.device_put(
+                jnp.asarray(local_indptr_np[:-1], dtype=offset_dtype),
+                gpu_device,
+            )
+
+            scratch_info = jax.ShapeDtypeStruct((block_ncols,), offset_dtype)
+            rows_info = jax.ShapeDtypeStruct((block_nnz,), coord_dtype)
+            perm_info = jax.ShapeDtypeStruct((block_nnz,), offset_dtype)
+            _, local_rows_dev, local_perm_dev = jax.ffi.ffi_call(
+                "csr_to_csc.csr_to_csc_fill_block",
+                (scratch_info, rows_info, perm_info),
+            )(
+                csr_indices_dev,
+                csr_indptr_dev,
+                initial_pos_dev,
+                col_start=np.int64(col_start),
+                col_end=np.int64(col_end),
+            )
+
+            csc_indices_np[base:end] = np.asarray(local_rows_dev, dtype=coord_dtype)
+            if include_perm:
+                perm_np[base:end] = np.asarray(local_perm_dev, dtype=offset_dtype)
+
+        if isinstance(csr_indptr, np.ndarray) and isinstance(csr_indices, np.ndarray):
+            return csc_indptr_np, csc_indices_np, perm_np
+
+        csc_indptr = jax.device_put(csc_indptr_np, gpu_device)
+        csc_indices = jax.device_put(csc_indices_np, gpu_device)
+        perm = None if perm_np is None else jax.device_put(perm_np, gpu_device)
+        return csc_indptr, csc_indices, perm
+    finally:
+        if needs_x64 and not old_x64:
+            jax.config.update('jax_enable_x64', False)
+
+
 def csr_to_csc_index(
     csr_indptr: Union[jax.Array, np.ndarray],
     csr_indices: Union[jax.Array, np.ndarray],
     *,
     shape: Tuple[int, int],
+    include_perm: bool = True,
+    method: str = "coo",
+    column_block_size: int = 4096,
 ):
     """Convert CSR format index arrays to CSC format.
 
     Transforms the sparse matrix representation from Compressed Sparse Row
-    (CSR) format to Compressed Sparse Column (CSC) format. Internally
-    converts to COO format as an intermediate step via :func:`csr_to_coo_index`,
-    then to CSC via :func:`coo_to_csc_index`.
+    (CSR) format to Compressed Sparse Column (CSC) format. The default
+    ``method="coo"`` preserves the legacy CSR -> COO -> CSC behavior.
 
     Parameters
     ----------
@@ -1325,6 +1580,18 @@ def csr_to_csc_index(
     shape : tuple of int
         A ``(n_rows, n_cols)`` tuple specifying the dimensions of the
         sparse matrix. Keyword-only argument.
+    include_perm : bool, optional
+        If ``True`` (default), return the permutation that maps CSC slots back
+        to CSR data positions. If ``False``, return ``None`` for the third
+        result while still constructing the CSC structure.
+    method : {"coo", "numpy", "gpu_column_block"}, optional
+        Conversion algorithm. ``"coo"`` expands CSR to COO first and then
+        converts COO to CSC; ``"numpy"`` computes the structure on CPU with
+        NumPy; ``"gpu_column_block"`` builds consecutive CSC column blocks
+        with CUDA kernels and falls back to ``"numpy"`` when CUDA is not
+        available.
+    column_block_size : int, optional
+        Number of CSC columns per CUDA block for ``method="gpu_column_block"``.
 
     Returns
     -------
@@ -1350,11 +1617,10 @@ def csr_to_csc_index(
 
     Notes
     -----
-    The conversion is performed in two steps: CSR is first expanded to
-    COO via :func:`csr_to_coo_index`, then the COO representation is
-    sorted by column via :func:`coo_to_csc_index`.  The returned
-    ``post_positions`` permutation array can be used to reorder a CSR
-    data array into CSC order.
+    The returned ``post_positions`` permutation array can be used to reorder a
+    CSR data array into CSC order. The ``"coo"`` method preserves the public
+    int32 index-helper contract, while ``"numpy"`` and ``"gpu_column_block"``
+    may return int64 offset arrays when the input row pointer requires them.
 
     Examples
     --------
@@ -1371,8 +1637,33 @@ def csr_to_csc_index(
     assert isinstance(shape, (tuple, list)), "Shape must be a tuple or list"
     assert len(shape) == 2, "Shape must have exactly two dimensions (rows, columns)"
     assert shape[0] > 0 and shape[1] > 0, "Shape dimensions must be positive integers"
-    pre_ids, post_ids = csr_to_coo_index(csr_indptr, csr_indices)
-    csc_indptr, csc_indices, post_positions = coo_to_csc_index(pre_ids, post_ids, shape=shape)
+    if method == "coo":
+        csc_indptr, csc_indices, post_positions = _csr_to_csc_index_via_coo(
+            csr_indptr,
+            csr_indices,
+            shape=shape,
+            include_perm=include_perm,
+        )
+    elif method == "numpy":
+        csc_indptr, csc_indices, post_positions = _csr_to_csc_index_numpy(
+            csr_indptr,
+            csr_indices,
+            shape=shape,
+            include_perm=include_perm,
+        )
+    elif method == "gpu_column_block":
+        csc_indptr, csc_indices, post_positions = _csr_to_csc_index_gpu_column_block(
+            csr_indptr,
+            csr_indices,
+            shape=shape,
+            include_perm=include_perm,
+            column_block_size=column_block_size,
+        )
+    else:
+        raise ValueError(
+            f"Unknown csr_to_csc_index method {method!r}; "
+            f"expected 'coo', 'numpy', or 'gpu_column_block'."
+        )
     return csc_indptr, csc_indices, post_positions
 
 
@@ -1381,6 +1672,7 @@ def csc_to_csr_index(
     csc_indices: Union[jax.Array, np.ndarray],
     *,
     shape: Tuple[int, int],
+    include_perm: bool = True,
 ):
     """Convert CSC format index arrays to CSR format.
 
@@ -1401,6 +1693,10 @@ def csc_to_csr_index(
     shape : tuple of int
         A ``(n_rows, n_cols)`` tuple giving the dimensions of the matrix the
         CSC arrays describe.  Keyword-only argument.
+    include_perm : bool, optional
+        If ``True`` (default), return the permutation that maps CSR slots back
+        to CSC data positions. If ``False``, return ``None`` for the third
+        result while still constructing the CSR structure.
 
     Returns
     -------
@@ -1445,7 +1741,12 @@ def csc_to_csr_index(
     assert isinstance(shape, (tuple, list)), "Shape must be a tuple or list"
     assert len(shape) == 2, "Shape must have exactly two dimensions (rows, columns)"
     assert shape[0] > 0 and shape[1] > 0, "Shape dimensions must be positive integers"
-    csr_indptr, csr_indices, perm = csr_to_csc_index(csc_indptr, csc_indices, shape=(shape[1], shape[0]))
+    csr_indptr, csr_indices, perm = csr_to_csc_index(
+        csc_indptr,
+        csc_indices,
+        shape=(shape[1], shape[0]),
+        include_perm=include_perm,
+    )
     return csr_indptr, csr_indices, perm
 
 

--- a/brainevent/_misc_test.py
+++ b/brainevent/_misc_test.py
@@ -299,6 +299,27 @@ def test_gpu_column_block_method_rejects_non_positive_block_size():
         )
 
 
+def test_load_csr_to_csc_cuda_module_is_lazy_and_cached(monkeypatch):
+    import brainevent._misc as misc
+    import brainevent._op as op
+
+    calls = []
+    fake_module = object()
+
+    def fake_load_cuda_file(path, *, name):
+        calls.append((path, name))
+        return fake_module
+
+    monkeypatch.setattr(misc, "_CSR_TO_CSC_CUDA_MODULE", None)
+    monkeypatch.setattr(op, "load_cuda_file", fake_load_cuda_file)
+
+    assert misc._load_csr_to_csc_cuda_module() is fake_module
+    assert misc._load_csr_to_csc_cuda_module() is fake_module
+    assert len(calls) == 1
+    assert calls[0][0].name == "csr_to_csc.cu"
+    assert calls[0][1] == "csr_to_csc"
+
+
 def test_gpu_column_block_method_falls_back_to_numpy(monkeypatch):
     import brainevent._misc as misc
 

--- a/brainevent/_misc_test.py
+++ b/brainevent/_misc_test.py
@@ -115,6 +115,57 @@ def test_csc_to_csr_index_roundtrip():
     np.testing.assert_array_equal(np.asarray(perm)[np.asarray(perm2)], np.arange(len(perm)))
 
 
+class TestCsrToCscIndexMethods(unittest.TestCase):
+    def test_default_matches_explicit_coo(self):
+        from brainevent._misc import csr_to_csc_index
+        indptr = np.array([0, 2, 3, 5], dtype=np.int32)
+        indices = np.array([0, 2, 1, 0, 3], dtype=np.int32)
+        default = csr_to_csc_index(indptr, indices, shape=(3, 4))
+        explicit = csr_to_csc_index(indptr, indices, shape=(3, 4), method="coo")
+        for got, expected in zip(default, explicit):
+            np.testing.assert_array_equal(np.asarray(got), np.asarray(expected))
+
+    def test_numpy_matches_coo_reordered_data(self):
+        from brainevent._misc import csr_to_csc_index
+        indptr = np.array([0, 2, 3, 5], dtype=np.int32)
+        indices = np.array([0, 2, 1, 0, 3], dtype=np.int32)
+        data = np.array([10., 20., 30., 40., 50.])
+        coo_indptr, coo_rows, coo_perm = csr_to_csc_index(indptr, indices, shape=(3, 4), method="coo")
+        np_indptr, np_rows, np_perm = csr_to_csc_index(indptr, indices, shape=(3, 4), method="numpy")
+        np.testing.assert_array_equal(np.asarray(np_indptr), np.asarray(coo_indptr))
+        np.testing.assert_array_equal(np.asarray(np_rows), np.asarray(coo_rows))
+        np.testing.assert_array_equal(data[np.asarray(np_perm)], data[np.asarray(coo_perm)])
+
+    def test_include_perm_false(self):
+        from brainevent._misc import csr_to_csc_index, csc_to_csr_index
+        indptr = np.array([0, 2, 3, 5], dtype=np.int32)
+        indices = np.array([0, 2, 1, 0, 3], dtype=np.int32)
+        csc_indptr, csc_indices, perm = csr_to_csc_index(
+            indptr, indices, shape=(3, 4), method="numpy", include_perm=False
+        )
+        self.assertIsNone(perm)
+        _, _, back_perm = csc_to_csr_index(csc_indptr, csc_indices, shape=(3, 4), include_perm=False)
+        self.assertIsNone(back_perm)
+
+    def test_numpy_preserves_int64_indptr_and_int32_indices(self):
+        from brainevent._misc import csr_to_csc_index
+        indptr = np.array([0, 2, 3, 5], dtype=np.int64)
+        indices = np.array([0, 2, 1, 0, 3], dtype=np.int32)
+        csc_indptr, csc_indices, perm = csr_to_csc_index(
+            indptr, indices, shape=(3, 4), method="numpy"
+        )
+        self.assertEqual(np.asarray(csc_indptr).dtype, np.int64)
+        self.assertEqual(np.asarray(csc_indices).dtype, np.int32)
+        self.assertEqual(np.asarray(perm).dtype, np.int64)
+
+    def test_unknown_method_raises(self):
+        from brainevent._misc import csr_to_csc_index
+        indptr = np.array([0, 1], dtype=np.int32)
+        indices = np.array([0], dtype=np.int32)
+        with self.assertRaisesRegex(ValueError, "Unknown csr_to_csc_index method"):
+            csr_to_csc_index(indptr, indices, shape=(1, 1), method="bogus")
+
+
 class TestCsrToCooIndex(unittest.TestCase):
     def test_expands_indptr_into_row_ids(self):
         from brainevent._misc import csr_to_coo_index

--- a/brainevent/_misc_test.py
+++ b/brainevent/_misc_test.py
@@ -18,7 +18,10 @@
 
 import unittest
 
+import jax
+import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from brainevent._misc import generate_block_dim, coo2csr
 
@@ -165,6 +168,40 @@ class TestCsrToCscIndexMethods(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unknown csr_to_csc_index method"):
             csr_to_csc_index(indptr, indices, shape=(1, 1), method="bogus")
 
+    def test_numpy_preserves_int64_coordinate_indices(self):
+        from brainevent._misc import csr_to_csc_index
+        indptr = np.array([0, 2, 3, 5], dtype=np.int32)
+        indices = np.array([0, 2, 1, 0, 3], dtype=np.int64)
+        csc_indptr, csc_indices, perm = csr_to_csc_index(
+            indptr, indices, shape=(3, 4), method="numpy"
+        )
+        self.assertEqual(np.asarray(csc_indptr).dtype, np.int32)
+        self.assertEqual(np.asarray(csc_indices).dtype, np.int64)
+        self.assertEqual(np.asarray(perm).dtype, np.int32)
+
+    def test_numpy_jax_output_temporarily_enables_int64_offsets(self):
+        from brainevent._misc import csr_to_csc_index
+        old_x64 = jax.config.jax_enable_x64
+        jax.config.update("jax_enable_x64", False)
+        try:
+            indptr = np.array([0, 2, 3, 5], dtype=np.int64)
+            indices = jnp.array([0, 2, 1, 0, 3], dtype=jnp.int32)
+            csc_indptr, csc_indices, perm = csr_to_csc_index(
+                indptr, indices, shape=(3, 4), method="numpy"
+            )
+            self.assertEqual(csc_indptr.dtype, jnp.int64)
+            self.assertEqual(csc_indices.dtype, jnp.int32)
+            self.assertEqual(perm.dtype, jnp.int64)
+            self.assertFalse(jax.config.jax_enable_x64)
+        finally:
+            jax.config.update("jax_enable_x64", old_x64)
+
+    def test_offset_index_dtype_promotes_large_nse(self):
+        from brainevent._misc import _offset_index_dtype
+        self.assertEqual(_offset_index_dtype(np.iinfo(np.int32).max), np.int32)
+        self.assertEqual(_offset_index_dtype(np.iinfo(np.int32).max + 1), np.int64)
+        self.assertEqual(_offset_index_dtype(3, preferred=np.int64), np.int64)
+
 
 class TestCsrToCooIndex(unittest.TestCase):
     def test_expands_indptr_into_row_ids(self):
@@ -193,6 +230,187 @@ class TestCsrToCooIndex(unittest.TestCase):
         new_indptr, new_indices, _ = coo2csr(row_ids, col_ids, shape=(3, 4))
         np.testing.assert_array_equal(np.asarray(new_indptr), indptr)
         np.testing.assert_array_equal(np.asarray(new_indices), indices)
+
+
+class TestCsrStructureDtypes(unittest.TestCase):
+    def test_public_structure_dtype_contract_accepts_signed_layouts(self):
+        from brainevent._misc import _check_csr_structure_dtypes
+        _check_csr_structure_dtypes(
+            np.array([0, 1], dtype=np.int32),
+            np.array([0, 2], dtype=np.int32),
+        )
+        _check_csr_structure_dtypes(
+            np.array([0, 1], dtype=np.int64),
+            np.array([0, 2], dtype=np.int64),
+        )
+        _check_csr_structure_dtypes(
+            np.array([0, 1], dtype=np.int32),
+            np.array([0, 2], dtype=np.int64),
+        )
+
+    def test_public_structure_dtype_contract_rejects_unsigned_indices(self):
+        from brainevent._misc import _check_csr_structure_dtypes
+        with self.assertRaisesRegex(AssertionError, "signed int32 or int64"):
+            _check_csr_structure_dtypes(
+                np.array([0, 1], dtype=np.uint32),
+                np.array([0, 2], dtype=np.int32),
+            )
+
+    def test_public_structure_dtype_contract_rejects_int64_indices_with_int32_indptr(self):
+        from brainevent._misc import _check_csr_structure_dtypes
+        with self.assertRaisesRegex(AssertionError, "same dtype"):
+            _check_csr_structure_dtypes(
+                np.array([0, 1], dtype=np.int64),
+                np.array([0, 2], dtype=np.int32),
+            )
+
+    def test_cuda_structure_dtype_contract_accepts_int32_indices_and_int64_indptr(self):
+        from brainevent._misc import _check_csr_cuda_structure_dtypes
+        _check_csr_cuda_structure_dtypes(
+            jax.ShapeDtypeStruct((2,), jnp.int32),
+            jax.ShapeDtypeStruct((2,), jnp.int64),
+        )
+
+    def test_cuda_structure_dtype_contract_rejects_int64_indices(self):
+        from brainevent._misc import _check_csr_cuda_structure_dtypes
+        with self.assertRaisesRegex(TypeError, "indices with dtype int32"):
+            _check_csr_cuda_structure_dtypes(
+                jax.ShapeDtypeStruct((2,), jnp.int64),
+                jax.ShapeDtypeStruct((2,), jnp.int64),
+            )
+
+    def test_cuda_structure_dtype_contract_rejects_unsigned_indptr(self):
+        from brainevent._misc import _check_csr_cuda_structure_dtypes
+        with self.assertRaisesRegex(TypeError, "indptr with dtype int32 or int64"):
+            _check_csr_cuda_structure_dtypes(
+                jax.ShapeDtypeStruct((2,), jnp.int32),
+                jax.ShapeDtypeStruct((2,), jnp.uint32),
+            )
+
+
+def test_gpu_column_block_method_rejects_non_positive_block_size():
+    from brainevent._misc import csr_to_csc_index
+    indptr = np.array([0, 1], dtype=np.int32)
+    indices = np.array([0], dtype=np.int32)
+    with pytest.raises(ValueError, match="positive integer"):
+        csr_to_csc_index(
+            indptr, indices, shape=(1, 1), method="gpu_column_block",
+            column_block_size=0,
+        )
+
+
+def test_gpu_column_block_method_falls_back_to_numpy(monkeypatch):
+    import brainevent._misc as misc
+
+    def fail_load():
+        raise RuntimeError("simulated CUDA loader failure")
+
+    monkeypatch.setattr(misc, "_load_csr_to_csc_cuda_module", fail_load)
+    indptr = np.array([0, 2, 3, 5], dtype=np.int32)
+    indices = np.array([0, 2, 1, 0, 3], dtype=np.int32)
+
+    got = misc.csr_to_csc_index(
+        indptr, indices, shape=(3, 4), method="gpu_column_block",
+        column_block_size=2,
+    )
+    expected = misc.csr_to_csc_index(
+        indptr, indices, shape=(3, 4), method="numpy",
+    )
+
+    for got_arr, expected_arr in zip(got, expected):
+        np.testing.assert_array_equal(np.asarray(got_arr), np.asarray(expected_arr))
+
+
+def test_gpu_column_block_method_stitches_column_blocks_correctly(monkeypatch):
+    import brainevent._misc as misc
+
+    shape = (64, 64)
+    n_rows, n_cols = shape
+    per_row = 8
+    indptr = np.arange(n_rows + 1, dtype=np.int32) * per_row
+    row_ids = np.repeat(np.arange(n_rows, dtype=np.int32), per_row)
+    offsets = np.tile(np.array([0, 1, 7, 13, 21, 34, 45, 63], dtype=np.int32), n_rows)
+    indices = ((row_ids * 17 + offsets) % n_cols).astype(np.int32)
+    column_block_size = 11
+    fill_blocks = []
+
+    monkeypatch.setattr(misc, "_load_csr_to_csc_cuda_module", lambda: object())
+    monkeypatch.setattr(misc.jax, "devices", lambda kind=None: [object()] if kind == "gpu" else [])
+    monkeypatch.setattr(misc.jax, "device_put", lambda x, device=None: x)
+
+    def fake_ffi_call(name, out_info):
+        if name == "csr_to_csc.csr_to_csc_count":
+            def count(csr_indices, csr_indptr):
+                return np.bincount(np.asarray(csr_indices), minlength=shape[1]).astype(out_info.dtype)
+            return count
+
+        if name == "csr_to_csc.csr_to_csc_fill_block":
+            _, rows_info, perm_info = out_info
+
+            def fill_block(csr_indices, csr_indptr, initial_pos, *, col_start, col_end):
+                col_start = int(col_start)
+                col_end = int(col_end)
+                fill_blocks.append((col_start, col_end, np.asarray(initial_pos).copy()))
+
+                csr_indices_np = np.asarray(csr_indices)
+                csr_indptr_np = np.asarray(csr_indptr)
+                positions = np.arange(csr_indices_np.size)
+                row_ids = np.searchsorted(csr_indptr_np, positions, side="right") - 1
+                in_block = (col_start <= csr_indices_np) & (csr_indices_np < col_end)
+                block_positions = positions[in_block]
+                order_chunks = []
+                for col in range(col_start, col_end):
+                    col_positions = block_positions[csr_indices_np[block_positions] == col]
+                    order_chunks.append(col_positions[::-1])
+                order = np.concatenate(order_chunks) if order_chunks else np.zeros(0, dtype=np.int64)
+                scratch = np.zeros(out_info[0].shape, dtype=out_info[0].dtype)
+                return (
+                    scratch,
+                    row_ids[order].astype(rows_info.dtype),
+                    order.astype(perm_info.dtype),
+                )
+            return fill_block
+
+        raise AssertionError(f"unexpected FFI call: {name}")
+
+    monkeypatch.setattr(misc.jax.ffi, "ffi_call", fake_ffi_call)
+
+    got = misc.csr_to_csc_index(
+        indptr, indices, shape=shape, method="gpu_column_block",
+        column_block_size=column_block_size,
+    )
+    expected = misc.csr_to_csc_index(indptr, indices, shape=shape, method="numpy")
+
+    got_indptr, got_rows, got_perm = [np.asarray(arr) for arr in got]
+    expected_indptr, expected_rows, expected_perm = [np.asarray(arr) for arr in expected]
+
+    np.testing.assert_array_equal(got_indptr, expected_indptr)
+    for col in range(n_cols):
+        got_start, got_end = int(got_indptr[col]), int(got_indptr[col + 1])
+        expected_start, expected_end = int(expected_indptr[col]), int(expected_indptr[col + 1])
+        got_pairs = sorted(zip(got_rows[got_start:got_end], got_perm[got_start:got_end]))
+        expected_pairs = sorted(zip(expected_rows[expected_start:expected_end], expected_perm[expected_start:expected_end]))
+        assert got_pairs == expected_pairs, col
+
+    expected_blocks = [
+        (start, min(start + column_block_size, n_cols))
+        for start in range(0, n_cols, column_block_size)
+    ]
+    assert [(start, end) for start, end, _ in fill_blocks] == expected_blocks
+
+    got_no_perm = misc.csr_to_csc_index(
+        indptr, indices, shape=shape, method="gpu_column_block",
+        include_perm=False, column_block_size=column_block_size,
+    )
+    np.testing.assert_array_equal(np.asarray(got_no_perm[0]), np.asarray(expected[0]))
+    got_no_perm_rows = np.asarray(got_no_perm[1])
+    for col in range(n_cols):
+        start, end = int(got_indptr[col]), int(got_indptr[col + 1])
+        np.testing.assert_array_equal(
+            np.sort(got_no_perm_rows[start:end]),
+            np.sort(expected_rows[start:end]),
+        )
+    assert got_no_perm[2] is None
 
 
 class TestCooToCscIndex(unittest.TestCase):

--- a/brainevent/include/brainevent/dispatch.h
+++ b/brainevent/include/brainevent/dispatch.h
@@ -152,6 +152,68 @@ struct complex128_t {
         }                                                                \
     }()
 
+/// Dispatch over signed index dtypes used by sparse structure arrays.
+#define BE_DISPATCH_SIGNED_INDEX(DTYPE, SCALAR_VAR, ...)                 \
+    [&] {                                                                \
+        switch (DTYPE) {                                                 \
+            case BE::DType::Int32: {                                     \
+                using SCALAR_VAR = int32_t;                              \
+                __VA_ARGS__                                              \
+                break;                                                   \
+            }                                                            \
+            case BE::DType::Int64: {                                     \
+                using SCALAR_VAR = int64_t;                              \
+                __VA_ARGS__                                              \
+                break;                                                   \
+            }                                                            \
+            default:                                                     \
+                fprintf(stderr,                                          \
+                    "[be] BE_DISPATCH_SIGNED_INDEX: unsupported dtype %s\n", \
+                    BE::dtype_name(DTYPE));                              \
+                abort();                                                 \
+        }                                                                \
+    }()
+
+#define BE_DISPATCH_SIGNED_INDEX_PAIR(INDEX_DTYPE, OFFSET_DTYPE, INDEX_VAR, OFFSET_VAR, ...) \
+    BE_DISPATCH_SIGNED_INDEX(INDEX_DTYPE, INDEX_VAR, {                  \
+        BE_DISPATCH_SIGNED_INDEX(OFFSET_DTYPE, OFFSET_VAR, {            \
+            __VA_ARGS__                                                  \
+        });                                                              \
+    })
+
+/// Dispatch over CSR row-pointer dtypes supported by raw CUDA kernels.
+/// CSR column indices stay int32; indptr may be int32 or int64.
+#define BE_DISPATCH_CSR_INDPTR(DTYPE, INDPTR_VAR, ...)                   \
+    [&] {                                                                \
+        switch (DTYPE) {                                                 \
+            case BE::DType::Int32: {                                     \
+                using INDPTR_VAR = int32_t;                              \
+                __VA_ARGS__                                              \
+                break;                                                   \
+            }                                                            \
+            case BE::DType::Int64: {                                     \
+                using INDPTR_VAR = int64_t;                              \
+                __VA_ARGS__                                              \
+                break;                                                   \
+            }                                                            \
+            default:                                                     \
+                fprintf(stderr,                                          \
+                    "[be] BE_DISPATCH_CSR_INDPTR: unsupported dtype %s\n", \
+                    BE::dtype_name(DTYPE));                              \
+                abort();                                                 \
+        }                                                                \
+    }()
+
+#define BE_CHECK_CSR_INDICES_INT32(TENSOR)                               \
+    do {                                                                 \
+        if ((TENSOR).dtype() != BE::DType::Int32) {                      \
+            fprintf(stderr,                                              \
+                "[be] CSR CUDA kernels require int32 indices, got %s\n", \
+                BE::dtype_name((TENSOR).dtype()));                       \
+            abort();                                                     \
+        }                                                                \
+    } while (0)
+
 /// Dispatch over complex dtypes.
 #define BE_DISPATCH_COMPLEX(DTYPE, SCALAR_VAR, ...)                     \
     [&] {                                                                \


### PR DESCRIPTION

For CSR, it is allowed to construct an int64 indptr.
For CSR, introduce a CSR-to-CSC conversion function that utilizes CPU-GPU collaboration.