### PR TITLE
fix(_op): use None instead of removed batching.not_mapped in general_batching_rule

### DIFF
--- a/brainevent/_op/util.py
+++ b/brainevent/_op/util.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, Optional, Protocol, Sequence, Tuple, TYPE_CHEC
 import jax
 import numpy as np
 from jax import tree_util
-from jax.interpreters import ad, batching
+from jax.interpreters import ad
 
 from brainevent._compatible_import import Primitive, init_zero
 
@@ -368,9 +368,9 @@ def general_batching_rule(
         A pytree with the same structure as *outs*.  When at least one
         operand is batched, every leaf is ``0`` (the batch dimension is
         the leading axis of each output).  When no operand is batched
-        (every entry of *axes* is ``None``), every leaf is
-        ``jax.interpreters.batching.not_mapped`` to signal that the
-        outputs carry no batch dimension.
+        (every entry of *axes* is ``None``), every leaf is ``None`` to
+        signal that the outputs carry no batch dimension (the value JAX
+        uses internally as the ``not_mapped`` sentinel).
 
     Notes
     -----
@@ -410,13 +410,16 @@ def general_batching_rule(
     # If no operand is actually batched (every axis is ``None``), there is
     # nothing to scan over -- ``jax.lax.scan(f, 0, {})`` would raise
     # "scan got no values to scan over".  Bind the primitive once and mark
-    # every output as unbatched.
+    # every output as unbatched.  ``None`` is the batch dimension JAX uses
+    # for an unmapped output (its ``not_mapped`` sentinel is ``None`` in
+    # every supported version), so we avoid the public ``batching.not_mapped``
+    # symbol, which newer jax has removed.
     if not batch_args:
         if isinstance(prim, Primitive):
             out = prim.bind(*args, **kwargs)
         else:
             out = prim(*args, **kwargs)
-        return out, tree_util.tree_map(lambda _: batching.not_mapped, out)
+        return out, tree_util.tree_map(lambda _: None, out)
 
     def f(_, x):
         """Apply the primitive to a single batch element for ``jax.lax.scan``.

--- a/brainevent/_op/util_audit_test.py
+++ b/brainevent/_op/util_audit_test.py
@@ -44,7 +44,7 @@ import numpy as np
 import pytest
 
 from jax.extend.core import Primitive
-from jax.interpreters import ad, batching, mlir
+from jax.interpreters import ad, mlir
 
 from brainevent._op import util
 from brainevent._op.util import (
@@ -110,7 +110,7 @@ def test_m1_general_batching_rule_all_unbatched():
     Pre-fix ``jax.lax.scan(f, 0, {})`` raised
     ``ValueError: scan got no values to scan over``.  Post-fix the rule
     binds the primitive once and reports every output as unbatched
-    (``batching.not_mapped``).
+    (a ``None`` batch dimension, JAX's ``not_mapped`` sentinel).
     """
     prim = Primitive('m1_unbatched_add')
     prim.multiple_results = False
@@ -126,14 +126,15 @@ def test_m1_general_batching_rule_all_unbatched():
     out, out_dim = general_batching_rule(prim, (a, b), (None, None))
 
     np.testing.assert_allclose(np.asarray(out), np.asarray(a + b))
-    # Every output dim must be flagged unbatched.  ``batching.not_mapped`` is
-    # ``None``, which the default pytree flattener treats as an empty node, so
-    # we flatten with ``is_leaf`` recognizing the sentinel as a real leaf
-    # (this mirrors how JAX inspects output batch dims).
-    is_not_mapped = lambda x: x is batching.not_mapped
+    # Every output dim must be flagged unbatched.  JAX's ``not_mapped``
+    # sentinel is ``None`` in every supported version, and the default pytree
+    # flattener treats ``None`` as an empty node, so we flatten with
+    # ``is_leaf`` recognizing the sentinel as a real leaf (this mirrors how
+    # JAX inspects output batch dims).
+    is_not_mapped = lambda x: x is None
     leaves = jax.tree.leaves(out_dim, is_leaf=is_not_mapped)
     assert leaves, 'expected at least one output-dim leaf'
-    assert all(leaf is batching.not_mapped for leaf in leaves)
+    assert all(leaf is None for leaf in leaves)
     # The out_dim pytree must mirror the output structure.
     assert (jax.tree.structure(out_dim, is_leaf=is_not_mapped)
             == jax.tree.structure(out))


### PR DESCRIPTION
## Problem

The unpinned-JAX CI job (`test_linux (3.13)`, matrix `jax-version: ""` → latest) failed:

```
brainevent/_op/util_audit_test.py::test_m1_general_batching_rule_all_unbatched
AttributeError: module 'jax.interpreters.batching' has no attribute 'not_mapped'
```

Newer JAX removed the public `jax.interpreters.batching.not_mapped` symbol. The pinned matrix jobs (0.7.2 / 0.8.0 / 0.9.0) still export it, so only the latest-JAX job broke. Both the source (`util.py:419`) and the audit test referenced the doomed symbol.

## Fix

Replace the fragile symbol with bare `None`, which is **exactly** what `not_mapped` equals in every supported JAX version (`not_mapped = None` in 0.7.2 → latest, and JAX's batching machinery compares with `is not_mapped`). No compatibility shim or private API needed.

- `brainevent/_op/util.py` — return `None` as the unbatched output batch-dim; drop the now-unused `batching` import; update docstring/comment.
- `brainevent/_op/util_audit_test.py` — assert against `None`; drop unused `batching` import; update docstring/comment.

## Verification

- `util_audit_test.py`: 5 passed, 4 skipped
- Real `jax.vmap` dispatch (`in_axes=(0, None)` and nested `jit + vmap`) consuming the `None` batch-dim end-to-end
- Full CSR op modules (`float_test.py`, `binary_test.py`) + `util_audit_test.py`: 51 passed
- Package imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace usage of JAX's removed batching.not_mapped sentinel with None to restore compatibility with newer JAX versions while preserving batching semantics.

Bug Fixes:
- Fix failures on newer JAX versions by no longer referencing the removed jax.interpreters.batching.not_mapped symbol and using None instead for unbatched outputs.

Tests:
- Update batching audit test expectations to assert against None as the unbatched batch dimension sentinel.