### PR TITLE
perf(_numba_random): defer numba import; widen jax/numpy bounds, drop absl-py

### DIFF
--- a/brainevent/_numba_random.py
+++ b/brainevent/_numba_random.py
@@ -26,29 +26,20 @@ Three algorithm families are provided:
 * **LFSR88** — Combined LFSR with period ~2^88 (3-component).
 * **LFSR113** — Combined LFSR with period ~2^113 (4-component).
 * **LFSR128** — Combined LFSR with period ~2^128 (4-component).
+
+Numba is **not** imported when this module is imported. The primitives are
+defined as plain-Python functions and are JIT-compiled lazily: the first call
+to any ``get_numba_lfsr_*`` helper imports Numba and swaps each primitive for
+its ``@numba.njit(inline='always')`` dispatcher (see ``_ensure_numba_compiled``).
+This keeps ``import brainevent`` free of Numba's import cost.
 """
 
-import importlib.util
 import math
+from typing import Callable, Dict
 
 import numpy as np
 
 from .config import get_lfsr_algorithm
-
-if importlib.util.find_spec('numba') is not None:
-    import numba
-else:
-    class _NumbaStub:
-        """Minimal stub so decorated functions remain plain Python callables."""
-
-        @staticmethod
-        def njit(func=None, **kwargs):
-            if func is not None:
-                return func
-            return lambda f: f
-
-
-    numba = _NumbaStub()
 
 __all__ = [
     # LFSR88
@@ -91,7 +82,6 @@ __all__ = [
 #  LFSR88
 # ──────────────────────────────────────────────────────────────────────
 
-@numba.njit(inline='always')
 def lfsr88_seed(seed):
     """Create an LFSR88 state array from an integer seed.
 
@@ -113,7 +103,6 @@ def lfsr88_seed(seed):
     return state
 
 
-@numba.njit(inline='always')
 def lfsr88_next_key(state):
     """Advance the LFSR88 state in-place by one step."""
     s1 = state[0]
@@ -135,7 +124,6 @@ def lfsr88_next_key(state):
     state[3] = b
 
 
-@numba.njit(inline='always')
 def lfsr88_randint(state):
     """Generate a random ``uint32`` value and advance the LFSR88 state.
 
@@ -147,7 +135,6 @@ def lfsr88_randint(state):
     return state[0] ^ state[1] ^ state[2]
 
 
-@numba.njit(inline='always')
 def lfsr88_rand(state):
     """Generate a uniform random float in [0, 1) and advance the LFSR88 state.
 
@@ -159,7 +146,6 @@ def lfsr88_rand(state):
     return np.float64(state[0] ^ state[1] ^ state[2]) * 2.3283064365386963e-10
 
 
-@numba.njit(inline='always')
 def lfsr88_randn(state, epsilon=1e-10):
     """Generate a standard-normal random value (Box-Muller) and advance the LFSR88 state.
 
@@ -176,19 +162,16 @@ def lfsr88_randn(state, epsilon=1e-10):
     return z
 
 
-@numba.njit(inline='always')
 def lfsr88_uniform(state, low, high):
     """Generate a uniform random float in [low, high) and advance the LFSR88 state."""
     return lfsr88_rand(state) * (high - low) + low
 
 
-@numba.njit(inline='always')
 def lfsr88_normal(state, mu, sigma, epsilon=1e-10):
     """Generate a normal random value N(mu, sigma) and advance the LFSR88 state."""
     return mu + sigma * lfsr88_randn(state, epsilon)
 
 
-@numba.njit(inline='always')
 def lfsr88_random_integers(state, low, high):
     """Generate a random integer in [low, high] (inclusive) and advance the LFSR88 state."""
     val = lfsr88_randint(state)
@@ -199,7 +182,6 @@ def lfsr88_random_integers(state, low, high):
 #  LFSR113
 # ──────────────────────────────────────────────────────────────────────
 
-@numba.njit(inline='always')
 def lfsr113_seed(seed):
     """Create an LFSR113 state array from an integer seed.
 
@@ -221,7 +203,6 @@ def lfsr113_seed(seed):
     return state
 
 
-@numba.njit(inline='always')
 def lfsr113_next_key(state):
     """Advance the LFSR113 state in-place by one step."""
     z1 = state[0]
@@ -247,21 +228,18 @@ def lfsr113_next_key(state):
     state[3] = z4
 
 
-@numba.njit(inline='always')
 def lfsr113_randint(state):
     """Generate a random ``uint32`` value and advance the LFSR113 state."""
     lfsr113_next_key(state)
     return state[0] ^ state[1] ^ state[2] ^ state[3]
 
 
-@numba.njit(inline='always')
 def lfsr113_rand(state):
     """Generate a uniform random float in [0, 1) and advance the LFSR113 state."""
     lfsr113_next_key(state)
     return np.float64(state[0] ^ state[1] ^ state[2] ^ state[3]) * 2.3283064365386963e-10
 
 
-@numba.njit(inline='always')
 def lfsr113_randn(state, epsilon=1e-10):
     """Generate a standard-normal random value (Box-Muller) and advance the LFSR113 state."""
     u1 = lfsr113_rand(state)
@@ -273,19 +251,16 @@ def lfsr113_randn(state, epsilon=1e-10):
     return z
 
 
-@numba.njit(inline='always')
 def lfsr113_uniform(state, low, high):
     """Generate a uniform random float in [low, high) and advance the LFSR113 state."""
     return lfsr113_rand(state) * (high - low) + low
 
 
-@numba.njit(inline='always')
 def lfsr113_normal(state, mu, sigma, epsilon=1e-10):
     """Generate a normal random value N(mu, sigma) and advance the LFSR113 state."""
     return mu + sigma * lfsr113_randn(state, epsilon)
 
 
-@numba.njit(inline='always')
 def lfsr113_random_integers(state, low, high):
     """Generate a random integer in [low, high] (inclusive) and advance the LFSR113 state."""
     val = lfsr113_randint(state)
@@ -296,7 +271,6 @@ def lfsr113_random_integers(state, low, high):
 #  LFSR128
 # ──────────────────────────────────────────────────────────────────────
 
-@numba.njit(inline='always')
 def lfsr128_seed(seed):
     """Create an LFSR128 state array from an integer seed.
 
@@ -319,7 +293,6 @@ def lfsr128_seed(seed):
     return state
 
 
-@numba.njit(inline='always')
 def lfsr128_next_key(state):
     """Advance the LFSR128 state in-place by one step."""
     z1 = state[0]
@@ -345,21 +318,18 @@ def lfsr128_next_key(state):
     state[3] = z4
 
 
-@numba.njit(inline='always')
 def lfsr128_randint(state):
     """Generate a random ``uint32`` value and advance the LFSR128 state."""
     lfsr128_next_key(state)
     return state[0] ^ state[1] ^ state[2] ^ state[3]
 
 
-@numba.njit(inline='always')
 def lfsr128_rand(state):
     """Generate a uniform random float in [0, 1) and advance the LFSR128 state."""
     lfsr128_next_key(state)
     return np.float64(state[0] ^ state[1] ^ state[2] ^ state[3]) * 2.3283064365386963e-10
 
 
-@numba.njit(inline='always')
 def lfsr128_randn(state, epsilon=1e-10):
     """Generate a standard-normal random value (Box-Muller) and advance the LFSR128 state."""
     u1 = lfsr128_rand(state)
@@ -371,19 +341,16 @@ def lfsr128_randn(state, epsilon=1e-10):
     return z
 
 
-@numba.njit(inline='always')
 def lfsr128_uniform(state, low, high):
     """Generate a uniform random float in [low, high) and advance the LFSR128 state."""
     return lfsr128_rand(state) * (high - low) + low
 
 
-@numba.njit(inline='always')
 def lfsr128_normal(state, mu, sigma, epsilon=1e-10):
     """Generate a normal random value N(mu, sigma) and advance the LFSR128 state."""
     return mu + sigma * lfsr128_randn(state, epsilon)
 
 
-@numba.njit(inline='always')
 def lfsr128_random_integers(state, low, high):
     """Generate a random integer in [low, high] (inclusive) and advance the LFSR128 state."""
     val = lfsr128_randint(state)
@@ -394,66 +361,118 @@ def lfsr128_random_integers(state, low, high):
 #  Dispatch tables and helpers
 # ──────────────────────────────────────────────────────────────────────
 
-_NUMBA_LFSR_SEED = {
-    'lfsr88': lfsr88_seed,
-    'lfsr113': lfsr113_seed,
-    'lfsr128': lfsr128_seed,
-}
+# Names of every LFSR primitive defined above, in definition order. Used by
+# ``_ensure_numba_compiled`` to swap each plain-Python function for its
+# ``numba.njit`` dispatcher exactly once, on first use.
+_LFSR_FUNC_NAMES = (
+    'lfsr88_seed', 'lfsr88_next_key', 'lfsr88_randint', 'lfsr88_rand',
+    'lfsr88_randn', 'lfsr88_uniform', 'lfsr88_normal', 'lfsr88_random_integers',
+    'lfsr113_seed', 'lfsr113_next_key', 'lfsr113_randint', 'lfsr113_rand',
+    'lfsr113_randn', 'lfsr113_uniform', 'lfsr113_normal', 'lfsr113_random_integers',
+    'lfsr128_seed', 'lfsr128_next_key', 'lfsr128_randint', 'lfsr128_rand',
+    'lfsr128_randn', 'lfsr128_uniform', 'lfsr128_normal', 'lfsr128_random_integers',
+)
 
-_NUMBA_LFSR_RANDOM_INTEGERS = {
-    'lfsr88': lfsr88_random_integers,
-    'lfsr113': lfsr113_random_integers,
-    'lfsr128': lfsr128_random_integers,
-}
+# Dispatch tables mapping an algorithm name to its primitive. They are populated
+# lazily by ``_ensure_numba_compiled`` so that importing this module never
+# triggers ``import numba``; they stay empty until the first ``get_numba_lfsr_*``
+# call.
+_NUMBA_LFSR_SEED: Dict[str, Callable] = {}
+_NUMBA_LFSR_RANDOM_INTEGERS: Dict[str, Callable] = {}
+_NUMBA_LFSR_RAND: Dict[str, Callable] = {}
+_NUMBA_LFSR_RANDINT: Dict[str, Callable] = {}
+_NUMBA_LFSR_RANDN: Dict[str, Callable] = {}
+_NUMBA_LFSR_UNIFORM: Dict[str, Callable] = {}
+_NUMBA_LFSR_NORMAL: Dict[str, Callable] = {}
 
-_NUMBA_LFSR_RAND = {
-    'lfsr88': lfsr88_rand,
-    'lfsr113': lfsr113_rand,
-    'lfsr128': lfsr128_rand,
-}
+_NUMBA_COMPILED = False
 
-_NUMBA_LFSR_RANDINT = {
-    'lfsr88': lfsr88_randint,
-    'lfsr113': lfsr113_randint,
-    'lfsr128': lfsr128_randint,
-}
 
-_NUMBA_LFSR_RANDN = {
-    'lfsr88': lfsr88_randn,
-    'lfsr113': lfsr113_randn,
-    'lfsr128': lfsr128_randn,
-}
+def _ensure_numba_compiled():
+    """Numba-compile the LFSR primitives on first use and build the dispatch tables.
 
-_NUMBA_LFSR_UNIFORM = {
-    'lfsr88': lfsr88_uniform,
-    'lfsr113': lfsr113_uniform,
-    'lfsr128': lfsr128_uniform,
-}
+    Importing this module leaves every LFSR primitive as a plain-Python callable
+    so that ``import brainevent`` does not pull in (and pay the import cost of)
+    Numba. The first time a kernel generator requests a primitive through one of
+    the ``get_numba_lfsr_*`` helpers, this function imports Numba, replaces each
+    module-level primitive with its ``@numba.njit(inline='always')`` dispatcher,
+    and fills in the dispatch tables. It is idempotent.
 
-_NUMBA_LFSR_NORMAL = {
-    'lfsr88': lfsr88_normal,
-    'lfsr113': lfsr113_normal,
-    'lfsr128': lfsr128_normal,
-}
+    The module globals are rebound in place -- rather than only storing compiled
+    copies in the dispatch tables -- because the primitives call one another by
+    global name (for example ``lfsr88_rand`` calls ``lfsr88_next_key``). Numba
+    resolves those references against the live module namespace when the
+    enclosing kernel is compiled, so every primitive must already be a dispatcher
+    by then.
+
+    Notes
+    -----
+    If Numba is not installed the primitives are left as plain-Python functions
+    and the dispatch tables are built from those, mirroring the behaviour of the
+    previous import-time Numba stub.
+    """
+    global _NUMBA_COMPILED
+    if _NUMBA_COMPILED:
+        return
+
+    g = globals()
+    try:
+        import numba
+    except ImportError:
+        numba = None
+
+    if numba is not None:
+        for name in _LFSR_FUNC_NAMES:
+            g[name] = numba.njit(inline='always')(g[name])
+
+    _NUMBA_LFSR_SEED.update(
+        lfsr88=g['lfsr88_seed'], lfsr113=g['lfsr113_seed'], lfsr128=g['lfsr128_seed'],
+    )
+    _NUMBA_LFSR_RANDOM_INTEGERS.update(
+        lfsr88=g['lfsr88_random_integers'],
+        lfsr113=g['lfsr113_random_integers'],
+        lfsr128=g['lfsr128_random_integers'],
+    )
+    _NUMBA_LFSR_RAND.update(
+        lfsr88=g['lfsr88_rand'], lfsr113=g['lfsr113_rand'], lfsr128=g['lfsr128_rand'],
+    )
+    _NUMBA_LFSR_RANDINT.update(
+        lfsr88=g['lfsr88_randint'], lfsr113=g['lfsr113_randint'], lfsr128=g['lfsr128_randint'],
+    )
+    _NUMBA_LFSR_RANDN.update(
+        lfsr88=g['lfsr88_randn'], lfsr113=g['lfsr113_randn'], lfsr128=g['lfsr128_randn'],
+    )
+    _NUMBA_LFSR_UNIFORM.update(
+        lfsr88=g['lfsr88_uniform'], lfsr113=g['lfsr113_uniform'], lfsr128=g['lfsr128_uniform'],
+    )
+    _NUMBA_LFSR_NORMAL.update(
+        lfsr88=g['lfsr88_normal'], lfsr113=g['lfsr113_normal'], lfsr128=g['lfsr128_normal'],
+    )
+
+    _NUMBA_COMPILED = True
 
 
 def get_numba_lfsr_seed():
     """Return the Numba LFSR seed function for the current global algorithm."""
+    _ensure_numba_compiled()
     return _NUMBA_LFSR_SEED[get_lfsr_algorithm()]
 
 
 def get_numba_lfsr_random_integers():
     """Return the Numba LFSR random_integers function for the current global algorithm."""
+    _ensure_numba_compiled()
     return _NUMBA_LFSR_RANDOM_INTEGERS[get_lfsr_algorithm()]
 
 
 def get_numba_lfsr_uniform():
     """Return the Numba LFSR uniform function for the current global algorithm."""
+    _ensure_numba_compiled()
     return _NUMBA_LFSR_UNIFORM[get_lfsr_algorithm()]
 
 
 def get_numba_lfsr_normal():
     """Return the Numba LFSR normal function for the current global algorithm."""
+    _ensure_numba_compiled()
     return _NUMBA_LFSR_NORMAL[get_lfsr_algorithm()]
 
 
@@ -466,7 +485,7 @@ def get_numba_lfsr_funcs():
         Keys: ``'seed'``, ``'rand'``, ``'randint'``, ``'randn'``,
         ``'uniform'``, ``'normal'``, ``'random_integers'``.
     """
-
+    _ensure_numba_compiled()
     alg = get_lfsr_algorithm()
     return {
         'seed': _NUMBA_LFSR_SEED[alg],

--- a/brainevent/_numba_random_test.py
+++ b/brainevent/_numba_random_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
 import numpy as np
 import pytest
 
@@ -24,6 +29,8 @@ from brainevent._numba_random import (
     lfsr128_seed, lfsr128_rand, lfsr128_randn,
     lfsr128_random_integers,
 )
+
+_NUMBA_AVAILABLE = importlib.util.find_spec('numba') is not None
 
 
 class TestLFSR88Seed:
@@ -368,6 +375,144 @@ class TestEdgeCases:
         state = lfsr88_seed(42)
         v = lfsr88_normal(state, 0.0, -1.0)
         assert isinstance(v, float)
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Lazy Numba import / compilation
+# ──────────────────────────────────────────────────────────────────────
+
+def _run_snippet(snippet: str) -> str:
+    """Run ``snippet`` in a fresh interpreter and return its stdout.
+
+    A subprocess is used because importing the LFSR primitives and triggering
+    their lazy Numba compilation both mutate global process state that cannot be
+    reset within the running pytest session.
+    """
+    proc = subprocess.run(
+        [sys.executable, '-c', textwrap.dedent(snippet)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"subprocess failed:\n{proc.stdout}\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+class TestLazyNumbaImport:
+    """The module must not import Numba until a primitive is actually requested."""
+
+    def test_import_brainevent_does_not_import_numba(self):
+        out = _run_snippet(
+            """
+            import sys
+            import brainevent  # noqa: F401
+            print('numba' in sys.modules)
+            """
+        )
+        assert out == 'False', "importing brainevent must not import numba"
+
+    def test_import_numba_random_does_not_import_numba(self):
+        out = _run_snippet(
+            """
+            import sys
+            import brainevent._numba_random  # noqa: F401
+            print('numba' in sys.modules)
+            """
+        )
+        assert out == 'False', "importing _numba_random must not import numba"
+
+    def test_primitives_are_plain_python_before_compilation(self):
+        out = _run_snippet(
+            """
+            from brainevent import _numba_random as nr
+            print(nr._NUMBA_COMPILED)
+            print(type(nr.lfsr88_seed).__name__)
+            print(len(nr._NUMBA_LFSR_SEED))
+            """
+        )
+        compiled, kind, n_tables = out.splitlines()
+        assert compiled == 'False'
+        assert kind == 'function'          # plain Python, not a Numba dispatcher
+        assert n_tables == '0'             # dispatch tables empty until first use
+
+    @pytest.mark.skipif(not _NUMBA_AVAILABLE, reason="numba not installed")
+    def test_get_helper_triggers_numba_and_rebinds_globals(self):
+        out = _run_snippet(
+            """
+            import sys
+            from brainevent import _numba_random as nr
+            assert 'numba' not in sys.modules
+            fn = nr.get_numba_lfsr_seed()
+            print('numba' in sys.modules)
+            print(nr._NUMBA_COMPILED)
+            print(len(nr._NUMBA_LFSR_SEED))
+            print(type(fn).__module__.split('.')[0])
+            print(type(nr.lfsr88_seed).__module__.split('.')[0])
+            """
+        )
+        numba_imported, compiled, n_tables, fn_mod, global_mod = out.splitlines()
+        assert numba_imported == 'True'
+        assert compiled == 'True'
+        assert n_tables == '3'             # lfsr88 / lfsr113 / lfsr128
+        assert fn_mod == 'numba'           # getter returns a Numba dispatcher
+        assert global_mod == 'numba'       # module global rebound in place
+
+
+@pytest.mark.skipif(not _NUMBA_AVAILABLE, reason="numba not installed")
+class TestNumbaCompiledPrimitives:
+    """Behaviour of the primitives once Numba compilation has been triggered."""
+
+    def test_ensure_compiled_is_idempotent(self):
+        from brainevent import _numba_random as nr
+        nr._ensure_numba_compiled()
+        first = nr.get_numba_lfsr_seed()
+        nr._ensure_numba_compiled()        # second call must be a no-op
+        assert nr.get_numba_lfsr_seed() is first
+
+    def test_all_dispatch_tables_populated(self):
+        from brainevent import _numba_random as nr
+        funcs = nr.get_numba_lfsr_funcs()
+        assert set(funcs) == {
+            'seed', 'rand', 'randint', 'randn', 'uniform', 'normal', 'random_integers',
+        }
+        for table in (
+            nr._NUMBA_LFSR_SEED, nr._NUMBA_LFSR_RAND, nr._NUMBA_LFSR_RANDINT,
+            nr._NUMBA_LFSR_RANDN, nr._NUMBA_LFSR_UNIFORM, nr._NUMBA_LFSR_NORMAL,
+            nr._NUMBA_LFSR_RANDOM_INTEGERS,
+        ):
+            assert set(table) == {'lfsr88', 'lfsr113', 'lfsr128'}
+
+    def test_compiled_seed_matches_plain_python(self):
+        # The bare ``lfsr88_seed`` imported at module load is the plain-Python
+        # version; the getter returns the Numba dispatcher. They must agree.
+        from brainevent._numba_random import get_numba_lfsr_seed
+        compiled_seed = get_numba_lfsr_seed()
+        for s in (0, 1, 42, 2 ** 31 - 1):
+            np.testing.assert_array_equal(compiled_seed(s), lfsr88_seed(s))
+
+    def test_inline_inside_njit_kernel(self):
+        # Exercises the real usage: the primitives are inlined device functions
+        # inside another @numba.njit kernel. This only compiles if the rebound
+        # globals resolve the chained calls (normal -> randn -> rand -> next_key).
+        import numba
+        from brainevent._numba_random import (
+            get_numba_lfsr_seed, get_numba_lfsr_normal, get_numba_lfsr_uniform,
+        )
+        _seed = get_numba_lfsr_seed()
+        _normal = get_numba_lfsr_normal()
+        _uniform = get_numba_lfsr_uniform()
+
+        @numba.njit
+        def kernel(seed, n):
+            state = _seed(seed)
+            acc = 0.0
+            for _ in range(n):
+                acc += _normal(state, 0.0, 1.0)
+                acc += _uniform(state, -1.0, 1.0)
+            return acc
+
+        a = kernel(np.uint32(7), 128)
+        b = kernel(np.uint32(7), 128)
+        assert np.isfinite(a)
+        assert a == b                      # deterministic for a fixed seed
 
 
 if __name__ == '__main__':

--- a/brainevent/_op/numba_cuda_ffi.py
+++ b/brainevent/_op/numba_cuda_ffi.py
@@ -37,6 +37,7 @@ from .numba_ffi import (
     get_xla_stream,
     get_device_ordinal,
     _normalize_shapes_and_dtypes,
+    _warn_if_untested_jax,
 )
 from .util import OutType, abstract_arguments
 
@@ -363,6 +364,7 @@ class NumbaCudaFfiHandler:
         self._callback = _CUDA_FFI_CALLBACK_TYPE(self._ffi_callback)
 
         # Register as an FFI target for CUDA platform
+        _warn_if_untested_jax()
         capsule = jax.ffi.pycapsule(ctypes.cast(self._callback, c_void_p).value)
         jax.ffi.register_ffi_target(name, capsule, platform="CUDA")
 
@@ -841,6 +843,7 @@ class NumbaCudaCallableHandler:
         self._callback = _CUDA_CALLABLE_CALLBACK_TYPE(self._ffi_callback)
 
         # Register as an FFI target for CUDA platform
+        _warn_if_untested_jax()
         capsule = jax.ffi.pycapsule(ctypes.cast(self._callback, c_void_p).value)
         jax.ffi.register_ffi_target(name, capsule, platform="CUDA")
 

--- a/brainevent/_op/numba_ffi.py
+++ b/brainevent/_op/numba_ffi.py
@@ -97,6 +97,54 @@ def _detect_xla_ffi_api_version() -> Tuple[int, int]:
 XLA_FFI_API_MAJOR, XLA_FFI_API_MINOR = _detect_xla_ffi_api_version()
 
 
+# Highest ``(major, minor)`` jax release whose XLA FFI ABI — the
+# ``XLA_FFI_API_MINOR`` value and the ``ffi.h`` struct layout mirrored by the
+# ctypes definitions in this module — has been validated against this bridge.
+# This replaces the former hard ``jax<0.11`` install pin: newer jax is allowed,
+# but :func:`_warn_if_untested_jax` warns once if the ABI may have shifted.
+_MAX_VALIDATED_JAX = (0, 10)
+
+# Set the first time :func:`_warn_if_untested_jax` runs so the warning fires at
+# most once per process.
+_jax_ffi_compat_checked = False
+
+
+def _warn_if_untested_jax() -> None:
+    """Warn once if the installed jax is newer than the validated XLA FFI ABI.
+
+    Called when the bridge actually uses the XLA FFI ABI (i.e. when an FFI
+    target is registered with XLA). The numba FFI path mirrors the jaxlib
+    ``ffi.h`` struct layout and the ``XLA_FFI_API_MINOR`` handshake by hand, so a
+    jax/jaxlib release that changes that layout could silently break it. Rather
+    than pin a hard upper bound at install time, the bridge runs against any jax
+    and emits a single :class:`RuntimeWarning` when the installed version is
+    newer than :data:`_MAX_VALIDATED_JAX`, pointing the user at the issue
+    tracker. Parsing failures are ignored (no warning).
+    """
+    global _jax_ffi_compat_checked
+    if _jax_ffi_compat_checked:
+        return
+    _jax_ffi_compat_checked = True
+    try:
+        version = tuple(int(part) for part in jax.__version__.split('.')[:2])
+    except (AttributeError, ValueError):
+        return
+    if version > _MAX_VALIDATED_JAX:
+        import warnings
+
+        tested = f"{_MAX_VALIDATED_JAX[0]}.{_MAX_VALIDATED_JAX[1]}"
+        warnings.warn(
+            f"brainevent's numba XLA FFI bridge has been validated against "
+            f"jax <= {tested}.x, but jax {jax.__version__} is installed. The XLA "
+            f"FFI ABI (XLA_FFI_API_MINOR and the ffi.h struct layout) may have "
+            f"changed; if numba kernels fail to compile or return wrong results, "
+            f"please report it at "
+            f"https://github.com/chaobrain/brainevent/issues.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
 class XLA_FFI_Error_Code(enum.IntEnum):
     """Subset of XLA FFI error codes (mirrors ``absl::StatusCode``)."""
     OK = 0
@@ -558,6 +606,7 @@ class NumbaCpuFfiHandler:
         self._callback = _FFI_CALLBACK_TYPE(self._ffi_callback)
 
         # Register as an FFI target (typed FFI api_version=1 is the default in JAX 0.9+)
+        _warn_if_untested_jax()
         capsule = jax.ffi.pycapsule(ctypes.cast(self._callback, c_void_p).value)
         jax.ffi.register_ffi_target(name, capsule, platform="cpu")
 

--- a/brainevent/_op/numba_ffi_test.py
+++ b/brainevent/_op/numba_ffi_test.py
@@ -18,6 +18,7 @@
 import importlib.util
 import os
 import unittest
+import warnings
 
 os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
 
@@ -32,10 +33,14 @@ cpu_platform = jax.default_backend() == 'cpu'
 if not cpu_platform or not numba_installed:
     pytest.skip(allow_module_level=True, reason='Numba CPU FFI tests only run on CPU platform with Numba installed')
 
+from brainevent._op import numba_ffi
 from brainevent._op.numba_ffi import (
     _ensure_sequence,
     _normalize_shapes_and_dtypes,
     _numpy_from_buffer,
+    _detect_xla_ffi_api_version,
+    _warn_if_untested_jax,
+    _MAX_VALIDATED_JAX,
     _XLA_FFI_DTYPE_TO_NUMPY,
     numba_kernel,
     NumbaCpuFfiHandler,
@@ -890,6 +895,56 @@ class TestNumbaKernelInputOutputAliases(unittest.TestCase):
 
         self.assertTrue(jnp.allclose(result, expected))
         jax.block_until_ready((a, b, result, expected))
+
+
+class TestXlaFfiAbiVersionCheck:
+    """The hard ``jax<0.11`` install pin was replaced by a runtime ABI check."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_state(self):
+        # Save and restore the globals these tests mutate so ordering is safe.
+        saved_version = jax.__version__
+        saved_flag = numba_ffi._jax_ffi_compat_checked
+        yield
+        jax.__version__ = saved_version
+        numba_ffi._jax_ffi_compat_checked = saved_flag
+
+    def test_detect_returns_major_minor_tuple(self):
+        major, minor = _detect_xla_ffi_api_version()
+        assert isinstance(major, int) and isinstance(minor, int)
+        # Floor for every supported jaxlib is (0, 1); detected value is >= that.
+        assert (major, minor) >= (0, 1)
+
+    def test_no_warning_on_validated_version(self):
+        jax.__version__ = f"{_MAX_VALIDATED_JAX[0]}.{_MAX_VALIDATED_JAX[1]}.99"
+        numba_ffi._jax_ffi_compat_checked = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an error
+            _warn_if_untested_jax()
+
+    def test_warns_on_newer_version(self):
+        newer = f"{_MAX_VALIDATED_JAX[0]}.{_MAX_VALIDATED_JAX[1] + 1}.0"
+        jax.__version__ = newer
+        numba_ffi._jax_ffi_compat_checked = False
+        with pytest.warns(RuntimeWarning, match="XLA FFI ABI"):
+            _warn_if_untested_jax()
+
+    def test_warns_at_most_once(self):
+        jax.__version__ = f"{_MAX_VALIDATED_JAX[0]}.{_MAX_VALIDATED_JAX[1] + 1}.0"
+        numba_ffi._jax_ffi_compat_checked = False
+        with pytest.warns(RuntimeWarning):
+            _warn_if_untested_jax()
+        # Second call must be silent (warn-once guard).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_if_untested_jax()
+
+    def test_unparseable_version_is_silent(self):
+        jax.__version__ = "not-a-version"
+        numba_ffi._jax_ffi_compat_checked = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_if_untested_jax()  # must not raise or warn
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,15 +82,15 @@ keywords = [
     'dynamic sparsity',
 ]
 dependencies = [
-    'numpy>=1.15',
+    'numpy>=2.0',
     'brainunit>=0.0.8',
-    'absl-py',
-    # Upper-bounded because the XLA FFI ABI (XLA_FFI_API_MINOR, ffi.h layout)
-    # used by the compiled kernels can change across minor releases; an
-    # incompatible jaxlib otherwise surfaces only as a runtime load/compile
-    # failure instead of at install time.  jax and jaxlib ship in lockstep, so
-    # bounding jax bounds jaxlib (L16).
-    'jax>=0.5.0,<0.11',
+    # No upper bound: the XLA FFI ABI (XLA_FFI_API_MINOR, ffi.h layout) used by
+    # the compiled kernels can change across minor releases, but the numba FFI
+    # bridge now detects the installed jaxlib's ABI version at runtime
+    # (``_detect_xla_ffi_api_version``) and warns when jax is newer than the
+    # validated range (``_warn_if_untested_jax`` in ``_op/numba_ffi.py``),
+    # instead of pinning a hard ceiling here.
+    'jax>=0.8.0',
 ]
 
 
@@ -107,12 +107,12 @@ brainevent = "brainevent._cli:main"
 
 
 [project.optional-dependencies]
-# Upper bound mirrors the core 'jax' pin above: the FFI ABI is only tested
-# through the 0.9.x/0.10.x line (L16).
-cpu = ['jax[cpu]>=0.7.2,<0.11', 'numba']
-cuda12 = ['jax[cuda12]>=0.7.2,<0.11']
-cuda13 = ['jax[cuda13]>=0.7.2,<0.11']
-tpu = ['jax[tpu]>=0.7.2,<0.11']
+# Lower bound mirrors the core 'jax' pin above; no upper bound — FFI ABI
+# compatibility is checked at runtime (see the core 'jax' dependency note).
+cpu = ['jax[cpu]>=0.8.0', 'numba']
+cuda12 = ['jax[cuda12]>=0.8.0']
+cuda13 = ['jax[cuda13]>=0.8.0']
+tpu = ['jax[tpu]>=0.8.0']
 testing = ['pytest', 'pytest-cov']
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-numpy
-jax>=0.7.2
+numpy>=2.0
+jax>=0.8.0
 brainunit>=0.0.4
 brainstate
-absl-py
 braintools


### PR DESCRIPTION
## Summary

- **Lazy numba import**: `import brainevent` no longer imports `numba`. The LFSR primitives in `_numba_random.py` are now plain-Python functions, JIT-compiled lazily on the first `get_numba_lfsr_*` call. That call rebinds the module globals to `njit` dispatchers so the `inline='always'` cross-references (e.g. `lfsr88_rand` → `lfsr88_next_key`) still resolve when an enclosing kernel compiles. Numba-absent behaviour is preserved.
- **Dependencies**:
  - Drop `absl-py` — never imported (only a C++ `absl::StatusCode` doc reference); not in brainevent's dependency closure (jax/jaxlib don't require it).
  - `numpy>=1.15` → `numpy>=2.0`.
  - `jax`: drop the hard `<0.11` upper bound, raise the floor to `>=0.8.0` (core + cpu/cuda12/cuda13/tpu extras).
- **Runtime FFI ABI check** replaces the removed jax install pin: `_warn_if_untested_jax()` warns once, at FFI target registration, when the installed jax is newer than the validated XLA FFI ABI (`XLA_FFI_API_MINOR` / `ffi.h` layout). Wired into the CPU and both CUDA `register_ffi_target` sites.

## Why

Importing `numba` is expensive (~1–2s); it was pulled in eagerly on every `import brainevent` via `_numba_random`. The ABI version is already auto-detected from the installed `jaxlib` header, so the hard `<0.11` pin is better expressed as a runtime warning.

## Tests

- `import brainevent` / `import _numba_random` do not import numba (subprocess).
- Lazy-compilation lifecycle: plain before, dispatcher + populated tables after.
- Inline inside a real `@numba.njit` kernel (chained `normal→randn→rand→next_key`).
- FFI version-check helper: no warn on validated, warn on newer, warn-once, unparseable-version silent.

97 passed locally (incl. real numba-backed `_jit_scalar` end-to-end variants). mypy: no new errors in changed source files.