### PR TITLE
fix(_op): detect XLA FFI API version so the numba bridge works on jax<0.10

### DIFF
--- a/brainevent/_jit_normal/main_test.py
+++ b/brainevent/_jit_normal/main_test.py
@@ -280,10 +280,10 @@ class Test_JITC_Operator_Behavior:
         r3 = left_vec @ mat
         r4 = left_vec @ dense
         assert u.math.allclose(r1, r2,
-                               rtol=1e-4 * u.get_unit(r2),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r2))
         assert u.math.allclose(r3, r4,
-                               rtol=1e-4 * u.get_unit(r4),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r4))
         jax.block_until_ready((right_vec, left_vec))
 

--- a/brainevent/_jit_scalar/main_test.py
+++ b/brainevent/_jit_scalar/main_test.py
@@ -274,10 +274,10 @@ class Test_JITC_Operator_Behavior:
         r3 = left_vec @ mat
         r4 = left_vec @ dense
         assert u.math.allclose(r1, r2,
-                               rtol=1e-4 * u.get_unit(r2),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r2))
         assert u.math.allclose(r3, r4,
-                               rtol=1e-4 * u.get_unit(r4),
+                               rtol=1e-4,
                                atol=1e-4 * u.get_unit(r4))
         jax.block_until_ready((right_vec, left_vec))
 

--- a/brainevent/_jit_uniform/main_test.py
+++ b/brainevent/_jit_uniform/main_test.py
@@ -279,13 +279,13 @@ class Test_JITC_Operator_Behavior:
         assert u.math.allclose(
             r1,
             r2,
-            rtol=1e-4 * u.get_unit(r2),
+            rtol=1e-4,
             atol=1e-4 * u.get_unit(r2),
         )
         assert u.math.allclose(
             r3,
             r4,
-            rtol=1e-4 * u.get_unit(r4),
+            rtol=1e-4,
             atol=1e-4 * u.get_unit(r4),
         )
         jax.block_until_ready((right_vec, left_vec))

--- a/brainevent/_op/numba_ffi.py
+++ b/brainevent/_op/numba_ffi.py
@@ -16,6 +16,8 @@
 import ctypes
 import enum
 import importlib.util
+import os
+import re
 import threading
 import traceback
 from ctypes import c_void_p, c_int, c_int32, c_int64, c_uint32, c_size_t, c_char_p, POINTER, Structure, CFUNCTYPE
@@ -40,11 +42,59 @@ _FFI_CALLBACK_COUNTER = 0
 # Serializes target registration (trace/lowering time, distinct from execution).
 _REGISTRATION_LOCK = threading.Lock()
 
-# XLA FFI API version implemented by this bridge (jaxlib c_api.h
-# XLA_FFI_API_MAJOR / XLA_FFI_API_MINOR).  Reported back during the metadata
-# handshake so XLA does not reject the handler on a version mismatch.
-XLA_FFI_API_MAJOR = 0
-XLA_FFI_API_MINOR = 3
+def _detect_xla_ffi_api_version() -> Tuple[int, int]:
+    """Return the ``(major, minor)`` XLA FFI API version the installed jaxlib implements.
+
+    The metadata handshake (:meth:`NumbaCpuFfiHandler._ffi_callback`) must report
+    an API version the running XLA framework accepts; XLA validates
+    ``minimum <= reported <= framework``.  That framework version is
+    jaxlib-specific — jaxlib 0.7/0.8 ship ``0.1``, 0.9 ships ``0.2`` and 0.10
+    ships ``0.3`` — so a value hardcoded to the newest release is rejected by
+    every older jaxlib whose framework version is lower (the mismatch that broke
+    the entire numba FFI path on ``jax < 0.10``).  Minor-version bumps are
+    ABI-compatible (new struct fields are only appended and gated by
+    ``struct_size``), so reporting the installed build's own version is always
+    both accepted and safe.
+
+    jaxlib bundles the authoritative numbers in ``xla/ffi/api/c_api.h``
+    (``#define XLA_FFI_API_MAJOR`` / ``XLA_FFI_API_MINOR``); parse them so the
+    reported version tracks whatever jaxlib is actually loaded.
+
+    Returns
+    -------
+    tuple of int
+        ``(major, minor)`` read from the installed jaxlib header, or ``(0, 1)``
+        — the lowest version every jaxlib in the supported range accepts — when
+        the header cannot be located or parsed.
+    """
+    try:
+        import jaxlib
+        header = os.path.join(
+            os.path.dirname(jaxlib.__file__), 'include', 'xla', 'ffi', 'api', 'c_api.h'
+        )
+        major = minor = None
+        with open(header, 'r') as fh:
+            for line in fh:
+                m = re.match(r'\s*#\s*define\s+XLA_FFI_API_MAJOR\s+(\d+)', line)
+                if m:
+                    major = int(m.group(1))
+                    continue
+                m = re.match(r'\s*#\s*define\s+XLA_FFI_API_MINOR\s+(\d+)', line)
+                if m:
+                    minor = int(m.group(1))
+        if major is not None and minor is not None:
+            return major, minor
+    except Exception:
+        pass
+    # Universal floor: every jaxlib in the supported range (jax>=0.5) accepts 0.1.
+    return 0, 1
+
+
+# XLA FFI API version reported by this bridge during the metadata handshake.
+# Detected from the installed jaxlib (see :func:`_detect_xla_ffi_api_version`)
+# rather than hardcoded, so the bridge works across the supported jax range
+# (0.7 → 0.10+) instead of only the newest release.
+XLA_FFI_API_MAJOR, XLA_FFI_API_MINOR = _detect_xla_ffi_api_version()
 
 
 class XLA_FFI_Error_Code(enum.IntEnum):

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Fixed
+
+- **numba FFI bridge now works on `jax`/`jaxlib` 0.7–0.9, not only 0.10+.** The
+  XLA FFI metadata handshake reported a hardcoded API version (`0.3`), which only
+  the jaxlib bundled with `jax` 0.10+ accepts. Older jaxlib builds advertise a
+  lower framework version (`0.1` for 0.7/0.8, `0.2` for 0.9) and rejected every
+  numba CPU/`numba_cuda` kernel registration with an
+  `INVALID_ARGUMENT … incompatible API version` error, failing ~180 tests on
+  those versions. The bridge now detects the installed jaxlib's FFI API version
+  from its bundled `xla/ffi/api/c_api.h` header and reports that, so registration
+  succeeds across the supported `jax >= 0.5` range.
 
 ## [0.1.0] - 2026-06-07
 


### PR DESCRIPTION
## Summary

Tests failed en masse on `jax`/`jaxlib` < 0.10. Root cause: the numba CPU/CUDA FFI bridge hardcoded the XLA FFI metadata API version to **0.3**, which only the jaxlib bundled with `jax` 0.10+ accepts. Older jaxlib builds advertise a lower framework version (`0.1` for 0.7/0.8, `0.2` for 0.9), so XLA rejected **every** numba kernel registration with `INVALID_ARGUMENT … incompatible API version`, cascading into ~180 test failures.

## Changes

- **`brainevent/_op/numba_ffi.py`** — replace the hardcoded `(0, 3)` constants with `_detect_xla_ffi_api_version()`, which parses the installed jaxlib's bundled `xla/ffi/api/c_api.h` (`#define XLA_FFI_API_MAJOR` / `_MINOR`). The reported version now tracks whatever jaxlib is loaded. Minor bumps are ABI-compatible (fields are only appended and gated by `struct_size`), so reporting the build's own version is always both accepted and safe; falls back to the universal `0.1` floor if the header is absent. `numba_cuda_ffi` imports the same constants, so both the CPU and GPU bridges are fixed by this single change.
- **`brainevent/_jit_{scalar,normal,uniform}/main_test.py`** — fix a dimensional error in the JITC unit-operator tests: `rtol` was multiplied by the data unit, but a relative tolerance is dimensionless (`|a-b| <= atol + rtol*|b|`). saiunit 0.4.0 correctly rejects a unit-bearing `rtol`. Drop the unit from `rtol`, keep `atol` unitful.
- **`changelog.md`** — document the FFI bridge fix under `[Unreleased]`.

## Verification

Created conda envs `jax07cu`/`jax08cu`/`jax09cu` (`jax[cuda12]==0.7.0/0.8.0/0.9.0`) and ran the full CI-equivalent suite (`pytest -m ""`) on each:

| jax | detected FFI API | result |
| --- | --- | --- |
| 0.7.0 | 0.1 | **2879 passed**, 0 failed |
| 0.8.0 | 0.1 | **2879 passed**, 0 failed |
| 0.9.0 | 0.2 | **2879 passed**, 0 failed |

(Before the fix: 178 failures in the default suite, +6 in the slow suite.) GPU `numba_cuda` FFI bridge also validated directly (50 passed). `mypy` ratchet reports **no new errors** vs the committed baseline.

## Summary by Sourcery

Detect the installed jaxlib XLA FFI API version at runtime so the numba FFI bridge works across supported jax versions and fix unit handling in JIT unit-operator tests.

Bug Fixes:
- Make the numba CPU/GPU XLA FFI bridge compatible with jax/jaxlib 0.7–0.9 by deriving the reported FFI API version from the installed jaxlib headers instead of hardcoding it.
- Correct JIT unit-operator tests to use a dimensionless relative tolerance while keeping the absolute tolerance unitful.

Documentation:
- Document the XLA numba FFI bridge compatibility fix in the unreleased changelog section.