### PR TITLE
docs(agents): record the test co-location rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 8. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
 9. Typing tests should pass mypy with no errors, but prioritize meaningful type annotations that improve readability and maintainability over exhaustive coverage of every variable.
 10. Support jax version >=0.8.0
-
+11. Co-locate tests with the code under test: each module `foo.py` has its tests in a sibling `foo_test.py` (suffix style — never a separate `tests/` directory, never the `test_*.py` prefix). 
 
 ## Docstring style (NumPy-doc)
 


### PR DESCRIPTION
Rule 11 was applied to the codebase in the test-colocation PR, but the `AGENTS.md` entry documenting it was never committed — the change had been sitting uncommitted in the working tree.

This writes the convention down: each module `foo.py` keeps its tests in a sibling `foo_test.py` — no `tests/` directory, no `test_*.py` prefix.

Docs only; no code changes.

## Summary by Sourcery

Documentation:
- Add a new rule to AGENTS.md describing the convention of co-locating tests with their corresponding modules using a foo_test.py suffix.