### PR TITLE
fix init pytest

### DIFF
--- a/brainevent/_csr/initialize_test.py
+++ b/brainevent/_csr/initialize_test.py
@@ -26,6 +26,17 @@ from brainevent._csr import hybrid_config as hc
 from brainevent._csr import initialize
 
 
+@pytest.fixture(autouse=True)
+def _restore_cache_dir():
+    cache_dir = brainevent.get_cache_dir()
+    hc.get_hybrid_config.cache_clear()
+    try:
+        yield
+    finally:
+        brainevent.set_cache_dir(cache_dir)
+        hc.get_hybrid_config.cache_clear()
+
+
 def test_default_config_matches_cu_defaults():
     assert hc.DEFAULT_HYBRID_CONFIG == hc.HybridConfig(256, 2048, 128, 4096)
 


### PR DESCRIPTION
Restore the original cache dir after initializing the test

## Summary by Sourcery

Ensure test runs restore the original cache directory and hybrid config cache state after execution.

Bug Fixes:
- Prevent pytest initialization from leaving a modified cache directory or stale hybrid configuration cache between tests.

Tests:
- Add an autouse pytest fixture to reset the cache directory and hybrid configuration cache around each test run.