### PR TITLE
Rename CLAUDE.md to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,5 +249,4 @@ dev/
 docs/_brand/
 docs/_static/css/brainx-header.css
 docs/_static/js/brainx-header.js
-/CLAUDE.md
 /dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+
+## Working agreement
+
+1. Before writing any code, describe approach, wait for approval.
+2. Requirements ambiguous? Ask clarifying questions before writing code.
+3. After writing code, list edge cases + suggest test cases.
+4. Bug? Write a test that reproduces it, then fix until the test passes.
+5. Every correction: reflect on the mistake, plan to avoid repeating it.
+6. All updates must happen on the worktree branch, not main. 
+7. Write specs under `docs/specs` before implementation.
+8. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
+9. Typing tests should pass mypy with no errors, but prioritize meaningful type annotations that improve readability and maintainability over exhaustive coverage of every variable.
+10. Support jax version >=0.8.0
+
+
+## Docstring style (NumPy-doc)
+
+All public classes, methods, functions must use [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html). Canonical section order:
+
+1. **Short summary** – one-line imperative description (no blank line before).
+2. **Extended summary** – optional, follow blank line after short summary.
+3. **Parameters** – each entry: `name : type` on own line, description indented below.
+4. **Returns** / **Yields** – same format as Parameters.
+5. **Raises** – exception type and when raised.
+6. **See Also** – related functions / classes.
+7. **Notes** – implementation details, math, references.
+8. **References** – numbered bibliography entries (`.. [1]`).
+9. **Examples** – runnable, doctestable code snippets.
+
+### Rules for the Examples section
+
+- Wrap example code in `.. code-block:: python` directive so Sphinx render with syntax highlighting.
+- Prefix every input line with `>>>` (continuation lines with `...`) for `doctest` compatibility.
+- Show expected output on line immediately after statement, **without** prompt prefix.
+- Separate distinct scenarios with blank `>>>` line.
+- Always include necessary imports (`import brainunit as u`, etc.) at top of example block so self-contained.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Renamed `CLAUDE.md` to `AGENTS.md`, untracked it from `.gitignore`, and committed it
- Left a small `CLAUDE.md` stub (`@AGENTS.md`) for tools that still look for that filename

## Test plan
- N/A (docs-only change)

## Summary by Sourcery

Rename and unignore the main agent working agreement document and provide a stub for the old filename for tooling compatibility.

Documentation:
- Add AGENTS.md documenting the working agreement and docstring style guidelines for the project.

Chores:
- Introduce a CLAUDE.md stub that redirects tooling to AGENTS.md.