### PR TITLE
Scan all CUDA sources: fix two correctness bugs, remove dead code, restore the CSRMV warp tier

### DIFF
--- a/brainevent/_csr/binary_csrmm.cu
+++ b/brainevent/_csr/binary_csrmm.cu
@@ -532,9 +532,9 @@ void binary_csrmm_t_warp_hetero##SUFFIX(                                   \
 
 // float32 homogeneous
 // @BE binary_csrmm_nt_auto_homo_f32_bool
-FFI_CSRMM_NT_AUTO_HOMO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_f32_float
-FFI_CSRMM_NT_AUTO_HOMO(_f32_float, float,  float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_f32_float, float,  float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_homo_f32_bool
 FFI_CSRMM_T_WARP_HOMO(_f32_bool,  float,  int8_t)
 // @BE binary_csrmm_t_warp_homo_f32_float
@@ -542,9 +542,9 @@ FFI_CSRMM_T_WARP_HOMO(_f32_float, float,  float)
 
 // float64 homogeneous
 // @BE binary_csrmm_nt_auto_homo_f64_bool
-FFI_CSRMM_NT_AUTO_HOMO(_f64_bool,  double, int8_t, 8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_HOMO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_homo_f64_float
-FFI_CSRMM_NT_AUTO_HOMO(_f64_float, double, float,  8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_HOMO(_f64_float, double, float,  8 * 32 * sizeof(double))
 // @BE binary_csrmm_t_warp_homo_f64_bool
 FFI_CSRMM_T_WARP_HOMO(_f64_bool,  double, int8_t)
 // @BE binary_csrmm_t_warp_homo_f64_float
@@ -552,9 +552,9 @@ FFI_CSRMM_T_WARP_HOMO(_f64_float, double, float)
 
 // float16 homogeneous
 // @BE binary_csrmm_nt_auto_homo_f16_bool
-FFI_CSRMM_NT_AUTO_HOMO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_f16_float
-FFI_CSRMM_NT_AUTO_HOMO(_f16_float, __half, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_f16_float, __half, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_homo_f16_bool
 FFI_CSRMM_T_WARP_HOMO(_f16_bool,  __half, int8_t)
 // @BE binary_csrmm_t_warp_homo_f16_float
@@ -562,9 +562,9 @@ FFI_CSRMM_T_WARP_HOMO(_f16_float, __half, float)
 
 // bfloat16 homogeneous
 // @BE binary_csrmm_nt_auto_homo_bf16_bool
-FFI_CSRMM_NT_AUTO_HOMO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_bf16_float
-FFI_CSRMM_NT_AUTO_HOMO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HOMO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_homo_bf16_bool
 FFI_CSRMM_T_WARP_HOMO(_bf16_bool,  __nv_bfloat16, int8_t)
 // @BE binary_csrmm_t_warp_homo_bf16_float
@@ -576,9 +576,9 @@ FFI_CSRMM_T_WARP_HOMO(_bf16_float, __nv_bfloat16, float)
 
 // float32 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_f32_bool
-FFI_CSRMM_NT_AUTO_HETERO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_f32_float
-FFI_CSRMM_NT_AUTO_HETERO(_f32_float, float,  float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_hetero_f32_bool
 FFI_CSRMM_T_WARP_HETERO(_f32_bool,  float,  int8_t)
 // @BE binary_csrmm_t_warp_hetero_f32_float
@@ -586,9 +586,9 @@ FFI_CSRMM_T_WARP_HETERO(_f32_float, float,  float)
 
 // float64 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_f64_bool
-FFI_CSRMM_NT_AUTO_HETERO(_f64_bool,  double, int8_t, 8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_HETERO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_hetero_f64_float
-FFI_CSRMM_NT_AUTO_HETERO(_f64_float, double, float,  8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_HETERO(_f64_float, double, float,  8 * 32 * sizeof(double))
 // @BE binary_csrmm_t_warp_hetero_f64_bool
 FFI_CSRMM_T_WARP_HETERO(_f64_bool,  double, int8_t)
 // @BE binary_csrmm_t_warp_hetero_f64_float
@@ -596,9 +596,9 @@ FFI_CSRMM_T_WARP_HETERO(_f64_float, double, float)
 
 // float16 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_f16_bool
-FFI_CSRMM_NT_AUTO_HETERO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_f16_float
-FFI_CSRMM_NT_AUTO_HETERO(_f16_float, __half, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_f16_float, __half, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_hetero_f16_bool
 FFI_CSRMM_T_WARP_HETERO(_f16_bool,  __half, int8_t)
 // @BE binary_csrmm_t_warp_hetero_f16_float
@@ -606,9 +606,9 @@ FFI_CSRMM_T_WARP_HETERO(_f16_float, __half, float)
 
 // bfloat16 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_bf16_bool
-FFI_CSRMM_NT_AUTO_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_bf16_float
-FFI_CSRMM_NT_AUTO_HETERO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_HETERO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_hetero_bf16_bool
 FFI_CSRMM_T_WARP_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
 // @BE binary_csrmm_t_warp_hetero_bf16_float

--- a/brainevent/_csr/binary_csrmm.cu
+++ b/brainevent/_csr/binary_csrmm.cu
@@ -79,16 +79,16 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                              \
         IndptrT j = start;                                                         \
         _Pragma("unroll 4")                                                    \
         for (; j + 1 < end; j += 2) {                                          \
-            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);           \
-            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+1] * n + c]);          \
+            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]);   \
+            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+1] * n + c]);  \
             acc0 += w * mask0;                                                 \
             acc1 += w * mask1;                                                 \
         }                                                                      \
         for (; j < end; j++) {                                                 \
-            ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);              \
+            ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);      \
             acc0 += w * mask;                                                  \
         }                                                                      \
-        C[row * n + c] = WRITE_W(acc0 + acc1);                                 \
+        C[(size_t)row * n + c] = WRITE_W(acc0 + acc1);                         \
     }                                                                          \
 }
 
@@ -117,13 +117,13 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              
             IndptrT j = start + strip;                                              \
             _Pragma("unroll 4")                                                \
             for (; j + 8 < end; j += 16) {                                     \
-                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);       \
-                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+8] * n + c]);      \
+                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]); \
+                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+8] * n + c]); \
                 acc0 += w * mask0;                                              \
                 acc1 += w * mask1;                                              \
             }                                                                  \
             for (; j < end; j += 8) {                                           \
-                ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);          \
+                ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);  \
                 acc0 += w * mask;                                               \
             }                                                                  \
         }                                                                       \
@@ -133,7 +133,7 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              
             ACC_T sum = ACC_ZERO;                                               \
             _Pragma("unroll 8")                                                \
             for (int s = 0; s < 8; s++) sum += smem[s * 32 + lane];            \
-            C[row * n + c] = WRITE_W(sum);                                     \
+            C[(size_t)row * n + c] = WRITE_W(sum);                             \
         }                                                                       \
         __syncthreads();                                                        \
     }                                                                           \
@@ -169,16 +169,16 @@ __global__ void _csrmm_nt_warp_hetero_kern##SUFFIX(                             
         IndptrT j = start;                                                           \
         _Pragma("unroll 4")                                                      \
         for (; j + 1 < end; j += 2) {                                            \
-            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);             \
-            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+1] * n + c]);            \
+            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]);     \
+            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+1] * n + c]);    \
             acc0 += READ_W(weights[j])   * mask0;                                \
             acc1 += READ_W(weights[j+1]) * mask1;                                \
         }                                                                        \
         for (; j < end; j++) {                                                   \
-            ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);                \
+            ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);        \
             acc0 += READ_W(weights[j]) * mask;                                   \
         }                                                                        \
-        C[row * n + c] = WRITE_W(acc0 + acc1);                                   \
+        C[(size_t)row * n + c] = WRITE_W(acc0 + acc1);                           \
     }                                                                            \
 }
 
@@ -206,13 +206,13 @@ __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                            
             IndptrT j = start + strip;                                                \
             _Pragma("unroll 4")                                                  \
             for (; j + 8 < end; j += 16) {                                       \
-                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);         \
-                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+8] * n + c]);        \
+                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]); \
+                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+8] * n + c]); \
                 acc0 += READ_W(weights[j])   * mask0;                            \
                 acc1 += READ_W(weights[j+8]) * mask1;                            \
             }                                                                    \
             for (; j < end; j += 8) {                                             \
-                ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);            \
+                ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);    \
                 acc0 += READ_W(weights[j]) * mask;                               \
             }                                                                    \
         }                                                                         \
@@ -222,7 +222,7 @@ __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                            
             ACC_T sum = ACC_ZERO;                                                 \
             _Pragma("unroll 8")                                                  \
             for (int s = 0; s < 8; s++) sum += smem[s * 32 + lane];              \
-            C[row * n + c] = WRITE_W(sum);                                       \
+            C[(size_t)row * n + c] = WRITE_W(sum);                               \
         }                                                                         \
         __syncthreads();                                                          \
     }                                                                             \

--- a/brainevent/_csr/binary_csrmm.cu
+++ b/brainevent/_csr/binary_csrmm.cu
@@ -42,13 +42,6 @@
 #include "cuda_common.h"
 #include "brainevent/common.h"
 
-// Maximum grid.x dimension — caps block count for reduced scheduling overhead.
-// 4096 blocks x 128 threads = 524K threads, saturates all SMs.
-#define CSRMM_MAX_GRID_X 4096
-
-// Rows per block for warp kernels (4 warps x 32 lanes = 128 threads)
-#define CSRMM_WARP_RPB 4
-
 // =========================================================================
 // Homogeneous Weight Kernels (weights.size == 1)
 // =========================================================================

--- a/brainevent/_csr/binary_csrmm.cu
+++ b/brainevent/_csr/binary_csrmm.cu
@@ -139,28 +139,6 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                              
     }                                                                           \
 }
 
-#define DEFINE_CSRMM_T_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                  READ_W, WRITE_W, ACC_ZERO)                  \
-template <typename IndptrT> \
-__global__ void _csrmm_t_warp_homo_kern##SUFFIX(                              \
-    const WEIGHT_T* __restrict__ weights,                                     \
-    const int32_t*  __restrict__ indices,                                     \
-    const IndptrT*  __restrict__ indptr,                                      \
-    const SPIKE_T*  __restrict__ B,                                           \
-    WEIGHT_T*       __restrict__ C,                                           \
-    int m, int n                                                              \
-) {                                                                           \
-    int row       = blockIdx.x;                                               \
-    int col_start = blockIdx.y * 32;                                          \
-    int c         = col_start + (int)threadIdx.x;                             \
-    if (row >= m || c >= n) return;                                           \
-    if (!IS_ACTIVE(B[row * n + c])) return;                                  \
-    IndptrT start = indptr[row], end = indptr[row + 1];                          \
-    WEIGHT_T w_out = weights[0];                                              \
-    for (IndptrT j = start; j < end; j++) {                                       \
-        atomicAdd(&C[indices[j] * n + c], w_out);                            \
-    }                                                                         \
-}
 
 // =========================================================================
 // Heterogeneous Weight Kernels (weights.size == nnz)
@@ -250,27 +228,6 @@ __global__ void _csrmm_nt_block_hetero_kern##SUFFIX(                            
     }                                                                             \
 }
 
-#define DEFINE_CSRMM_T_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                    READ_W, WRITE_W, ACC_ZERO)                  \
-template <typename IndptrT> \
-__global__ void _csrmm_t_warp_hetero_kern##SUFFIX(                              \
-    const WEIGHT_T* __restrict__ weights,                                       \
-    const int32_t*  __restrict__ indices,                                       \
-    const IndptrT*  __restrict__ indptr,                                        \
-    const SPIKE_T*  __restrict__ B,                                             \
-    WEIGHT_T*       __restrict__ C,                                             \
-    int m, int n                                                                \
-) {                                                                             \
-    int row       = blockIdx.x;                                                 \
-    int col_start = blockIdx.y * 32;                                            \
-    int c         = col_start + (int)threadIdx.x;                               \
-    if (row >= m || c >= n) return;                                             \
-    if (!IS_ACTIVE(B[row * n + c])) return;                                    \
-    IndptrT start = indptr[row], end = indptr[row + 1];                            \
-    for (IndptrT j = start; j < end; j++) {                                         \
-        atomicAdd(&C[indices[j] * n + c], weights[j]);                         \
-    }                                                                           \
-}
 
 // =========================================================================
 // Kernel Instantiations — Homogeneous Weights
@@ -285,10 +242,6 @@ DEFINE_CSRMM_NT_BLOCK_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float, \
                             READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float, \
                             READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,   \
-                          READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,   \
-                          READ_F32, WRITE_F32, 0.0f)
 
 // float64 homogeneous
 DEFINE_CSRMM_NT_WARP_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -299,10 +252,6 @@ DEFINE_CSRMM_NT_BLOCK_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, 
                             READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMM_NT_BLOCK_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double, \
                             READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,   \
-                          READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,   \
-                          READ_F64, WRITE_F64, 0.0)
 
 // float16 homogeneous
 DEFINE_CSRMM_NT_WARP_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -313,10 +262,6 @@ DEFINE_CSRMM_NT_BLOCK_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
                             READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float, \
                             READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,   \
-                          READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,   \
-                          READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 homogeneous
 DEFINE_CSRMM_NT_WARP_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -327,10 +272,6 @@ DEFINE_CSRMM_NT_BLOCK_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, 
                             READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float, \
                             READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,   \
-                          READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,   \
-                          READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // Kernel Instantiations — Heterogeneous Weights
@@ -345,10 +286,6 @@ DEFINE_CSRMM_NT_BLOCK_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float, 
                               READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float, \
                               READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,   \
-                            READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,   \
-                            READ_F32, WRITE_F32, 0.0f)
 
 // float64 heterogeneous
 DEFINE_CSRMM_NT_WARP_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -359,10 +296,6 @@ DEFINE_CSRMM_NT_BLOCK_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double
                               READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMM_NT_BLOCK_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double, \
                               READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,   \
-                            READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,   \
-                            READ_F64, WRITE_F64, 0.0)
 
 // float16 heterogeneous
 DEFINE_CSRMM_NT_WARP_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -373,10 +306,6 @@ DEFINE_CSRMM_NT_BLOCK_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,
                               READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float, \
                               READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,   \
-                            READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,   \
-                            READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 heterogeneous
 DEFINE_CSRMM_NT_WARP_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -387,10 +316,6 @@ DEFINE_CSRMM_NT_BLOCK_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16
                               READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float, \
                               READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,   \
-                            READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,   \
-                            READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // FFI Entry Points — Homogeneous Weights
@@ -434,30 +359,6 @@ void binary_csrmm_nt_auto_homo##SUFFIX(                                         
     });                                                                         \
 }
 
-#define FFI_CSRMM_T_WARP_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)              \
-void binary_csrmm_t_warp_homo##SUFFIX(                                     \
-    const BE::Tensor weights, const BE::Tensor indices,                    \
-    const BE::Tensor indptr,  const BE::Tensor B,                          \
-    BE::Tensor C,       int64_t stream                                     \
-) {                                                                        \
-    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
-    cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
-    int m        = static_cast<int>(indptr.size(0)) - 1;                   \
-    int n        = static_cast<int>(B.size(1));                            \
-    int k        = static_cast<int>(C.size(0));                            \
-    int c_blocks = (n + 31) / 32;                                          \
-    dim3 grid(m, c_blocks);                                                \
-    WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
-        _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(              \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
-            static_cast<const int32_t*>(indices.data_ptr()),               \
-            static_cast<const IndptrT*>(indptr.data_ptr()),                \
-            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
-            d_c, m, n);                                                    \
-    });                                                                    \
-}
 
 // =========================================================================
 // FFI Entry Points — Heterogeneous Weights
@@ -501,30 +402,6 @@ void binary_csrmm_nt_auto_hetero##SUFFIX(                                       
     });                                                                         \
 }
 
-#define FFI_CSRMM_T_WARP_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)            \
-void binary_csrmm_t_warp_hetero##SUFFIX(                                   \
-    const BE::Tensor weights, const BE::Tensor indices,                    \
-    const BE::Tensor indptr,  const BE::Tensor B,                          \
-    BE::Tensor C,       int64_t stream                                     \
-) {                                                                        \
-    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
-    cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
-    int m        = static_cast<int>(indptr.size(0)) - 1;                   \
-    int n        = static_cast<int>(B.size(1));                            \
-    int k        = static_cast<int>(C.size(0));                            \
-    int c_blocks = (n + 31) / 32;                                          \
-    dim3 grid(m, c_blocks);                                                \
-    WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
-        _csrmm_t_warp_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(            \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
-            static_cast<const int32_t*>(indices.data_ptr()),               \
-            static_cast<const IndptrT*>(indptr.data_ptr()),                \
-            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
-            d_c, m, n);                                                    \
-    });                                                                    \
-}
 
 // =========================================================================
 // FFI Instantiations — Homogeneous Weights
@@ -535,40 +412,24 @@ void binary_csrmm_t_warp_hetero##SUFFIX(                                   \
 FFI_CSRMM_NT_AUTO_HOMO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_f32_float
 FFI_CSRMM_NT_AUTO_HOMO(_f32_float, float,  float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_homo_f32_bool
-FFI_CSRMM_T_WARP_HOMO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmm_t_warp_homo_f32_float
-FFI_CSRMM_T_WARP_HOMO(_f32_float, float,  float)
 
 // float64 homogeneous
 // @BE binary_csrmm_nt_auto_homo_f64_bool
 FFI_CSRMM_NT_AUTO_HOMO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_homo_f64_float
 FFI_CSRMM_NT_AUTO_HOMO(_f64_float, double, float,  8 * 32 * sizeof(double))
-// @BE binary_csrmm_t_warp_homo_f64_bool
-FFI_CSRMM_T_WARP_HOMO(_f64_bool,  double, int8_t)
-// @BE binary_csrmm_t_warp_homo_f64_float
-FFI_CSRMM_T_WARP_HOMO(_f64_float, double, float)
 
 // float16 homogeneous
 // @BE binary_csrmm_nt_auto_homo_f16_bool
 FFI_CSRMM_NT_AUTO_HOMO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_f16_float
 FFI_CSRMM_NT_AUTO_HOMO(_f16_float, __half, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_homo_f16_bool
-FFI_CSRMM_T_WARP_HOMO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmm_t_warp_homo_f16_float
-FFI_CSRMM_T_WARP_HOMO(_f16_float, __half, float)
 
 // bfloat16 homogeneous
 // @BE binary_csrmm_nt_auto_homo_bf16_bool
 FFI_CSRMM_NT_AUTO_HOMO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_homo_bf16_float
 FFI_CSRMM_NT_AUTO_HOMO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_homo_bf16_bool
-FFI_CSRMM_T_WARP_HOMO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmm_t_warp_homo_bf16_float
-FFI_CSRMM_T_WARP_HOMO(_bf16_float, __nv_bfloat16, float)
 
 // =========================================================================
 // FFI Instantiations — Heterogeneous Weights
@@ -579,37 +440,21 @@ FFI_CSRMM_T_WARP_HOMO(_bf16_float, __nv_bfloat16, float)
 FFI_CSRMM_NT_AUTO_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_f32_float
 FFI_CSRMM_NT_AUTO_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_hetero_f32_bool
-FFI_CSRMM_T_WARP_HETERO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmm_t_warp_hetero_f32_float
-FFI_CSRMM_T_WARP_HETERO(_f32_float, float,  float)
 
 // float64 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_f64_bool
 FFI_CSRMM_NT_AUTO_HETERO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_hetero_f64_float
 FFI_CSRMM_NT_AUTO_HETERO(_f64_float, double, float,  8 * 32 * sizeof(double))
-// @BE binary_csrmm_t_warp_hetero_f64_bool
-FFI_CSRMM_T_WARP_HETERO(_f64_bool,  double, int8_t)
-// @BE binary_csrmm_t_warp_hetero_f64_float
-FFI_CSRMM_T_WARP_HETERO(_f64_float, double, float)
 
 // float16 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_f16_bool
 FFI_CSRMM_NT_AUTO_HETERO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_f16_float
 FFI_CSRMM_NT_AUTO_HETERO(_f16_float, __half, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_hetero_f16_bool
-FFI_CSRMM_T_WARP_HETERO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmm_t_warp_hetero_f16_float
-FFI_CSRMM_T_WARP_HETERO(_f16_float, __half, float)
 
 // bfloat16 heterogeneous
 // @BE binary_csrmm_nt_auto_hetero_bf16_bool
 FFI_CSRMM_NT_AUTO_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_hetero_bf16_float
 FFI_CSRMM_NT_AUTO_HETERO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_hetero_bf16_bool
-FFI_CSRMM_T_WARP_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmm_t_warp_hetero_bf16_float
-FFI_CSRMM_T_WARP_HETERO(_bf16_float, __nv_bfloat16, float)

--- a/brainevent/_csr/binary_csrmv.cu
+++ b/brainevent/_csr/binary_csrmv.cu
@@ -105,28 +105,6 @@ __global__ void _csrmv_nt_block_homo_kern##SUFFIX(                              
     if (threadIdx.x == 0) output[row] = WRITE_W(acc);                           \
 }
 
-#define DEFINE_CSRMV_T_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                  READ_W, WRITE_W, ACC_ZERO)                  \
-template <typename IndptrT> \
-__global__ void _csrmv_t_warp_homo_kern##SUFFIX(                              \
-    const WEIGHT_T* __restrict__ weights,                                     \
-    const int32_t*  __restrict__ indices,                                     \
-    const IndptrT*  __restrict__ indptr,                                      \
-    const SPIKE_T*  __restrict__ vector,                                      \
-    WEIGHT_T*       __restrict__ output,                                      \
-    int m                                                                     \
-) {                                                                           \
-    int row = blockIdx.x * blockDim.x + threadIdx.x;                          \
-    if (row >= m) return;                                                     \
-    if (!IS_ACTIVE(vector[row])) return;                                      \
-    IndptrT start = indptr[row], end = indptr[row + 1];                           \
-    if (start == end) return;                                                 \
-    ACC_T w = READ_W(weights[0]);                                             \
-    WEIGHT_T w_out = WRITE_W(w);                                              \
-    for (IndptrT j = start; j < end; j++) {                                       \
-        atomicAdd(&output[indices[j]], w_out);                                \
-    }                                                                         \
-}
 
 // =========================================================================
 // Heterogeneous Weight Kernels (weights.size == nnz)
@@ -193,26 +171,6 @@ __global__ void _csrmv_nt_block_hetero_kern##SUFFIX(                            
     if (threadIdx.x == 0) output[row] = WRITE_W(acc);                             \
 }
 
-#define DEFINE_CSRMV_T_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                    READ_W, WRITE_W, ACC_ZERO)                  \
-template <typename IndptrT> \
-__global__ void _csrmv_t_warp_hetero_kern##SUFFIX(                              \
-    const WEIGHT_T* __restrict__ weights,                                       \
-    const int32_t*  __restrict__ indices,                                       \
-    const IndptrT*  __restrict__ indptr,                                        \
-    const SPIKE_T*  __restrict__ vector,                                        \
-    WEIGHT_T*       __restrict__ output,                                        \
-    int m                                                                       \
-) {                                                                             \
-    int row = blockIdx.x * blockDim.x + threadIdx.x;                            \
-    if (row >= m) return;                                                       \
-    if (!IS_ACTIVE(vector[row])) return;                                        \
-    IndptrT start = indptr[row], end = indptr[row + 1];                             \
-    if (start == end) return;                                                   \
-    for (IndptrT j = start; j < end; j++) {                                         \
-        atomicAdd(&output[indices[j]], WRITE_W(READ_W(weights[j])));            \
-    }                                                                           \
-}
 
 // =========================================================================
 // Kernel Instantiations — Homogeneous Weights
@@ -227,10 +185,6 @@ DEFINE_CSRMV_NT_BLOCK_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
                             READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                             READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,    \
-                          READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,    \
-                          READ_F32, WRITE_F32, 0.0f)
 
 // float64 homogeneous
 DEFINE_CSRMV_NT_THREAD_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -241,10 +195,6 @@ DEFINE_CSRMV_NT_BLOCK_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, 
                             READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                             READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
-DEFINE_CSRMV_T_WARP_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,    \
-                          READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMV_T_WARP_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,    \
-                          READ_F64, WRITE_F64, 0.0)
 
 // float16 homogeneous
 DEFINE_CSRMV_NT_THREAD_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -255,10 +205,6 @@ DEFINE_CSRMV_NT_BLOCK_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  
                             READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                             READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,    \
-                          READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,    \
-                          READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 homogeneous
 DEFINE_CSRMV_NT_THREAD_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -269,10 +215,6 @@ DEFINE_CSRMV_NT_BLOCK_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, 
                             READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                             READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,    \
-                          READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMV_T_WARP_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,    \
-                          READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // Kernel Instantiations — Heterogeneous Weights
@@ -287,10 +229,6 @@ DEFINE_CSRMV_NT_BLOCK_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float, 
                               READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                               READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,    \
-                            READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,    \
-                            READ_F32, WRITE_F32, 0.0f)
 
 // float64 heterogeneous
 DEFINE_CSRMV_NT_THREAD_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -301,10 +239,6 @@ DEFINE_CSRMV_NT_BLOCK_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double
                               READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                               READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
-DEFINE_CSRMV_T_WARP_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,    \
-                            READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMV_T_WARP_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,    \
-                            READ_F64, WRITE_F64, 0.0)
 
 // float16 heterogeneous
 DEFINE_CSRMV_NT_THREAD_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -315,10 +249,6 @@ DEFINE_CSRMV_NT_BLOCK_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,
                               READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                               READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,    \
-                            READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,    \
-                            READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 heterogeneous
 DEFINE_CSRMV_NT_THREAD_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -329,10 +259,6 @@ DEFINE_CSRMV_NT_BLOCK_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16
                               READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                               READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,    \
-                            READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMV_T_WARP_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,    \
-                            READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // FFI Entry Points — Homogeneous Weights
@@ -366,28 +292,6 @@ void binary_csrmv_nt_auto_homo##SUFFIX(                                         
     });                                                                         \
 }
 
-#define FFI_CSRMV_T_WARP_HOMO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)         \
-void binary_csrmv_t_warp_homo##SUFFIX(                               \
-    const BE::Tensor weights, const BE::Tensor indices,              \
-    const BE::Tensor indptr,  const BE::Tensor vector,               \
-    BE::Tensor output,  int64_t stream                               \
-) {                                                                  \
-    BE_CHECK_CSR_INDICES_INT32(indices);                             \
-    cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);      \
-    int m             = static_cast<int>(indptr.size(0)) - 1;        \
-    int k             = static_cast<int>(output.size(0));            \
-    WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
-    cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
-    int blocks = (m + 255) / 256;                                    \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
-        _csrmv_t_warp_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(      \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
-            static_cast<const int32_t*>(indices.data_ptr()),         \
-            static_cast<const IndptrT*>(indptr.data_ptr()),          \
-            static_cast<const SPIKE_C_T*>(vector.data_ptr()),        \
-            d_out, m);                                               \
-    });                                                              \
-}
 
 // =========================================================================
 // FFI Entry Points — Heterogeneous Weights
@@ -421,28 +325,6 @@ void binary_csrmv_nt_auto_hetero##SUFFIX(                                       
     });                                                                         \
 }
 
-#define FFI_CSRMV_T_WARP_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)       \
-void binary_csrmv_t_warp_hetero##SUFFIX(                             \
-    const BE::Tensor weights, const BE::Tensor indices,              \
-    const BE::Tensor indptr,  const BE::Tensor vector,               \
-    BE::Tensor output,  int64_t stream                               \
-) {                                                                  \
-    BE_CHECK_CSR_INDICES_INT32(indices);                             \
-    cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);      \
-    int m             = static_cast<int>(indptr.size(0)) - 1;        \
-    int k             = static_cast<int>(output.size(0));            \
-    WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
-    cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
-    int blocks = (m + 255) / 256;                                    \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
-        _csrmv_t_warp_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(    \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
-            static_cast<const int32_t*>(indices.data_ptr()),         \
-            static_cast<const IndptrT*>(indptr.data_ptr()),          \
-            static_cast<const SPIKE_C_T*>(vector.data_ptr()),        \
-            d_out, m);                                               \
-    });                                                              \
-}
 
 // =========================================================================
 // FFI Instantiations — Homogeneous Weights
@@ -453,40 +335,24 @@ void binary_csrmv_t_warp_hetero##SUFFIX(                             \
 FFI_CSRMV_NT_AUTO_HOMO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_homo_f32_float
 FFI_CSRMV_NT_AUTO_HOMO(_f32_float, float,  float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_homo_f32_bool
-FFI_CSRMV_T_WARP_HOMO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmv_t_warp_homo_f32_float
-FFI_CSRMV_T_WARP_HOMO(_f32_float, float,  float)
 
 // float64 homogeneous
 // @BE binary_csrmv_nt_auto_homo_f64_bool
 FFI_CSRMV_NT_AUTO_HOMO(_f64_bool,  double, int8_t, 8 * sizeof(double))
 // @BE binary_csrmv_nt_auto_homo_f64_float
 FFI_CSRMV_NT_AUTO_HOMO(_f64_float, double, float,  8 * sizeof(double))
-// @BE binary_csrmv_t_warp_homo_f64_bool
-FFI_CSRMV_T_WARP_HOMO(_f64_bool,  double, int8_t)
-// @BE binary_csrmv_t_warp_homo_f64_float
-FFI_CSRMV_T_WARP_HOMO(_f64_float, double, float)
 
 // float16 homogeneous
 // @BE binary_csrmv_nt_auto_homo_f16_bool
 FFI_CSRMV_NT_AUTO_HOMO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_homo_f16_float
 FFI_CSRMV_NT_AUTO_HOMO(_f16_float, __half, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_homo_f16_bool
-FFI_CSRMV_T_WARP_HOMO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmv_t_warp_homo_f16_float
-FFI_CSRMV_T_WARP_HOMO(_f16_float, __half, float)
 
 // bfloat16 homogeneous
 // @BE binary_csrmv_nt_auto_homo_bf16_bool
 FFI_CSRMV_NT_AUTO_HOMO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_homo_bf16_float
 FFI_CSRMV_NT_AUTO_HOMO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_homo_bf16_bool
-FFI_CSRMV_T_WARP_HOMO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmv_t_warp_homo_bf16_float
-FFI_CSRMV_T_WARP_HOMO(_bf16_float, __nv_bfloat16, float)
 
 // =========================================================================
 // FFI Instantiations — Heterogeneous Weights
@@ -497,37 +363,21 @@ FFI_CSRMV_T_WARP_HOMO(_bf16_float, __nv_bfloat16, float)
 FFI_CSRMV_NT_AUTO_HETERO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_hetero_f32_float
 FFI_CSRMV_NT_AUTO_HETERO(_f32_float, float,  float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_hetero_f32_bool
-FFI_CSRMV_T_WARP_HETERO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmv_t_warp_hetero_f32_float
-FFI_CSRMV_T_WARP_HETERO(_f32_float, float,  float)
 
 // float64 heterogeneous
 // @BE binary_csrmv_nt_auto_hetero_f64_bool
 FFI_CSRMV_NT_AUTO_HETERO(_f64_bool,  double, int8_t, 8 * sizeof(double))
 // @BE binary_csrmv_nt_auto_hetero_f64_float
 FFI_CSRMV_NT_AUTO_HETERO(_f64_float, double, float,  8 * sizeof(double))
-// @BE binary_csrmv_t_warp_hetero_f64_bool
-FFI_CSRMV_T_WARP_HETERO(_f64_bool,  double, int8_t)
-// @BE binary_csrmv_t_warp_hetero_f64_float
-FFI_CSRMV_T_WARP_HETERO(_f64_float, double, float)
 
 // float16 heterogeneous
 // @BE binary_csrmv_nt_auto_hetero_f16_bool
 FFI_CSRMV_NT_AUTO_HETERO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_hetero_f16_float
 FFI_CSRMV_NT_AUTO_HETERO(_f16_float, __half, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_hetero_f16_bool
-FFI_CSRMV_T_WARP_HETERO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmv_t_warp_hetero_f16_float
-FFI_CSRMV_T_WARP_HETERO(_f16_float, __half, float)
 
 // bfloat16 heterogeneous
 // @BE binary_csrmv_nt_auto_hetero_bf16_bool
 FFI_CSRMV_NT_AUTO_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_hetero_bf16_float
 FFI_CSRMV_NT_AUTO_HETERO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_hetero_bf16_bool
-FFI_CSRMV_T_WARP_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmv_t_warp_hetero_bf16_float
-FFI_CSRMV_T_WARP_HETERO(_bf16_float, __nv_bfloat16, float)

--- a/brainevent/_csr/binary_csrmv.cu
+++ b/brainevent/_csr/binary_csrmv.cu
@@ -67,6 +67,40 @@ __global__ void _csrmv_nt_thread_homo_kern##SUFFIX(                             
     output[row] = WRITE_W(acc);                                                  \
 }
 
+// One warp per row, several warps packed into each block and grid-strided.
+//
+// `row` derives only from blockIdx/threadIdx.x>>5, so it is warp-uniform: every
+// lane of a warp runs the same number of loop trips and reaches WARP_RED
+// together, which is the convergence precondition __shfl_down_sync requires.
+#define DEFINE_CSRMV_NT_WARP_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T,   \
+                                   READ_W, WRITE_W, WARP_RED, ACC_ZERO)          \
+template <typename IndptrT> \
+__global__ void _csrmv_nt_warp_homo_kern##SUFFIX(                                \
+    const WEIGHT_T* __restrict__ weights,                                        \
+    const int32_t*  __restrict__ indices,                                        \
+    const IndptrT*  __restrict__ indptr,                                         \
+    const SPIKE_T*  __restrict__ vector,                                         \
+    WEIGHT_T*       __restrict__ output,                                         \
+    int m                                                                        \
+) {                                                                              \
+    int lane      = threadIdx.x & 31;                                            \
+    int warp_id   = threadIdx.x >> 5;                                            \
+    int warps_per = blockDim.x >> 5;                                             \
+    ACC_T w = READ_W(weights[0]);                                                \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                    \
+         row += gridDim.x * warps_per) {                                         \
+        IndptrT start = indptr[row], end = indptr[row + 1];                      \
+        ACC_T acc = ACC_ZERO;                                                    \
+        _Pragma("unroll 2")                                                      \
+        for (IndptrT j = start + lane; j < end; j += 32) {                       \
+            ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                   \
+            acc += w * mask;                                                     \
+        }                                                                        \
+        acc = WARP_RED(acc);                                                     \
+        if (lane == 0) output[row] = WRITE_W(acc);                               \
+    }                                                                            \
+}
+
 #define DEFINE_CSRMV_NT_BLOCK_HOMO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                     READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
 template <typename IndptrT> \
@@ -134,6 +168,35 @@ __global__ void _csrmv_nt_thread_hetero_kern##SUFFIX(                           
     output[row] = WRITE_W(acc);                                                    \
 }
 
+// See DEFINE_CSRMV_NT_WARP_HOMO for the warp-uniformity argument.
+#define DEFINE_CSRMV_NT_WARP_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T,   \
+                                     READ_W, WRITE_W, WARP_RED, ACC_ZERO)          \
+template <typename IndptrT> \
+__global__ void _csrmv_nt_warp_hetero_kern##SUFFIX(                                \
+    const WEIGHT_T* __restrict__ weights,                                          \
+    const int32_t*  __restrict__ indices,                                          \
+    const IndptrT*  __restrict__ indptr,                                           \
+    const SPIKE_T*  __restrict__ vector,                                           \
+    WEIGHT_T*       __restrict__ output,                                           \
+    int m                                                                          \
+) {                                                                                \
+    int lane      = threadIdx.x & 31;                                              \
+    int warp_id   = threadIdx.x >> 5;                                              \
+    int warps_per = blockDim.x >> 5;                                               \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                      \
+         row += gridDim.x * warps_per) {                                           \
+        IndptrT start = indptr[row], end = indptr[row + 1];                        \
+        ACC_T acc = ACC_ZERO;                                                      \
+        _Pragma("unroll 2")                                                        \
+        for (IndptrT j = start + lane; j < end; j += 32) {                         \
+            ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                     \
+            acc += READ_W(weights[j]) * mask;                                      \
+        }                                                                          \
+        acc = WARP_RED(acc);                                                       \
+        if (lane == 0) output[row] = WRITE_W(acc);                                 \
+    }                                                                              \
+}
+
 #define DEFINE_CSRMV_NT_BLOCK_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                       READ_W, WRITE_W, WARP_RED, ACC_ZERO)        \
 template <typename IndptrT> \
@@ -183,7 +246,11 @@ DEFINE_CSRMV_NT_THREAD_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float, \
                              READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
                             READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
+                            READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
+                            READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                             READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 
 // float64 homogeneous
@@ -193,7 +260,11 @@ DEFINE_CSRMV_NT_THREAD_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,
                              READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
                             READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_HOMO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
+                            READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
+                            READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_HOMO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                             READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 
 // float16 homogeneous
@@ -203,7 +274,11 @@ DEFINE_CSRMV_NT_THREAD_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float, 
                              READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
                             READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
+                            READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
+                            READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                             READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 
 // bfloat16 homogeneous
@@ -213,7 +288,11 @@ DEFINE_CSRMV_NT_THREAD_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16,
                              READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
                             READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
+                            READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
+                            READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HOMO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                             READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 
 // =========================================================================
@@ -227,7 +306,11 @@ DEFINE_CSRMV_NT_THREAD_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,
                                READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
                               READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
+                              READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
+                              READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                               READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 
 // float64 heterogeneous
@@ -237,7 +320,11 @@ DEFINE_CSRMV_NT_THREAD_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, doubl
                                READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
                               READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
+                              READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
+                              READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                               READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 
 // float16 heterogeneous
@@ -247,7 +334,11 @@ DEFINE_CSRMV_NT_THREAD_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float
                                READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
                               READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
+                              READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
+                              READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                               READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 
 // bfloat16 heterogeneous
@@ -257,7 +348,11 @@ DEFINE_CSRMV_NT_THREAD_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat1
                                READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
                               READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
+                              READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
+                              READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                               READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 
 // =========================================================================
@@ -281,9 +376,13 @@ void binary_csrmv_nt_auto_homo##SUFFIX(                                         
     WEIGHT_C_T*       d_o = static_cast<WEIGHT_C_T*>(output.data_ptr());        \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
         const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
-        if (avg_nnz <= 512) {                                                   \
+        if (avg_nnz < 16) {                                                     \
             int blocks = (m + 255) / 256;                                       \
             _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else if (avg_nnz < 512) {                                             \
+            int blocks = BE_CSRMV_WARP_GRID(m);                                 \
+            _csrmv_nt_warp_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(            \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \
             _csrmv_nt_block_homo_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(         \
@@ -314,9 +413,13 @@ void binary_csrmv_nt_auto_hetero##SUFFIX(                                       
     WEIGHT_C_T*       d_o = static_cast<WEIGHT_C_T*>(output.data_ptr());        \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
         const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
-        if (avg_nnz <= 512) {                                                   \
+        if (avg_nnz < 16) {                                                     \
             int blocks = (m + 255) / 256;                                       \
             _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(        \
+                d_w, d_i, d_p, d_v, d_o, m);                                    \
+        } else if (avg_nnz < 512) {                                             \
+            int blocks = BE_CSRMV_WARP_GRID(m);                                 \
+            _csrmv_nt_warp_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \
             _csrmv_nt_block_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(       \

--- a/brainevent/_csr/binary_csrmv.cu
+++ b/brainevent/_csr/binary_csrmv.cu
@@ -381,7 +381,7 @@ void binary_csrmv_nt_auto_homo##SUFFIX(                                         
             _csrmv_nt_thread_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else if (avg_nnz < 512) {                                             \
-            int blocks = BE_CSRMV_WARP_GRID(m);                                 \
+            int blocks = BE_WARP_PER_ROW_GRID(m);                                 \
             _csrmv_nt_warp_homo_kern##SUFFIX<<<blocks, 256, 0, s>>>(            \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \
@@ -418,7 +418,7 @@ void binary_csrmv_nt_auto_hetero##SUFFIX(                                       
             _csrmv_nt_thread_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(        \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else if (avg_nnz < 512) {                                             \
-            int blocks = BE_CSRMV_WARP_GRID(m);                                 \
+            int blocks = BE_WARP_PER_ROW_GRID(m);                                 \
             _csrmv_nt_warp_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(          \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \

--- a/brainevent/_csr/binary_indexed_csrmm.cu
+++ b/brainevent/_csr/binary_indexed_csrmm.cu
@@ -141,28 +141,6 @@ __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                       
     }                                                                                 \
 }
 
-#define DEFINE_CSRMM_T_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                         READ_W, WRITE_W, ACC_ZERO)                  \
-template <typename IndptrT> \
-__global__ void _csrmm_t_warp_perm_hetero_kern##SUFFIX(                              \
-    const WEIGHT_T* __restrict__ weights,                                           \
-    const int32_t*  __restrict__ indices,                                           \
-    const IndptrT*  __restrict__ indptr,                                            \
-    const int32_t*  __restrict__ perm,                                              \
-    const SPIKE_T*  __restrict__ B,                                                 \
-    WEIGHT_T*       __restrict__ C,                                                 \
-    int m, int n                                                                    \
-) {                                                                                 \
-    int row       = blockIdx.x;                                                     \
-    int col_start = blockIdx.y * 32;                                                \
-    int c         = col_start + (int)threadIdx.x;                                   \
-    if (row >= m || c >= n) return;                                                 \
-    if (!IS_ACTIVE(B[row * n + c])) return;                                        \
-    IndptrT start = indptr[row], end = indptr[row + 1];                                \
-    for (IndptrT j = start; j < end; j++) {                                             \
-        atomicAdd(&C[indices[j] * n + c], weights[perm[j]]);                       \
-    }                                                                               \
-}
 
 // =========================================================================
 // Kernel Instantiations — Permuted Heterogeneous Weights
@@ -177,10 +155,6 @@ DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, fl
                                    READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float, \
                                    READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,   \
-                                 READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,   \
-                                 READ_F32, WRITE_F32, 0.0f)
 
 // float64 perm-heterogeneous
 DEFINE_CSRMM_NT_WARP_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -191,10 +165,6 @@ DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, d
                                    READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double, \
                                    READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,   \
-                                 READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,   \
-                                 READ_F64, WRITE_F64, 0.0)
 
 // float16 perm-heterogeneous
 DEFINE_CSRMM_NT_WARP_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -205,10 +175,6 @@ DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, f
                                    READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float, \
                                    READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,   \
-                                 READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,   \
-                                 READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 perm-heterogeneous
 DEFINE_CSRMM_NT_WARP_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -219,69 +185,11 @@ DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfl
                                    READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMM_NT_BLOCK_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float, \
                                    READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,   \
-                                 READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMM_T_WARP_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,   \
-                                 READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // FFI Entry Points — Permuted Heterogeneous Weights
 // =========================================================================
 
-#define FFI_CSRMM_NT_WARP_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)      \
-void binary_csrmm_nt_warp_perm_hetero##SUFFIX(                             \
-    const BE::Tensor weights, const BE::Tensor indices,                    \
-    const BE::Tensor indptr,  const BE::Tensor perm,                       \
-    const BE::Tensor B,       BE::Tensor C,       int64_t stream           \
-) {                                                                        \
-    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
-    cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
-    int m        = static_cast<int>(indptr.size(0)) - 1;                   \
-    int n        = static_cast<int>(B.size(1));                            \
-    int c_blocks = (n + 31) / 32;                                          \
-    int rpb      = CSRMM_WARP_RPB;                                         \
-    int gx       = (m + rpb - 1) / rpb;                                    \
-    if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                    \
-    if (gx < 1) gx = 1;                                                   \
-    dim3 grid(gx, c_blocks);                                               \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
-        _csrmm_nt_warp_perm_hetero_kern##SUFFIX<<<grid, rpb * 32, 0, s>>>( \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
-            static_cast<const int32_t*>(indices.data_ptr()),               \
-            static_cast<const IndptrT*>(indptr.data_ptr()),                \
-            static_cast<const int32_t*>(perm.data_ptr()),                  \
-            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
-            static_cast<WEIGHT_C_T*>(C.data_ptr()),                        \
-            m, n);                                                         \
-    });                                                                    \
-}
-
-#define FFI_CSRMM_NT_BLOCK_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
-void binary_csrmm_nt_block_perm_hetero##SUFFIX(                             \
-    const BE::Tensor weights, const BE::Tensor indices,                     \
-    const BE::Tensor indptr,  const BE::Tensor perm,                        \
-    const BE::Tensor B,       BE::Tensor C,       int64_t stream            \
-) {                                                                         \
-    BE_CHECK_CSR_INDICES_INT32(indices);                                    \
-    cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);              \
-    int m        = static_cast<int>(indptr.size(0)) - 1;                    \
-    int n        = static_cast<int>(B.size(1));                             \
-    int c_blocks = (n + 31) / 32;                                           \
-    int gx       = m;                                                       \
-    if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                     \
-    if (gx < 1) gx = 1;                                                    \
-    dim3 grid(gx, c_blocks);                                                \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                      \
-        _csrmm_nt_block_perm_hetero_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>( \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),             \
-            static_cast<const int32_t*>(indices.data_ptr()),                \
-            static_cast<const IndptrT*>(indptr.data_ptr()),                 \
-            static_cast<const int32_t*>(perm.data_ptr()),                   \
-            static_cast<const SPIKE_C_T*>(B.data_ptr()),                    \
-            static_cast<WEIGHT_C_T*>(C.data_ptr()),                         \
-            m, n);                                                          \
-    });                                                                     \
-}
 
 #define FFI_CSRMM_NT_AUTO_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T, SHM_SIZE) \
 void binary_csrmm_nt_auto_perm_hetero##SUFFIX(                                  \
@@ -322,80 +230,31 @@ void binary_csrmm_nt_auto_perm_hetero##SUFFIX(                                  
     });                                                                         \
 }
 
-#define FFI_CSRMM_T_WARP_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)       \
-void binary_csrmm_t_warp_perm_hetero##SUFFIX(                              \
-    const BE::Tensor weights, const BE::Tensor indices,                    \
-    const BE::Tensor indptr,  const BE::Tensor perm,                       \
-    const BE::Tensor B,       BE::Tensor C,       int64_t stream           \
-) {                                                                        \
-    BE_CHECK_CSR_INDICES_INT32(indices);                                   \
-    cudaStream_t s   = reinterpret_cast<cudaStream_t>(stream);             \
-    int m        = static_cast<int>(indptr.size(0)) - 1;                   \
-    int n        = static_cast<int>(B.size(1));                            \
-    int k        = static_cast<int>(C.size(0));                            \
-    int c_blocks = (n + 31) / 32;                                          \
-    dim3 grid(m, c_blocks);                                                \
-    WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());             \
-    cudaMemsetAsync(d_c, 0, (size_t)k * n * sizeof(WEIGHT_C_T), s);       \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                     \
-        _csrmm_t_warp_perm_hetero_kern##SUFFIX<<<grid, 32, 0, s>>>(       \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),            \
-            static_cast<const int32_t*>(indices.data_ptr()),               \
-            static_cast<const IndptrT*>(indptr.data_ptr()),                \
-            static_cast<const int32_t*>(perm.data_ptr()),                  \
-            static_cast<const SPIKE_C_T*>(B.data_ptr()),                   \
-            d_c, m, n);                                                    \
-    });                                                                    \
-}
 
 // =========================================================================
 // FFI Instantiations — Permuted Heterogeneous Weights
 // =========================================================================
 
 // float32 perm-heterogeneous
-// @BE binary_csrmm_nt_warp_perm_hetero_f32_bool
-FFI_CSRMM_NT_WARP_PERM_HETERO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmm_nt_warp_perm_hetero_f32_float
-FFI_CSRMM_NT_WARP_PERM_HETERO(_f32_float, float,  float)
-// @BE binary_csrmm_nt_block_perm_hetero_f32_bool
-FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
-// @BE binary_csrmm_nt_block_perm_hetero_f32_float
-FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f32_bool
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f32_float
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_perm_hetero_f32_bool
-FFI_CSRMM_T_WARP_PERM_HETERO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmm_t_warp_perm_hetero_f32_float
-FFI_CSRMM_T_WARP_PERM_HETERO(_f32_float, float,  float)
 
 // float64 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_f64_bool
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_perm_hetero_f64_float
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_float, double, float,  8 * 32 * sizeof(double))
-// @BE binary_csrmm_t_warp_perm_hetero_f64_bool
-FFI_CSRMM_T_WARP_PERM_HETERO(_f64_bool,  double, int8_t)
-// @BE binary_csrmm_t_warp_perm_hetero_f64_float
-FFI_CSRMM_T_WARP_PERM_HETERO(_f64_float, double, float)
 
 // float16 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_f16_bool
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f16_float
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_float, __half, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_perm_hetero_f16_bool
-FFI_CSRMM_T_WARP_PERM_HETERO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmm_t_warp_perm_hetero_f16_float
-FFI_CSRMM_T_WARP_PERM_HETERO(_f16_float, __half, float)
 
 // bfloat16 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_bf16_bool
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_bf16_float
 FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
-// @BE binary_csrmm_t_warp_perm_hetero_bf16_bool
-FFI_CSRMM_T_WARP_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmm_t_warp_perm_hetero_bf16_float
-FFI_CSRMM_T_WARP_PERM_HETERO(_bf16_float, __nv_bfloat16, float)

--- a/brainevent/_csr/binary_indexed_csrmm.cu
+++ b/brainevent/_csr/binary_indexed_csrmm.cu
@@ -41,13 +41,6 @@
 #include "cuda_common.h"
 #include "brainevent/common.h"
 
-// Maximum grid.x dimension — caps block count for reduced scheduling overhead.
-// 4096 blocks x 128 threads = 524K threads, saturates all SMs.
-#define CSRMM_MAX_GRID_X 4096
-
-// Rows per block for warp kernels (4 warps x 32 lanes = 128 threads)
-#define CSRMM_WARP_RPB 4
-
 // -------------------------------------------------------------------------
 // Permuted-heterogeneous kernels: read weights[perm[j]] (fused gather).
 // Identical to the plain heterogeneous CSR mat-mat kernels, but with an extra

--- a/brainevent/_csr/binary_indexed_csrmm.cu
+++ b/brainevent/_csr/binary_indexed_csrmm.cu
@@ -358,13 +358,13 @@ FFI_CSRMM_NT_WARP_PERM_HETERO(_f32_bool,  float,  int8_t)
 // @BE binary_csrmm_nt_warp_perm_hetero_f32_float
 FFI_CSRMM_NT_WARP_PERM_HETERO(_f32_float, float,  float)
 // @BE binary_csrmm_nt_block_perm_hetero_f32_bool
-FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_block_perm_hetero_f32_float
-FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_float, float,  float,  8 * sizeof(float))
+FFI_CSRMM_NT_BLOCK_PERM_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f32_bool
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f32_float
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_float, float,  float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f32_float, float,  float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_perm_hetero_f32_bool
 FFI_CSRMM_T_WARP_PERM_HETERO(_f32_bool,  float,  int8_t)
 // @BE binary_csrmm_t_warp_perm_hetero_f32_float
@@ -372,9 +372,9 @@ FFI_CSRMM_T_WARP_PERM_HETERO(_f32_float, float,  float)
 
 // float64 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_f64_bool
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_bool,  double, int8_t, 8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_bool,  double, int8_t, 8 * 32 * sizeof(double))
 // @BE binary_csrmm_nt_auto_perm_hetero_f64_float
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_float, double, float,  8 * sizeof(double))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f64_float, double, float,  8 * 32 * sizeof(double))
 // @BE binary_csrmm_t_warp_perm_hetero_f64_bool
 FFI_CSRMM_T_WARP_PERM_HETERO(_f64_bool,  double, int8_t)
 // @BE binary_csrmm_t_warp_perm_hetero_f64_float
@@ -382,9 +382,9 @@ FFI_CSRMM_T_WARP_PERM_HETERO(_f64_float, double, float)
 
 // float16 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_f16_bool
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_bool,  __half, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_f16_float
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_float, __half, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_f16_float, __half, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_perm_hetero_f16_bool
 FFI_CSRMM_T_WARP_PERM_HETERO(_f16_bool,  __half, int8_t)
 // @BE binary_csrmm_t_warp_perm_hetero_f16_float
@@ -392,9 +392,9 @@ FFI_CSRMM_T_WARP_PERM_HETERO(_f16_float, __half, float)
 
 // bfloat16 perm-heterogeneous
 // @BE binary_csrmm_nt_auto_perm_hetero_bf16_bool
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * 32 * sizeof(float))
 // @BE binary_csrmm_nt_auto_perm_hetero_bf16_float
-FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
+FFI_CSRMM_NT_AUTO_PERM_HETERO(_bf16_float, __nv_bfloat16, float,  8 * 32 * sizeof(float))
 // @BE binary_csrmm_t_warp_perm_hetero_bf16_bool
 FFI_CSRMM_T_WARP_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
 // @BE binary_csrmm_t_warp_perm_hetero_bf16_float

--- a/brainevent/_csr/binary_indexed_csrmm.cu
+++ b/brainevent/_csr/binary_indexed_csrmm.cu
@@ -81,16 +81,16 @@ __global__ void _csrmm_nt_warp_perm_hetero_kern##SUFFIX(                        
         IndptrT j = start;                                                               \
         _Pragma("unroll 4")                                                          \
         for (; j + 1 < end; j += 2) {                                                \
-            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);                 \
-            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+1] * n + c]);                \
+            ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]);         \
+            ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+1] * n + c]);        \
             acc0 += READ_W(weights[perm[j]])   * mask0;                              \
             acc1 += READ_W(weights[perm[j+1]]) * mask1;                              \
         }                                                                            \
         for (; j < end; j++) {                                                       \
-            ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);                    \
+            ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);            \
             acc0 += READ_W(weights[perm[j]]) * mask;                                 \
         }                                                                            \
-        C[row * n + c] = WRITE_W(acc0 + acc1);                                       \
+        C[(size_t)row * n + c] = WRITE_W(acc0 + acc1);                               \
     }                                                                                \
 }
 
@@ -119,13 +119,13 @@ __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                       
             IndptrT j = start + strip;                                                    \
             _Pragma("unroll 4")                                                      \
             for (; j + 8 < end; j += 16) {                                           \
-                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[indices[j]   * n + c]);             \
-                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[indices[j+8] * n + c]);            \
+                ACC_T mask0 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j]   * n + c]);     \
+                ACC_T mask1 = (ACC_T)IS_ACTIVE(B[(size_t)indices[j+8] * n + c]);    \
                 acc0 += READ_W(weights[perm[j]])   * mask0;                          \
                 acc1 += READ_W(weights[perm[j+8]]) * mask1;                          \
             }                                                                        \
             for (; j < end; j += 8) {                                                 \
-                ACC_T mask = (ACC_T)IS_ACTIVE(B[indices[j] * n + c]);                \
+                ACC_T mask = (ACC_T)IS_ACTIVE(B[(size_t)indices[j] * n + c]);        \
                 acc0 += READ_W(weights[perm[j]]) * mask;                             \
             }                                                                        \
         }                                                                             \
@@ -135,7 +135,7 @@ __global__ void _csrmm_nt_block_perm_hetero_kern##SUFFIX(                       
             ACC_T sum = ACC_ZERO;                                                     \
             _Pragma("unroll 8")                                                      \
             for (int s = 0; s < 8; s++) sum += smem[s * 32 + lane];                  \
-            C[row * n + c] = WRITE_W(sum);                                           \
+            C[(size_t)row * n + c] = WRITE_W(sum);                                   \
         }                                                                             \
         __syncthreads();                                                              \
     }                                                                                 \

--- a/brainevent/_csr/binary_indexed_csrmv.cu
+++ b/brainevent/_csr/binary_indexed_csrmv.cu
@@ -109,27 +109,6 @@ __global__ void _csrmv_nt_block_perm_hetero_kern##SUFFIX(                       
     if (threadIdx.x == 0) output[row] = WRITE_W(acc);                                  \
 }
 
-#define DEFINE_CSRMV_T_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
-                                         READ_W, WRITE_W, ACC_ZERO)                   \
-template <typename IndptrT> \
-__global__ void _csrmv_t_warp_perm_hetero_kern##SUFFIX(                               \
-    const WEIGHT_T* __restrict__ weights,                                            \
-    const int32_t*  __restrict__ indices,                                            \
-    const IndptrT*  __restrict__ indptr,                                             \
-    const int32_t*  __restrict__ perm,                                               \
-    const SPIKE_T*  __restrict__ vector,                                             \
-    WEIGHT_T*       __restrict__ output,                                             \
-    int m                                                                            \
-) {                                                                                  \
-    int row = blockIdx.x * blockDim.x + threadIdx.x;                                 \
-    if (row >= m) return;                                                            \
-    if (!IS_ACTIVE(vector[row])) return;                                             \
-    IndptrT start = indptr[row], end = indptr[row + 1];                                  \
-    if (start == end) return;                                                        \
-    for (IndptrT j = start; j < end; j++) {                                              \
-        atomicAdd(&output[indices[j]], WRITE_W(READ_W(weights[perm[j]])));           \
-    }                                                                                \
-}
 
 // float32 perm heterogeneous
 DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float, \
@@ -140,10 +119,6 @@ DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, fl
                                    READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                                    READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,    \
-                                 READ_F32, WRITE_F32, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,    \
-                                 READ_F32, WRITE_F32, 0.0f)
 
 // float64 perm heterogeneous
 DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double, \
@@ -154,10 +129,6 @@ DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, d
                                    READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                                    READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,    \
-                                 READ_F64, WRITE_F64, 0.0)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,    \
-                                 READ_F64, WRITE_F64, 0.0)
 
 // float16 perm heterogeneous
 DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float, \
@@ -168,10 +139,6 @@ DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, f
                                    READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                                    READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,    \
-                                 READ_F16, WRITE_F16, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,    \
-                                 READ_F16, WRITE_F16, 0.0f)
 
 // bfloat16 perm heterogeneous
 DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float, \
@@ -182,10 +149,6 @@ DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfl
                                    READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                                    READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,    \
-                                 READ_BF16, WRITE_BF16, 0.0f)
-DEFINE_CSRMV_T_WARP_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,    \
-                                 READ_BF16, WRITE_BF16, 0.0f)
 
 // =========================================================================
 // FFI Entry Points — Indexed (perm) Heterogeneous Weights
@@ -220,66 +183,27 @@ void binary_csrmv_nt_auto_perm_hetero##SUFFIX(                                  
     });                                                                             \
 }
 
-#define FFI_CSRMV_T_WARP_PERM_HETERO(SUFFIX, WEIGHT_C_T, SPIKE_C_T)  \
-void binary_csrmv_t_warp_perm_hetero##SUFFIX(                        \
-    const BE::Tensor weights, const BE::Tensor indices,             \
-    const BE::Tensor indptr,  const BE::Tensor perm,                \
-    const BE::Tensor vector,  BE::Tensor output,  int64_t stream    \
-) {                                                                 \
-    BE_CHECK_CSR_INDICES_INT32(indices);                            \
-    cudaStream_t s    = reinterpret_cast<cudaStream_t>(stream);     \
-    int m             = static_cast<int>(indptr.size(0)) - 1;       \
-    int k             = static_cast<int>(output.size(0));           \
-    WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr());\
-    cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);   \
-    int blocks = (m + 255) / 256;                                   \
-    BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {               \
-        _csrmv_t_warp_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>( \
-            static_cast<const WEIGHT_C_T*>(weights.data_ptr()),     \
-            static_cast<const int32_t*>(indices.data_ptr()),        \
-            static_cast<const IndptrT*>(indptr.data_ptr()),         \
-            static_cast<const int32_t*>(perm.data_ptr()),           \
-            static_cast<const SPIKE_C_T*>(vector.data_ptr()),       \
-            d_out, m);                                              \
-    });                                                             \
-}
 
 // float32 perm heterogeneous
 // @BE binary_csrmv_nt_auto_perm_hetero_f32_bool
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f32_bool,  float,  int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_perm_hetero_f32_float
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f32_float, float,  float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_perm_hetero_f32_bool
-FFI_CSRMV_T_WARP_PERM_HETERO(_f32_bool,  float,  int8_t)
-// @BE binary_csrmv_t_warp_perm_hetero_f32_float
-FFI_CSRMV_T_WARP_PERM_HETERO(_f32_float, float,  float)
 
 // float64 perm heterogeneous
 // @BE binary_csrmv_nt_auto_perm_hetero_f64_bool
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f64_bool,  double, int8_t, 8 * sizeof(double))
 // @BE binary_csrmv_nt_auto_perm_hetero_f64_float
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f64_float, double, float,  8 * sizeof(double))
-// @BE binary_csrmv_t_warp_perm_hetero_f64_bool
-FFI_CSRMV_T_WARP_PERM_HETERO(_f64_bool,  double, int8_t)
-// @BE binary_csrmv_t_warp_perm_hetero_f64_float
-FFI_CSRMV_T_WARP_PERM_HETERO(_f64_float, double, float)
 
 // float16 perm heterogeneous
 // @BE binary_csrmv_nt_auto_perm_hetero_f16_bool
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f16_bool,  __half, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_perm_hetero_f16_float
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_f16_float, __half, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_perm_hetero_f16_bool
-FFI_CSRMV_T_WARP_PERM_HETERO(_f16_bool,  __half, int8_t)
-// @BE binary_csrmv_t_warp_perm_hetero_f16_float
-FFI_CSRMV_T_WARP_PERM_HETERO(_f16_float, __half, float)
 
 // bfloat16 perm heterogeneous
 // @BE binary_csrmv_nt_auto_perm_hetero_bf16_bool
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t, 8 * sizeof(float))
 // @BE binary_csrmv_nt_auto_perm_hetero_bf16_float
 FFI_CSRMV_NT_AUTO_PERM_HETERO(_bf16_float, __nv_bfloat16, float,  8 * sizeof(float))
-// @BE binary_csrmv_t_warp_perm_hetero_bf16_bool
-FFI_CSRMV_T_WARP_PERM_HETERO(_bf16_bool,  __nv_bfloat16, int8_t)
-// @BE binary_csrmv_t_warp_perm_hetero_bf16_float
-FFI_CSRMV_T_WARP_PERM_HETERO(_bf16_float, __nv_bfloat16, float)

--- a/brainevent/_csr/binary_indexed_csrmv.cu
+++ b/brainevent/_csr/binary_indexed_csrmv.cu
@@ -225,7 +225,7 @@ void binary_csrmv_nt_auto_perm_hetero##SUFFIX(                                  
             _csrmv_nt_thread_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(       \
                 d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
         } else if (avg_nnz < 512) {                                                 \
-            int blocks = BE_CSRMV_WARP_GRID(m);                                     \
+            int blocks = BE_WARP_PER_ROW_GRID(m);                                     \
             _csrmv_nt_warp_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(         \
                 d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
         } else {                                                                    \

--- a/brainevent/_csr/binary_indexed_csrmv.cu
+++ b/brainevent/_csr/binary_indexed_csrmv.cu
@@ -71,6 +71,38 @@ __global__ void _csrmv_nt_thread_perm_hetero_kern##SUFFIX(                      
     output[row] = WRITE_W(acc);                                                         \
 }
 
+// One warp per row, 8 warps packed per block, grid-strided. `row` is
+// warp-uniform, so every lane reaches WARP_RED together — the convergence
+// precondition __shfl_down_sync requires.
+#define DEFINE_CSRMV_NT_WARP_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T,  \
+                                          READ_W, WRITE_W, WARP_RED, ACC_ZERO)         \
+template <typename IndptrT> \
+__global__ void _csrmv_nt_warp_perm_hetero_kern##SUFFIX(                               \
+    const WEIGHT_T* __restrict__ weights,                                              \
+    const int32_t*  __restrict__ indices,                                              \
+    const IndptrT*  __restrict__ indptr,                                               \
+    const int32_t*  __restrict__ perm,                                                 \
+    const SPIKE_T*  __restrict__ vector,                                               \
+    WEIGHT_T*       __restrict__ output,                                               \
+    int m                                                                              \
+) {                                                                                    \
+    int lane      = threadIdx.x & 31;                                                  \
+    int warp_id   = threadIdx.x >> 5;                                                  \
+    int warps_per = blockDim.x >> 5;                                                   \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                          \
+         row += gridDim.x * warps_per) {                                               \
+        IndptrT start = indptr[row], end = indptr[row + 1];                            \
+        ACC_T acc = ACC_ZERO;                                                          \
+        _Pragma("unroll 2")                                                            \
+        for (IndptrT j = start + lane; j < end; j += 32) {                             \
+            ACC_T mask = (ACC_T)IS_ACTIVE(vector[indices[j]]);                         \
+            acc += READ_W(weights[perm[j]]) * mask;                                    \
+        }                                                                              \
+        acc = WARP_RED(acc);                                                           \
+        if (lane == 0) output[row] = WRITE_W(acc);                                     \
+    }                                                                                  \
+}
+
 #define DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(SUFFIX, SPIKE_T, IS_ACTIVE, WEIGHT_T, ACC_T, \
                                            READ_W, WRITE_W, WARP_RED, ACC_ZERO)         \
 template <typename IndptrT> \
@@ -117,7 +149,11 @@ DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, f
                                     READ_F32, WRITE_F32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
                                    READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f32_bool,  int8_t, IS_ACTIVE_BOOL,  float, float,  \
+                                   READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
+                                   READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f32_float, float,  IS_ACTIVE_FLOAT, float, float,  \
                                    READ_F32, WRITE_F32, warp_reduce_sum_f32, 0.0f)
 
 // float64 perm heterogeneous
@@ -127,7 +163,11 @@ DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, 
                                     READ_F64, WRITE_F64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
                                    READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f64_bool,  int8_t, IS_ACTIVE_BOOL,  double, double,  \
+                                   READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
+                                   READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f64_float, float,  IS_ACTIVE_FLOAT, double, double,  \
                                    READ_F64, WRITE_F64, warp_reduce_sum_f64, 0.0)
 
 // float16 perm heterogeneous
@@ -137,7 +177,11 @@ DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, 
                                     READ_F16, WRITE_F16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
                                    READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f16_bool,  int8_t, IS_ACTIVE_BOOL,  __half, float,  \
+                                   READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
+                                   READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_f16_float, float,  IS_ACTIVE_FLOAT, __half, float,  \
                                    READ_F16, WRITE_F16, warp_reduce_sum_f32, 0.0f)
 
 // bfloat16 perm heterogeneous
@@ -147,7 +191,11 @@ DEFINE_CSRMV_NT_THREAD_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bf
                                     READ_BF16, WRITE_BF16, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
                                    READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_bf16_bool,  int8_t, IS_ACTIVE_BOOL,  __nv_bfloat16, float,  \
+                                   READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 DEFINE_CSRMV_NT_BLOCK_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
+                                   READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
+DEFINE_CSRMV_NT_WARP_PERM_HETERO(_bf16_float, float,  IS_ACTIVE_FLOAT, __nv_bfloat16, float,  \
                                    READ_BF16, WRITE_BF16, warp_reduce_sum_f32, 0.0f)
 
 // =========================================================================
@@ -172,9 +220,13 @@ void binary_csrmv_nt_auto_perm_hetero##SUFFIX(                                  
     WEIGHT_C_T*       d_o    = static_cast<WEIGHT_C_T*>(output.data_ptr());         \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                               \
         const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());        \
-        if (avg_nnz <= 512) {                                                       \
+        if (avg_nnz < 16) {                                                         \
             int blocks = (m + 255) / 256;                                          \
             _csrmv_nt_thread_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(       \
+                d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
+        } else if (avg_nnz < 512) {                                                 \
+            int blocks = BE_CSRMV_WARP_GRID(m);                                     \
+            _csrmv_nt_warp_perm_hetero_kern##SUFFIX<<<blocks, 256, 0, s>>>(         \
                 d_w, d_i, d_p, d_perm, d_v, d_o, m);                                \
         } else {                                                                    \
             _csrmv_nt_block_perm_hetero_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(      \

--- a/brainevent/_csr/binary_indexed_test.py
+++ b/brainevent/_csr/binary_indexed_test.py
@@ -845,11 +845,16 @@ def test_indexed_mm_cuda_kernel_selects_perm_names():
 
     from pathlib import Path
     cu = Path(mod.__file__).with_name("binary_indexed_csrmm.cu").read_text()
-    assert "DEFINE_CSRMM_T_WARP_PERM_HETERO" in cu
+    # ``nt_auto_perm`` is the only exported permuted entry point: it dispatches
+    # internally to the warp and block device kernels, which therefore stay.
     assert "DEFINE_CSRMM_NT_WARP_PERM_HETERO" in cu
     assert "DEFINE_CSRMM_NT_BLOCK_PERM_HETERO" in cu
-    assert "binary_csrmm_t_warp_perm_hetero_f32_bool" in cu
     assert "binary_csrmm_nt_auto_perm_hetero_f32_bool" in cu
+    # The transpose route moved to the hybrid kernels, so the permuted
+    # ``t_warp`` family has no caller and must not come back.
+    assert "DEFINE_CSRMM_T_WARP_PERM_HETERO" not in cu
+    assert "FFI_CSRMM_T_WARP_PERM_HETERO" not in cu
+    assert "binary_csrmm_t_warp_perm_hetero" not in cu
 
 
 def test_import_brainevent_needs_no_nvcc():

--- a/brainevent/_csr/binary_test.py
+++ b/brainevent/_csr/binary_test.py
@@ -1397,3 +1397,98 @@ def test_binary_csrmm_nt_block_shared_memory_is_large_enough(homo):
         expected = binary_csrmm(*args, backend='jax_raw', **kwargs)
 
         assert jnp.allclose(got, expected, rtol=1e-10, atol=1e-10)
+
+
+# ``binary_csrmv_nt_auto`` picks one of three row-mapping strategies from the
+# average row length: one thread per row below 16, one warp per row up to 512,
+# one block per row above that. The warp tier used to be missing, so rows of
+# moderate length fell to the thread kernel and read ``indices``/``weights``
+# uncoalesced -- measurably slower than a warp-per-row mapping. These row
+# lengths straddle both thresholds so every branch is exercised.
+_CSRMV_TIER_NNZ_PER_ROW = [4, 15, 16, 64, 511, 512, 1024]
+
+
+@requires_gpu_backend
+@pytest.mark.slow
+@pytest.mark.parametrize('nnz_per_row', _CSRMV_TIER_NNZ_PER_ROW)
+@pytest.mark.parametrize('homo', [False, True])
+def test_binary_csrmv_matches_reference_across_dispatch_tiers(nnz_per_row, homo):
+    """Every ``nt_auto`` row-mapping strategy must agree with the reference."""
+    with jax_x64_enabled():
+        rng = np.random.default_rng(nnz_per_row)
+        m, k = 256, 2048
+        indptr = np.arange(0, (m + 1) * nnz_per_row, nnz_per_row, dtype=np.int32)
+        indices = np.concatenate([
+            np.sort(rng.choice(k, nnz_per_row, replace=False)).astype(np.int32)
+            for _ in range(m)
+        ])
+        nnz = int(indptr[-1])
+        weights = rng.standard_normal(1 if homo else nnz).astype(np.float64)
+        vector = rng.random(k) < 0.5
+
+        workspace = _make_binary_task_workspace(jnp.asarray(indptr))
+        kwargs = dict(shape=(m, k), transpose=False, workspace=workspace)
+        args = (jnp.asarray(weights), jnp.asarray(indices),
+                jnp.asarray(indptr), jnp.asarray(vector))
+
+        got = binary_csrmv(*args, backend='cuda_raw', **kwargs)
+        expected = binary_csrmv(*args, backend='jax_raw', **kwargs)
+
+        assert jnp.allclose(got, expected, rtol=1e-10, atol=1e-10)
+
+
+@requires_gpu_backend
+@pytest.mark.slow
+def test_binary_csrmv_warp_tier_handles_ragged_and_empty_rows():
+    """The warp kernel must tolerate empty rows and a row count off the tiling.
+
+    One warp handles one row and the grid is strided, so a row count that is
+    not a multiple of the warps-per-block, mixed with empty and over-long rows,
+    is the case where an off-by-one in the row loop or a divergent lane in the
+    shuffle reduction would show up.
+    """
+    with jax_x64_enabled():
+        rng = np.random.default_rng(7)
+        k = 1024
+        # average stays in the warp tier while individual rows vary wildly
+        row_lengths = np.array([0, 1, 33, 0, 200, 64, 0, 7, 512, 90, 0, 31, 63, 65, 128],
+                               dtype=np.int32)
+        m = row_lengths.size
+        assert 16 <= row_lengths.sum() // m < 512, 'must land in the warp tier'
+        indptr = np.concatenate([[0], np.cumsum(row_lengths)]).astype(np.int32)
+        indices = np.concatenate(
+            [np.sort(rng.choice(k, int(n), replace=False)).astype(np.int32)
+             for n in row_lengths]
+        ).astype(np.int32)
+        weights = rng.standard_normal(int(indptr[-1])).astype(np.float64)
+        vector = rng.random(k) < 0.5
+
+        workspace = _make_binary_task_workspace(jnp.asarray(indptr))
+        kwargs = dict(shape=(m, k), transpose=False, workspace=workspace)
+        args = (jnp.asarray(weights), jnp.asarray(indices),
+                jnp.asarray(indptr), jnp.asarray(vector))
+
+        got = binary_csrmv(*args, backend='cuda_raw', **kwargs)
+        expected = binary_csrmv(*args, backend='jax_raw', **kwargs)
+
+        assert jnp.allclose(got, expected, rtol=1e-10, atol=1e-10)
+        # empty rows must be written, not left uninitialised
+        assert jnp.all(jnp.asarray(got)[row_lengths == 0] == 0.0)
+
+
+def test_binary_csrmv_cuda_source_keeps_three_dispatch_tiers():
+    """``nt_auto`` must keep the warp tier between the thread and block tiers.
+
+    Source-level so it runs without a GPU. A two-tier dispatcher still computes
+    the right answer, so the numeric tests above cannot catch its removal.
+    """
+    from pathlib import Path
+
+    cu = Path(binary_mod.__file__).with_name('binary_csrmv.cu').read_text()
+    for kind in ('homo', 'hetero'):
+        assert f'DEFINE_CSRMV_NT_WARP_{kind.upper()}(' in cu
+        assert f'_csrmv_nt_warp_{kind}_kern' in cu
+    # the three-way ladder itself
+    assert cu.count('if (avg_nnz < 16)') == 2
+    assert cu.count('} else if (avg_nnz < 512) {') == 2
+    assert 'avg_nnz <= 512' not in cu, 'two-tier dispatch came back'

--- a/brainevent/_csr/binary_test.py
+++ b/brainevent/_csr/binary_test.py
@@ -21,6 +21,7 @@ import brainstate
 import braintools
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from brainevent._csr.binary import (
@@ -1350,3 +1351,49 @@ def test_binary_csrmm_cuda_accepts_int64_indptr(transpose, homo):
                             backend='jax_raw', workspace=workspace32)
 
     assert jnp.allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+# The ``nt_block`` strategy inside ``binary_csrmm_nt_auto_*`` is only selected when
+# ``avg_nnz > 512``; its block reduction stages one accumulator per (strip, lane)
+# pair, i.e. 8 * 32 elements of shared memory. The launch used to request only
+# ``8 * sizeof(ACC_T)`` bytes -- a 32x under-request that overran the block's
+# dynamic shared-memory window. For float32 the overrun happened to stay inside the
+# driver's allocation granularity, but float64 (2048 bytes needed, 64 requested)
+# faulted with CUDA_ERROR_ILLEGAL_ADDRESS.
+_NT_BLOCK_NNZ_PER_ROW = 1024  # > 512 so nt_auto picks the block kernel
+
+
+def _dense_csr_operands(rng, m, k, n, dtype, homo):
+    """Build a CSR/dense pair whose average row length selects the block kernel."""
+    indptr = np.arange(0, (m + 1) * _NT_BLOCK_NNZ_PER_ROW,
+                       _NT_BLOCK_NNZ_PER_ROW, dtype=np.int32)
+    indices = np.concatenate([
+        np.sort(rng.choice(k, _NT_BLOCK_NNZ_PER_ROW, replace=False)).astype(np.int32)
+        for _ in range(m)
+    ])
+    nnz = int(indptr[-1])
+    weights = rng.standard_normal(1 if homo else nnz).astype(dtype)
+    matrix = rng.random((k, n)) < 0.5
+    return weights, indices, indptr, matrix
+
+
+@requires_gpu_backend
+@pytest.mark.slow
+@pytest.mark.parametrize('homo', [False, True])
+def test_binary_csrmm_nt_block_shared_memory_is_large_enough(homo):
+    """float64 ``nt_auto`` must not fault when it routes to the block kernel."""
+    with jax_x64_enabled():
+        rng = np.random.default_rng(0)
+        m, k, n = 32, 2048, 64
+        weights, indices, indptr, matrix = _dense_csr_operands(
+            rng, m, k, n, np.float64, homo
+        )
+        workspace = _make_binary_task_workspace(jnp.asarray(indptr))
+        kwargs = dict(shape=(m, k), transpose=False, workspace=workspace)
+        args = (jnp.asarray(weights), jnp.asarray(indices),
+                jnp.asarray(indptr), jnp.asarray(matrix))
+
+        got = binary_csrmm(*args, backend='cuda_raw', **kwargs)
+        expected = binary_csrmm(*args, backend='jax_raw', **kwargs)
+
+        assert jnp.allclose(got, expected, rtol=1e-10, atol=1e-10)

--- a/brainevent/_csr/dt2t.cu
+++ b/brainevent/_csr/dt2t.cu
@@ -62,7 +62,8 @@
  *                   non-zeros with step 32.  Writes are coalesced within each
  *                   warp stride.  Best when avg_nnz 8 – 512: enough non-zeros
  *                   per row to saturate a warp without the overhead of a block.
- *                   Grid: (m, 1, 1)   Block: (32, 1, 1)
+ *                   Grid: (BE_WARP_PER_ROW_GRID(m), 1, 1)   Block: (256, 1, 1)
+ *                   i.e. 8 warps (= 8 rows) per block, grid-strided.
  *
  *   NT_nz_thread:   1 thread per non-zero j.  Thread finds its row via O(log m)
  *                   binary search in indptr, then computes w[j]*y[row].
@@ -172,17 +173,21 @@ __global__ void _dt2t_nt_row_warp_kern##SUFFIX(                                 
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
 ) {                                                                              \
-    int row = blockIdx.x;                                                        \
-    if (row >= m) return;                                                        \
-    /* Broadcast: all 32 threads in the warp read the same y[row].           */  \
-    /* On modern NVIDIA GPUs this is served from L1 with a single cache line  */ \
-    /* fetch; no extra transactions compared to a single-thread read.         */ \
-    ACC_T y_val = READ_W(y[row]);                                                \
-    IndptrT start = indptr[row], end = indptr[row + 1];                              \
-    /* Warp-stride loop: threads handle j = start+tid, start+tid+32, ...      */ \
-    /* Consecutive threads write consecutive output elements -> coalesced.    */ \
-    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                   \
-        output[j] = WRITE_W(READ_W(w[j]) * y_val);                               \
+    int lane      = threadIdx.x & 31;                                            \
+    int warp_id   = threadIdx.x >> 5;                                            \
+    int warps_per = blockDim.x >> 5;                                             \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                    \
+         row += gridDim.x * warps_per) {                                         \
+        /* Broadcast: all 32 lanes of the warp read the same y[row].         */  \
+        /* On modern NVIDIA GPUs this is served from L1 with a single cache  */  \
+        /* line fetch; no extra transactions vs. a single-thread read.       */  \
+        ACC_T y_val = READ_W(y[row]);                                            \
+        IndptrT start = indptr[row], end = indptr[row + 1];                      \
+        /* Warp-stride loop: lanes handle j = start+lane, start+lane+32, ... */  \
+        /* Consecutive lanes write consecutive output elements -> coalesced. */  \
+        for (IndptrT j = start + lane; j < end; j += 32) {                       \
+            output[j] = WRITE_W(READ_W(w[j]) * y_val);                           \
+        }                                                                        \
     }                                                                            \
 }
 
@@ -335,7 +340,7 @@ void csrmv_dt2t_nt_auto##SUFFIX(                                                
             int blocks = (m + 255) / 256;                                                       \
             _dt2t_nt_row_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m); \
         } else if (avg_nnz < 512) {                                                             \
-            _dt2t_nt_row_warp_kern##SUFFIX<<<m, 32, 0, s>>>(d_y, d_w, d_ptr, d_out, m);         \
+            _dt2t_nt_row_warp_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(m), 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m);         \
         } else {                                                                                \
             const int VEC_SIZE = 4;                                                             \
             int total_threads = (nse + VEC_SIZE - 1) / VEC_SIZE;                                \
@@ -413,17 +418,21 @@ __global__ void _dt2t_mm_nt_row_warp_kern##SUFFIX(                              
     WEIGHT_T*       __restrict__ output,                                          \
     int m, int nse                                                                \
 ) {                                                                               \
-    int row = blockIdx.x;                                                         \
-    if (row >= m) return;                                                         \
+    int lane      = threadIdx.x & 31;                                             \
+    int warp_id   = threadIdx.x >> 5;                                             \
+    int warps_per = blockDim.x >> 5;                                              \
     int b = blockIdx.y;                                                           \
     const WEIGHT_T* w_b   = w      + (int64_t)b * nse;                            \
     WEIGHT_T*       out_b = output + (int64_t)b * nse;                            \
-    /* Broadcast: all 32 threads in the warp read the same y[b, row]. */          \
-    ACC_T y_val = READ_W(y[(int64_t)b * m + row]);                                \
-    IndptrT start = indptr[row], end = indptr[row + 1];                           \
-    /* Warp-stride loop -> coalesced writes within each stride segment. */        \
-    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                \
-        out_b[j] = WRITE_W(READ_W(w_b[j]) * y_val);                               \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                     \
+         row += gridDim.x * warps_per) {                                          \
+        /* Broadcast: all 32 lanes of the warp read the same y[b, row]. */        \
+        ACC_T y_val = READ_W(y[(int64_t)b * m + row]);                            \
+        IndptrT start = indptr[row], end = indptr[row + 1];                       \
+        /* Warp-stride loop -> coalesced writes within each stride segment. */    \
+        for (IndptrT j = start + lane; j < end; j += 32) {                        \
+            out_b[j] = WRITE_W(READ_W(w_b[j]) * y_val);                           \
+        }                                                                         \
     }                                                                             \
 }
 
@@ -520,8 +529,8 @@ void csrmm_dt2t_nt_auto##SUFFIX(                                                
             dim3 grid((m + 255) / 256, n_batch, 1);                                                   \
             _dt2t_mm_nt_row_thread_kern##SUFFIX<<<grid, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m, nse); \
         } else if (avg_nnz < 512) {                                                                   \
-            dim3 grid(m, n_batch, 1);                                                                 \
-            _dt2t_mm_nt_row_warp_kern##SUFFIX<<<grid, 32, 0, s>>>(d_y, d_w, d_ptr, d_out, m, nse);    \
+            dim3 grid(BE_WARP_PER_ROW_GRID(m), n_batch, 1);                                           \
+            _dt2t_mm_nt_row_warp_kern##SUFFIX<<<grid, 256, 0, s>>>(d_y, d_w, d_ptr, d_out, m, nse);   \
         } else {                                                                                      \
             const int VEC_SIZE = 4;                                                                   \
             int total_threads = (nse + VEC_SIZE - 1) / VEC_SIZE;                                      \

--- a/brainevent/_csr/float_csrmm.cu
+++ b/brainevent/_csr/float_csrmm.cu
@@ -86,9 +86,9 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                           \
     ACC_T w   = READ_W(weights[0]);                                         \
     ACC_T acc = ACC_ZERO;                                                   \
     for (IndptrT j = start; j < end; j++) {                                     \
-        acc += w * READ_W(B[indices[j] * n + c]);                           \
+        acc += w * READ_W(B[(size_t)indices[j] * n + c]);                   \
     }                                                                       \
-    C[row * n + c] = WRITE_W(acc);                                          \
+    C[(size_t)row * n + c] = WRITE_W(acc);                                  \
 }
 
 #define DEFINE_CSRMM_NT_BLOCK_HOMO(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, \
@@ -115,7 +115,7 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                           \
     ACC_T acc = ACC_ZERO;                                                    \
     if (c < n) {                                                             \
         for (IndptrT j = start + strip; j < end; j += 8) {                       \
-            acc += w * READ_W(B[indices[j] * n + c]);                        \
+            acc += w * READ_W(B[(size_t)indices[j] * n + c]);                \
         }                                                                    \
     }                                                                        \
     smem[strip * 32 + lane] = acc;                                           \
@@ -123,7 +123,7 @@ __global__ void _csrmm_nt_block_homo_kern##SUFFIX(                           \
     if (strip == 0 && c < n) {                                               \
         acc = ACC_ZERO;                                                      \
         for (int s = 0; s < 8; s++) acc += smem[s * 32 + lane];              \
-        C[row * n + c] = WRITE_W(acc);                                       \
+        C[(size_t)row * n + c] = WRITE_W(acc);                               \
     }                                                                        \
 }
 
@@ -142,12 +142,12 @@ __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                           \
     int col_start = blockIdx.y * 32;                                       \
     int c         = col_start + (int)threadIdx.x;                          \
     if (row >= m || c >= n) return;                                        \
-    ACC_T b_val   = READ_W(B[row * n + c]);                                \
+    ACC_T b_val   = READ_W(B[(size_t)row * n + c]);                        \
     ACC_T w       = READ_W(weights[0]);                                    \
     ACC_T contrib = w * b_val;                                             \
     IndptrT start = indptr[row], end = indptr[row + 1];                        \
     for (IndptrT j = start; j < end; j++) {                                    \
-        ATOMIC_ADD_W(&C[indices[j] * n + c], contrib);                     \
+        ATOMIC_ADD_W(&C[(size_t)indices[j] * n + c], contrib);             \
     }                                                                      \
 }
 

--- a/brainevent/_csr/float_csrmm.cu
+++ b/brainevent/_csr/float_csrmm.cu
@@ -78,17 +78,23 @@ __global__ void _csrmm_nt_warp_homo_kern##SUFFIX(                           \
     WEIGHT_T*       __restrict__ C,                                         \
     int m, int n                                                            \
 ) {                                                                         \
-    int row       = blockIdx.x;                                             \
+    int warp_id   = threadIdx.x >> 5;                                       \
+    int lane      = threadIdx.x & 31;                                       \
+    int rpb       = blockDim.x >> 5;                                        \
     int col_start = blockIdx.y * 32;                                        \
-    int c         = col_start + (int)threadIdx.x;                           \
-    if (row >= m || c >= n) return;                                         \
-    IndptrT start = indptr[row], end = indptr[row + 1];                         \
-    ACC_T w   = READ_W(weights[0]);                                         \
-    ACC_T acc = ACC_ZERO;                                                   \
-    for (IndptrT j = start; j < end; j++) {                                     \
-        acc += w * READ_W(B[(size_t)indices[j] * n + c]);                   \
+    int c         = col_start + lane;                                       \
+    if (c >= n) return;                                                     \
+    ACC_T w = READ_W(weights[0]);                                           \
+    for (int base = blockIdx.x * rpb; base < m; base += gridDim.x * rpb) {  \
+        int row = base + warp_id;                                           \
+        if (row >= m) continue;                                             \
+        IndptrT start = indptr[row], end = indptr[row + 1];                 \
+        ACC_T acc = ACC_ZERO;                                               \
+        for (IndptrT j = start; j < end; j++) {                             \
+            acc += w * READ_W(B[(size_t)indices[j] * n + c]);               \
+        }                                                                   \
+        C[(size_t)row * n + c] = WRITE_W(acc);                              \
     }                                                                       \
-    C[(size_t)row * n + c] = WRITE_W(acc);                                  \
 }
 
 #define DEFINE_CSRMM_NT_BLOCK_HOMO(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, \
@@ -138,16 +144,21 @@ __global__ void _csrmm_t_warp_homo_kern##SUFFIX(                           \
     WEIGHT_T*       __restrict__ C,                                        \
     int m, int n                                                           \
 ) {                                                                        \
-    int row       = blockIdx.x;                                            \
+    int warp_id   = threadIdx.x >> 5;                                      \
+    int lane      = threadIdx.x & 31;                                      \
+    int rpb       = blockDim.x >> 5;                                       \
     int col_start = blockIdx.y * 32;                                       \
-    int c         = col_start + (int)threadIdx.x;                          \
-    if (row >= m || c >= n) return;                                        \
-    ACC_T b_val   = READ_W(B[(size_t)row * n + c]);                        \
-    ACC_T w       = READ_W(weights[0]);                                    \
-    ACC_T contrib = w * b_val;                                             \
-    IndptrT start = indptr[row], end = indptr[row + 1];                        \
-    for (IndptrT j = start; j < end; j++) {                                    \
-        ATOMIC_ADD_W(&C[(size_t)indices[j] * n + c], contrib);             \
+    int c         = col_start + lane;                                      \
+    if (c >= n) return;                                                    \
+    ACC_T w = READ_W(weights[0]);                                          \
+    for (int base = blockIdx.x * rpb; base < m; base += gridDim.x * rpb) { \
+        int row = base + warp_id;                                          \
+        if (row >= m) continue;                                            \
+        ACC_T contrib = w * READ_W(B[(size_t)row * n + c]);                \
+        IndptrT start = indptr[row], end = indptr[row + 1];                \
+        for (IndptrT j = start; j < end; j++) {                            \
+            ATOMIC_ADD_W(&C[(size_t)indices[j] * n + c], contrib);         \
+        }                                                                  \
     }                                                                      \
 }
 
@@ -200,7 +211,6 @@ void csrmm_nt_auto_homo##SUFFIX(                                                
     int n           = static_cast<int>(B.size(1));                              \
     int avg_nnz     = (m > 0) ? (nse / m) : 0;                                  \
     int c_blocks    = (n + 31) / 32;                                            \
-    dim3 grid(m, c_blocks);                                                     \
     const WEIGHT_C_T* d_w = static_cast<const WEIGHT_C_T*>(weights.data_ptr()); \
     const int32_t*    d_i = static_cast<const int32_t*>(indices.data_ptr());    \
     const WEIGHT_C_T* d_b = static_cast<const WEIGHT_C_T*>(B.data_ptr());       \
@@ -208,9 +218,15 @@ void csrmm_nt_auto_homo##SUFFIX(                                                
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                           \
         const IndptrT* d_p = static_cast<const IndptrT*>(indptr.data_ptr());    \
         if (avg_nnz <= 64) {                                                    \
-            _csrmm_nt_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(               \
+            int gx = (m + CSRMM_WARP_RPB - 1) / CSRMM_WARP_RPB;                 \
+            if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                   \
+            if (gx < 1) gx = 1;                                                 \
+            dim3 warp_grid(gx, c_blocks);                                       \
+            _csrmm_nt_warp_homo_kern##SUFFIX                                    \
+                <<<warp_grid, CSRMM_WARP_RPB * 32, 0, s>>>(                     \
                 d_w, d_i, d_p, d_b, d_c, m, n);                                 \
         } else {                                                                \
+            dim3 grid(m, c_blocks);                                             \
             _csrmm_nt_block_homo_kern##SUFFIX<<<grid, 256, SHM_SIZE, s>>>(      \
                 d_w, d_i, d_p, d_b, d_c, m, n);                                 \
         }                                                                       \
@@ -231,9 +247,12 @@ void csrmm_t_warp_homo##SUFFIX(                                             \
     WEIGHT_C_T* d_c = static_cast<WEIGHT_C_T*>(C.data_ptr());               \
     cudaMemsetAsync(d_c, 0, (size_t)k * (size_t)n * sizeof(WEIGHT_C_T), s); \
     int c_blocks    = (n + 31) / 32;                                        \
-    dim3 grid(m, c_blocks);                                                 \
+    int gx          = (m + CSRMM_WARP_RPB - 1) / CSRMM_WARP_RPB;            \
+    if (gx > CSRMM_MAX_GRID_X) gx = CSRMM_MAX_GRID_X;                       \
+    if (gx < 1) gx = 1;                                                     \
+    dim3 grid(gx, c_blocks);                                                \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                       \
-        _csrmm_t_warp_homo_kern##SUFFIX<<<grid, 32, 0, s>>>(                \
+        _csrmm_t_warp_homo_kern##SUFFIX<<<grid, CSRMM_WARP_RPB * 32, 0, s>>>( \
             static_cast<const WEIGHT_C_T*>(weights.data_ptr()),             \
             static_cast<const int32_t*>(indices.data_ptr()),                \
             static_cast<const IndptrT*>(indptr.data_ptr()),                 \

--- a/brainevent/_csr/float_csrmv.cu
+++ b/brainevent/_csr/float_csrmv.cu
@@ -86,16 +86,20 @@ __global__ void _csrmv_nt_warp_kern##SUFFIX(                                    
     WEIGHT_T*       __restrict__ output,                                                   \
     int m                                                                                  \
 ) {                                                                                        \
-    int row = blockIdx.x;                                                                  \
-    if (row >= m) return;                                                                  \
-    IndptrT start = indptr[row], end = indptr[row + 1];                                        \
-    ACC_T acc = ACC_ZERO;                                                                  \
-    ACC_T w   = READ_W(weights[0]);                                                        \
-    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                             \
-        acc += w * READ_W(vector[indices[j]]);                                             \
+    int lane      = threadIdx.x & 31;                                                      \
+    int warp_id   = threadIdx.x >> 5;                                                      \
+    int warps_per = blockDim.x >> 5;                                                       \
+    ACC_T w = READ_W(weights[0]);                                                          \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                              \
+         row += gridDim.x * warps_per) {                                                   \
+        IndptrT start = indptr[row], end = indptr[row + 1];                                \
+        ACC_T acc = ACC_ZERO;                                                              \
+        for (IndptrT j = start + lane; j < end; j += 32) {                                 \
+            acc += w * READ_W(vector[indices[j]]);                                         \
+        }                                                                                  \
+        acc = WARP_RED(acc);                                                               \
+        if (lane == 0) output[row] = WRITE_W(acc);                                         \
     }                                                                                      \
-    acc = WARP_RED(acc);                                                                   \
-    if (threadIdx.x == 0) output[row] = WRITE_W(acc);                                      \
 }
 
 #define DEFINE_CSRMV_NT_BLOCK(SUFFIX, WEIGHT_T, ACC_T, READ_W, WRITE_W, WARP_RED, ACC_ZERO) \
@@ -139,13 +143,18 @@ __global__ void _csrmv_t_warp_kern##SUFFIX(                                     
     WEIGHT_T*       __restrict__ output,                                         \
     int m                                                                        \
 ) {                                                                              \
-    int row = blockIdx.x;                                                        \
-    if (row >= m) return;                                                        \
-    ACC_T v_val = READ_W(vector[row]);                                           \
-    IndptrT start = indptr[row], end = indptr[row + 1];                              \
-    WEIGHT_T contrib = WRITE_W(READ_W(weights[0]) * v_val);                      \
-    for (IndptrT j = start + (int)threadIdx.x; j < end; j += 32) {                   \
-        atomicAdd(&output[indices[j]], contrib);                                 \
+    int lane      = threadIdx.x & 31;                                            \
+    int warp_id   = threadIdx.x >> 5;                                            \
+    int warps_per = blockDim.x >> 5;                                             \
+    ACC_T w0 = READ_W(weights[0]);                                               \
+    for (int row = blockIdx.x * warps_per + warp_id; row < m;                    \
+         row += gridDim.x * warps_per) {                                         \
+        ACC_T v_val = READ_W(vector[row]);                                       \
+        IndptrT start = indptr[row], end = indptr[row + 1];                      \
+        WEIGHT_T contrib = WRITE_W(w0 * v_val);                                  \
+        for (IndptrT j = start + lane; j < end; j += 32) {                       \
+            atomicAdd(&output[indices[j]], contrib);                             \
+        }                                                                        \
     }                                                                            \
 }
 
@@ -190,7 +199,7 @@ void csrmv_nt_auto##SUFFIX(                                                     
             _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(               \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else if (avg_nnz < 512) {                                             \
-            _csrmv_nt_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                       \
+            _csrmv_nt_warp_kern##SUFFIX<<<BE_CSRMV_WARP_GRID(m), 256, 0, s>>>(  \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \
             _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(              \
@@ -212,7 +221,7 @@ void csrmv_t_warp##SUFFIX(                                           \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
-        _csrmv_t_warp_kern##SUFFIX<<<m, 32, 0, s>>>(                 \
+        _csrmv_t_warp_kern##SUFFIX<<<BE_CSRMV_WARP_GRID(m), 256, 0, s>>>( \
             static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
             static_cast<const int32_t*>(indices.data_ptr()),         \
             static_cast<const IndptrT*>(indptr.data_ptr()),          \

--- a/brainevent/_csr/float_csrmv.cu
+++ b/brainevent/_csr/float_csrmv.cu
@@ -199,7 +199,7 @@ void csrmv_nt_auto##SUFFIX(                                                     
             _csrmv_nt_thread_kern##SUFFIX<<<blocks, 256, 0, s>>>(               \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else if (avg_nnz < 512) {                                             \
-            _csrmv_nt_warp_kern##SUFFIX<<<BE_CSRMV_WARP_GRID(m), 256, 0, s>>>(  \
+            _csrmv_nt_warp_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(m), 256, 0, s>>>(  \
                 d_w, d_i, d_p, d_v, d_o, m);                                    \
         } else {                                                                \
             _csrmv_nt_block_kern##SUFFIX<<<m, 256, SHM_SIZE, s>>>(              \
@@ -221,7 +221,7 @@ void csrmv_t_warp##SUFFIX(                                           \
     WEIGHT_C_T* d_out = static_cast<WEIGHT_C_T*>(output.data_ptr()); \
     cudaMemsetAsync(d_out, 0, (size_t)k * sizeof(WEIGHT_C_T), s);    \
     BE_DISPATCH_CSR_INDPTR(indptr.dtype(), IndptrT, {                \
-        _csrmv_t_warp_kern##SUFFIX<<<BE_CSRMV_WARP_GRID(m), 256, 0, s>>>( \
+        _csrmv_t_warp_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(m), 256, 0, s>>>( \
             static_cast<const WEIGHT_C_T*>(weights.data_ptr()),      \
             static_cast<const int32_t*>(indices.data_ptr()),         \
             static_cast<const IndptrT*>(indptr.data_ptr()),          \

--- a/brainevent/_csr/slice_csr_slice_rows.cu
+++ b/brainevent/_csr/slice_csr_slice_rows.cu
@@ -129,7 +129,8 @@ __global__ void _slice_fwd_thread_hetero_kern##SUFFIX(                    \
 //   - __ldg() intrinsic routes read-only loads through texture cache
 //   - Scalar tail handles non-multiple-of-4 remainder elements
 //
-// Grid: (num_selected, 1, 1)   Block: (32, 1, 1)
+// Grid: (BE_WARP_PER_ROW_GRID(num_selected), 1, 1)   Block: (256, 1, 1)
+// i.e. 8 warps (= 8 selected rows) per block, grid-strided over the capped grid.
 // =========================================================================
 
 #define DEFINE_SLICE_FWD_WARP_HOMO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
@@ -142,16 +143,19 @@ __global__ void _slice_fwd_warp_homo_kern##SUFFIX(                    \
     WEIGHT_T*       __restrict__ output,                              \
     int m, int n_cols, int num_selected                               \
 ) {                                                                   \
-    int k = blockIdx.x;                                               \
-    if (k >= num_selected) return;                                    \
-    int r = row_indices[k];                                           \
-    if (r < 0 || r >= m) return;                                      \
-    IndptrT start = indptr[r], end = indptr[r + 1];                       \
-    int lane = (int)threadIdx.x;   /* 0..31 */                        \
-    WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;               \
+    int lane      = threadIdx.x & 31;                                 \
+    int warp_id   = threadIdx.x >> 5;                                 \
+    int warps_per = blockDim.x >> 5;                                  \
     WEIGHT_T w = WRITE_W(READ_W(data[0]));                            \
-    for (IndptrT j = start + lane; j < end; j += 32)                      \
-        row_out[indices[j]] = w;                                      \
+    for (int k = blockIdx.x * warps_per + warp_id; k < num_selected;  \
+         k += gridDim.x * warps_per) {                                \
+        int r = row_indices[k];                                       \
+        if (r < 0 || r >= m) continue;                                \
+        IndptrT start = indptr[r], end = indptr[r + 1];               \
+        WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;           \
+        for (IndptrT j = start + lane; j < end; j += 32)              \
+            row_out[indices[j]] = w;                                  \
+    }                                                                 \
 }
 
 #define DEFINE_SLICE_FWD_WARP_HETERO(SUFFIX, WEIGHT_T, READ_W, WRITE_W) \
@@ -164,17 +168,20 @@ __global__ void _slice_fwd_warp_hetero_kern##SUFFIX(                    \
     WEIGHT_T*       __restrict__ output,                                \
     int m, int n_cols, int num_selected                                 \
 ) {                                                                     \
-    int k = blockIdx.x;                                                 \
-    if (k >= num_selected) return;                                      \
-    int r = row_indices[k];                                             \
-    if (r < 0 || r >= m) return;                                        \
-    IndptrT start = indptr[r], end = indptr[r + 1];                         \
-    int lane = (int)threadIdx.x;   /* 0..31 */                          \
-    WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;                 \
-    for (IndptrT j = start + lane; j < end; j += 32) {                      \
-        int col = __ldg(&indices[j]);                                   \
-        WEIGHT_T val = WRITE_W(READ_W(__ldg(&data[j])));                \
-        row_out[col] = val;                                             \
+    int lane      = threadIdx.x & 31;                                   \
+    int warp_id   = threadIdx.x >> 5;                                   \
+    int warps_per = blockDim.x >> 5;                                    \
+    for (int k = blockIdx.x * warps_per + warp_id; k < num_selected;    \
+         k += gridDim.x * warps_per) {                                  \
+        int r = row_indices[k];                                         \
+        if (r < 0 || r >= m) continue;                                  \
+        IndptrT start = indptr[r], end = indptr[r + 1];                 \
+        WEIGHT_T* row_out = output + (ptrdiff_t)k * n_cols;             \
+        for (IndptrT j = start + lane; j < end; j += 32) {              \
+            int col = __ldg(&indices[j]);                               \
+            WEIGHT_T val = WRITE_W(READ_W(__ldg(&data[j])));            \
+            row_out[col] = val;                                         \
+        }                                                               \
     }                                                                   \
 }
 
@@ -273,7 +280,8 @@ __global__ void _slice_grad_thread_kern##SUFFIX(                 \
 // to ct_data[j].  Parallel warp execution hides atomicAdd latency well
 // for medium-to-large rows.
 //
-// Grid: (num_selected, 1, 1)   Block: (32, 1, 1)
+// Grid: (BE_WARP_PER_ROW_GRID(num_selected), 1, 1)   Block: (256, 1, 1)
+// i.e. 8 warps (= 8 selected rows) per block, grid-strided over the capped grid.
 // =========================================================================
 
 #define DEFINE_SLICE_GRAD_WARP(SUFFIX, WEIGHT_T, ATOMIC_ADD_W) \
@@ -286,17 +294,20 @@ __global__ void _slice_grad_warp_kern##SUFFIX(                 \
     WEIGHT_T*       __restrict__ ct_data,                      \
     int m, int n_cols, int num_selected                        \
 ) {                                                            \
-    int k = blockIdx.x;                                        \
-    if (k >= num_selected) return;                             \
-    int r = row_indices[k];                                    \
-    if (r < 0 || r >= m) return;                               \
-    IndptrT start = indptr[r], end = indptr[r + 1];                \
-    int lane = (int)threadIdx.x;                               \
-    const WEIGHT_T* ct_row = ct + (ptrdiff_t)k * n_cols;       \
-    for (IndptrT j = start + lane; j < end; j += 32) {             \
-        int col = __ldg(&indices[j]);                          \
-        WEIGHT_T val = __ldg(&ct_row[col]);                    \
-        ATOMIC_ADD_W(&ct_data[j], val);                        \
+    int lane      = threadIdx.x & 31;                          \
+    int warp_id   = threadIdx.x >> 5;                          \
+    int warps_per = blockDim.x >> 5;                           \
+    for (int k = blockIdx.x * warps_per + warp_id;             \
+         k < num_selected; k += gridDim.x * warps_per) {       \
+        int r = row_indices[k];                                \
+        if (r < 0 || r >= m) continue;                         \
+        IndptrT start = indptr[r], end = indptr[r + 1];        \
+        const WEIGHT_T* ct_row = ct + (ptrdiff_t)k * n_cols;   \
+        for (IndptrT j = start + lane; j < end; j += 32) {     \
+            int col = __ldg(&indices[j]);                      \
+            WEIGHT_T val = __ldg(&ct_row[col]);                \
+            ATOMIC_ADD_W(&ct_data[j], val);                    \
+        }                                                      \
     }                                                          \
 }
 
@@ -411,7 +422,7 @@ void csr_slice_rows_fwd_homo_auto##SUFFIX(                                      
                 d_data, d_indices, d_indptr, d_rows, d_output,                          \
                 m, n_cols, num_selected);                                               \
         } else if (avg_nnz < 512.0f) {                                                  \
-            _slice_fwd_warp_homo_kern##SUFFIX<<<num_selected, 32, 0, s>>>(              \
+            _slice_fwd_warp_homo_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(num_selected), 256, 0, s>>>(              \
                 d_data, d_indices, d_indptr, d_rows, d_output,                          \
                 m, n_cols, num_selected);                                               \
         } else {                                                                        \
@@ -450,7 +461,7 @@ void csr_slice_rows_fwd_hetero_auto##SUFFIX(                                    
                 d_data, d_indices, d_indptr, d_rows, d_output,                          \
                 m, n_cols, num_selected);                                               \
         } else if (avg_nnz < 512.0f) {                                                  \
-            _slice_fwd_warp_hetero_kern##SUFFIX<<<num_selected, 32, 0, s>>>(            \
+            _slice_fwd_warp_hetero_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(num_selected), 256, 0, s>>>(            \
                 d_data, d_indices, d_indptr, d_rows, d_output,                          \
                 m, n_cols, num_selected);                                               \
         } else {                                                                        \
@@ -489,7 +500,7 @@ void csr_slice_rows_grad_auto##SUFFIX(                                          
                 d_ct, d_indices, d_indptr, d_rows, d_ctdata,                           \
                 m, n_cols, num_selected);                                              \
         } else {                                                                       \
-            _slice_grad_warp_kern##SUFFIX<<<num_selected, 32, 0, s>>>(                 \
+            _slice_grad_warp_kern##SUFFIX<<<BE_WARP_PER_ROW_GRID(num_selected), 256, 0, s>>>(                 \
                 d_ct, d_indices, d_indptr, d_rows, d_ctdata,                           \
                 m, n_cols, num_selected);                                              \
         }                                                                              \

--- a/brainevent/_jit_normal/csr.cu
+++ b/brainevent/_jit_normal/csr.cu
@@ -293,7 +293,7 @@ __global__ void _count_chunks_notrans_f32_kern(
     unsigned int chunk_count = warp_sum_u32(lane_count);
     if (lane == 0)
     {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -338,7 +338,7 @@ __global__ void _fill_notrans_f32_kern(
     unsigned int lane_count = count_lane_connections(
         seed0, row, chunk_id, lane, cl, chunk_width);
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float loc = READ_F32(__ldg(&w_loc[0]));
     float scale = READ_F32(__ldg(&w_scale[0]));
@@ -400,7 +400,7 @@ __global__ void _count_chunks_notrans_mm_aw_t4_f32_kern(
     unsigned int chunk_count = group4_sum_u32(lane_count, group);
     if (sub_lane == 0)
     {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -447,7 +447,7 @@ __global__ void _fill_notrans_mm_aw_t4_f32_kern(
     unsigned int lane_count = count_lane_connections_t4(
         seed0, row, chunk_id, sub_lane, cl, chunk_width);
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float loc = READ_F32(__ldg(&w_loc[0]));
     float scale = READ_F32(__ldg(&w_scale[0]));
@@ -1062,7 +1062,7 @@ __global__ void _fill_notrans##SFX##_kern( \
     unsigned int lane_count = count_lane_connections( \
         seed0, row, chunk_id, lane, cl, chunk_width); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T loc = READ_W(__ldg(&w_loc[0])); \
     ACC_T scale = READ_W(__ldg(&w_scale[0])); \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, lane); \
@@ -1113,7 +1113,7 @@ __global__ void _fill_notrans_mm_aw_t4##SFX##_kern( \
     unsigned int lane_count = count_lane_connections_t4( \
         seed0, row, chunk_id, sub_lane, cl, chunk_width); \
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T loc = READ_W(__ldg(&w_loc[0])); \
     ACC_T scale = READ_W(__ldg(&w_scale[0])); \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, sub_lane); \

--- a/brainevent/_jit_normal/dt2t.cu
+++ b/brainevent/_jit_normal/dt2t.cu
@@ -219,7 +219,7 @@ __global__ void _fill_dt2t_f32_kern(
         seed0, row, chunk_id, lane, cl, chunk_width
     );
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float loc = __ldg(&w_loc[0]);
     float scale = __ldg(&w_scale[0]);
@@ -355,7 +355,7 @@ __global__ void _fill_dt2t##SFX##_kern( \
         seed0, row, chunk_id, lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T loc = READ_W(__ldg(&w_loc[0])); \
     ACC_T scale = READ_W(__ldg(&w_scale[0])); \
     ACC_T y_row = TRANSPOSE ? (ACC_T)0 : READ_W(__ldg(&y[row])); \

--- a/brainevent/_jit_scalar/csr.cu
+++ b/brainevent/_jit_scalar/csr.cu
@@ -223,7 +223,7 @@ __global__ void _count_chunks_notrans_f32_kern(
     );
     unsigned int chunk_count = warp_sum_u32(lane_count);
     if (lane == 0) {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -259,7 +259,7 @@ __global__ void _count_chunks_notrans_mm_aw_t4_f32_kern(
     );
     unsigned int chunk_count = group4_sum_u32(lane_count, group);
     if (sub_lane == 0) {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -295,7 +295,7 @@ __global__ void _fill_notrans_f32_kern(
         seed0, row, chunk_id, lane, cl, chunk_width
     );
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float w = READ_F32(__ldg(&weight[0]));
 
@@ -348,7 +348,7 @@ __global__ void _fill_notrans_mm_aw_t4_f32_kern(
         seed0, row, chunk_id, sub_lane, cl, chunk_width
     );
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float w = READ_F32(__ldg(&weight[0]));
 
@@ -898,7 +898,7 @@ __global__ void _fill_notrans##SFX##_kern( \
         seed0, row, chunk_id, lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T w = READ_W(__ldg(&weight[0])); \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, lane); \
     unsigned int q = stationary_initial_q(&rng, cl); \
@@ -947,7 +947,7 @@ __global__ void _fill_notrans_mm_aw_t4##SFX##_kern( \
         seed0, row, chunk_id, sub_lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T w = READ_W(__ldg(&weight[0])); \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, sub_lane); \
     unsigned int q = stationary_initial_q(&rng, cl); \

--- a/brainevent/_jit_scalar/dt2t.cu
+++ b/brainevent/_jit_scalar/dt2t.cu
@@ -173,7 +173,7 @@ __global__ void _fill_dt2t_f32_kern(
         seed0, row, chunk_id, lane, cl, chunk_width
     );
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float w = READ_F32(__ldg(&weight[0]));
     float y_row = TRANSPOSE ? 0.0f : __ldg(&y[row]);
@@ -302,7 +302,7 @@ __global__ void _fill_dt2t##SFX##_kern( \
         seed0, row, chunk_id, lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T w = READ_W(__ldg(&weight[0])); \
     ACC_T y_row = TRANSPOSE ? (ACC_T)0 : READ_W(__ldg(&y[row])); \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, lane); \

--- a/brainevent/_jit_uniform/csr.cu
+++ b/brainevent/_jit_uniform/csr.cu
@@ -223,7 +223,7 @@ __global__ void _count_chunks_notrans_f32_kern(
     );
     unsigned int chunk_count = warp_sum_u32(lane_count);
     if (lane == 0) {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -259,7 +259,7 @@ __global__ void _count_chunks_notrans_mm_aw_t4_f32_kern(
     );
     unsigned int chunk_count = group4_sum_u32(lane_count, group);
     if (sub_lane == 0) {
-        chunk_counts[row * n_chunks + chunk_id] = (int)chunk_count;
+        chunk_counts[(size_t)row * n_chunks + chunk_id] = (int)chunk_count;
     }
 }
 
@@ -296,7 +296,7 @@ __global__ void _fill_notrans_f32_kern(
         seed0, row, chunk_id, lane, cl, chunk_width
     );
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float wlo = READ_F32(__ldg(&w_low[0]));
     float range = READ_F32(__ldg(&w_high[0])) - wlo;
@@ -351,7 +351,7 @@ __global__ void _fill_notrans_mm_aw_t4_f32_kern(
         seed0, row, chunk_id, sub_lane, cl, chunk_width
     );
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float wlo = READ_F32(__ldg(&w_low[0]));
     float range = READ_F32(__ldg(&w_high[0])) - wlo;
@@ -577,7 +577,7 @@ __global__ void _fill_notrans##SFX##_kern( \
         seed0, row, chunk_id, lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T wlo = READ_W(__ldg(&w_low[0])); \
     ACC_T range = READ_W(__ldg(&w_high[0])) - wlo; \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, lane); \
@@ -629,7 +629,7 @@ __global__ void _fill_notrans_mm_aw_t4##SFX##_kern( \
         seed0, row, chunk_id, sub_lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = group4_exclusive_prefix_u32(lane_count, sub_lane, group); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T wlo = READ_W(__ldg(&w_low[0])); \
     ACC_T range = READ_W(__ldg(&w_high[0])) - wlo; \
     unsigned int rng = light_rng_init_wpr(seed0, row, chunk_id, sub_lane); \

--- a/brainevent/_jit_uniform/dt2t.cu
+++ b/brainevent/_jit_uniform/dt2t.cu
@@ -174,7 +174,7 @@ __global__ void _fill_dt2t_f32_kern(
         seed0, row, chunk_id, lane, cl, chunk_width
     );
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane);
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset;
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset;
 
     float wlo = __ldg(&w_low[0]);
     float range = __ldg(&w_high[0]) - wlo;
@@ -227,7 +227,7 @@ __global__ void _fill_dt2t##SFX##_kern( \
         seed0, row, chunk_id, lane, cl, chunk_width \
     ); \
     unsigned int lane_offset = warp_exclusive_prefix_u32(lane_count, lane); \
-    int base = __ldg(&chunk_offsets[row * n_chunks + chunk_id]) + (int)lane_offset; \
+    int base = __ldg(&chunk_offsets[(size_t)row * n_chunks + chunk_id]) + (int)lane_offset; \
     ACC_T wlo = READ_W(__ldg(&w_low[0])); \
     ACC_T range = READ_W(__ldg(&w_high[0])) - wlo; \
     ACC_T y_row = TRANSPOSE ? (ACC_T)0 : READ_W(__ldg(&y[row])); \

--- a/brainevent/include/cuda_common.h
+++ b/brainevent/include/cuda_common.h
@@ -263,6 +263,19 @@ __host__ __inline__ int be_csrmv_warp_grid(int m) {
 #define BE_CSRMV_WARP_GRID(m) be_csrmv_warp_grid(m)
 
 // =========================================================================
+// Launch Geometry — warp-per-row SpMM
+// =========================================================================
+//
+// SpMM warp kernels map lanes to *columns* (32 columns per warp) and warps to
+// rows, so the row tiling is a separate knob from the CSRMV one above.
+
+/** Maximum grid.x for SpMM warp kernels; 4096 x 128 threads saturates all SMs. */
+#define CSRMM_MAX_GRID_X 4096
+
+/** Rows per block for SpMM warp kernels (4 warps x 32 lanes = 128 threads). */
+#define CSRMM_WARP_RPB 4
+
+// =========================================================================
 // Atomic Add Helpers (with CUDA arch guards)
 // =========================================================================
 

--- a/brainevent/include/cuda_common.h
+++ b/brainevent/include/cuda_common.h
@@ -225,6 +225,44 @@ __device__ __inline__ double warp_reduce_sum_f64(double val) {
 #define ZERO_BF16 0.0f  // accumulator is float32
 
 // =========================================================================
+// Launch Geometry — warp-per-row SpMV
+// =========================================================================
+
+/**
+ * Warps per block for the warp-per-row SpMV tier.
+ *
+ * 8 warps == 256 threads, so one block retires 8 rows per sweep. Measured
+ * 2-3x faster than the one-warp-per-block (`<<<m, 32>>>`) shape at low average
+ * row length, and never slower.
+ */
+#define BE_CSRMV_WARP_WARPS_PER_BLOCK 8
+
+/** Upper bound on the warp-tier grid; the kernels are grid-strided. */
+#define BE_CSRMV_WARP_MAX_GRID 4096
+
+/**
+ * Grid size covering @p m rows at ::BE_CSRMV_WARP_WARPS_PER_BLOCK rows per
+ * block, capped at ::BE_CSRMV_WARP_MAX_GRID so the grid tracks the resident
+ * block count instead of scaling with the row count.
+ *
+ * Kernels launched with this must be grid-strided, since the cap can make the
+ * grid smaller than the row count. Never returns 0: an empty matrix still gets
+ * one block (which exits immediately), because a zero-sized grid is an invalid
+ * launch configuration.
+ *
+ * @param m  Number of rows.
+ * @return   Number of blocks to launch, in [1, ::BE_CSRMV_WARP_MAX_GRID].
+ */
+__host__ __inline__ int be_csrmv_warp_grid(int m) {
+    int blocks = (m + BE_CSRMV_WARP_WARPS_PER_BLOCK - 1) / BE_CSRMV_WARP_WARPS_PER_BLOCK;
+    if (blocks > BE_CSRMV_WARP_MAX_GRID) blocks = BE_CSRMV_WARP_MAX_GRID;
+    return blocks > 0 ? blocks : 1;
+}
+
+/** Convenience spelling of ::be_csrmv_warp_grid for use inside launch macros. */
+#define BE_CSRMV_WARP_GRID(m) be_csrmv_warp_grid(m)
+
+// =========================================================================
 // Atomic Add Helpers (with CUDA arch guards)
 // =========================================================================
 

--- a/brainevent/include/cuda_common.h
+++ b/brainevent/include/cuda_common.h
@@ -225,24 +225,24 @@ __device__ __inline__ double warp_reduce_sum_f64(double val) {
 #define ZERO_BF16 0.0f  // accumulator is float32
 
 // =========================================================================
-// Launch Geometry — warp-per-row SpMV
+// Launch Geometry — one warp per row (SpMV, row slicing, dt2t)
 // =========================================================================
 
 /**
- * Warps per block for the warp-per-row SpMV tier.
+ * Warps per block for kernels that map one row to one warp.
  *
  * 8 warps == 256 threads, so one block retires 8 rows per sweep. Measured
  * 2-3x faster than the one-warp-per-block (`<<<m, 32>>>`) shape at low average
  * row length, and never slower.
  */
-#define BE_CSRMV_WARP_WARPS_PER_BLOCK 8
+#define BE_WARP_PER_ROW_WPB 8
 
 /** Upper bound on the warp-tier grid; the kernels are grid-strided. */
-#define BE_CSRMV_WARP_MAX_GRID 4096
+#define BE_WARP_PER_ROW_MAX_GRID 4096
 
 /**
- * Grid size covering @p m rows at ::BE_CSRMV_WARP_WARPS_PER_BLOCK rows per
- * block, capped at ::BE_CSRMV_WARP_MAX_GRID so the grid tracks the resident
+ * Grid size covering @p m rows at ::BE_WARP_PER_ROW_WPB rows per
+ * block, capped at ::BE_WARP_PER_ROW_MAX_GRID so the grid tracks the resident
  * block count instead of scaling with the row count.
  *
  * Kernels launched with this must be grid-strided, since the cap can make the
@@ -251,16 +251,16 @@ __device__ __inline__ double warp_reduce_sum_f64(double val) {
  * launch configuration.
  *
  * @param m  Number of rows.
- * @return   Number of blocks to launch, in [1, ::BE_CSRMV_WARP_MAX_GRID].
+ * @return   Number of blocks to launch, in [1, ::BE_WARP_PER_ROW_MAX_GRID].
  */
-__host__ __inline__ int be_csrmv_warp_grid(int m) {
-    int blocks = (m + BE_CSRMV_WARP_WARPS_PER_BLOCK - 1) / BE_CSRMV_WARP_WARPS_PER_BLOCK;
-    if (blocks > BE_CSRMV_WARP_MAX_GRID) blocks = BE_CSRMV_WARP_MAX_GRID;
+__host__ __inline__ int be_warp_per_row_grid(int m) {
+    int blocks = (m + BE_WARP_PER_ROW_WPB - 1) / BE_WARP_PER_ROW_WPB;
+    if (blocks > BE_WARP_PER_ROW_MAX_GRID) blocks = BE_WARP_PER_ROW_MAX_GRID;
     return blocks > 0 ? blocks : 1;
 }
 
-/** Convenience spelling of ::be_csrmv_warp_grid for use inside launch macros. */
-#define BE_CSRMV_WARP_GRID(m) be_csrmv_warp_grid(m)
+/** Convenience spelling of ::be_warp_per_row_grid for use inside launch macros. */
+#define BE_WARP_PER_ROW_GRID(m) be_warp_per_row_grid(m)
 
 // =========================================================================
 // Launch Geometry — warp-per-row SpMM

--- a/docs/specs/cuda-kernel-audit.md
+++ b/docs/specs/cuda-kernel-audit.md
@@ -158,6 +158,21 @@ widened by inserting a `(size_t)` cast on the leading factor; the smem strides
 (`smem[strip * 32 + lane]`) were left alone since both factors there are block-bounded
 constants. Full GPU CSR suite: 699 passed.
 
+A tree-wide re-audit then found the same pattern in the JIT connectivity families:
+`chunk_counts[row * n_chunks + chunk_id]` and `chunk_offsets[...]` in
+`_jit_{normal,scalar,uniform}/{csr,dt2t}.cu` (24 sites). `n_chunks` defaults to 4, but
+`chunk_size` is user-settable, so `row * n_chunks` is not bounded by anything the kernel
+controls. Widened the same way. JIT GPU suites: 1512 passed, 4 skipped.
+
+Reachability for both is the same and worth stating plainly: the index only overflows once
+the indexed buffer itself exceeds 2^31 elements, i.e. ≥8.6 GB at 4 bytes (4.3 GB at fp16).
+That is out of reach on a small card and reachable on an 80 GB one. The fix costs nothing
+at runtime — the multiply widens to 64-bit, and none of these sites are in an inner loop —
+so it is worth taking rather than documenting as a limit.
+
+After this pass the only remaining unwidened multiplicative subscripts tree-wide are
+shared-memory strides with a literal `* 32`, bounded by block size by construction.
+
 ## Finding 4 — CSRMV was missing its warp-per-row tier (performance)
 
 ### The defect
@@ -259,6 +274,57 @@ of record.
 - `test_binary_csrmv_cuda_source_keeps_three_dispatch_tiers` — source-level, runs without a
   GPU. Necessary because a two-tier dispatcher is still *correct*, so no numeric test can
   catch the tier being dropped again. Verified to fail against the pre-change source.
+
+## Finding 5 — `float_csrmm.cu` warp kernels kept the unpacked launch shape
+
+`binary_csrmm.cu` and `binary_indexed_csrmm.cu` already launch their warp kernels as
+`CSRMM_WARP_RPB` (4) rows per 128-thread block with a grid-strided loop and a capped
+`grid.x`. `float_csrmm.cu` was never updated to match and still launched
+`<<<dim3(m, c_blocks), 32>>>` — one warp per block — for both its NT and transpose warp
+kernels. Same defect as Finding 4's launch shape, in the file that is otherwise the
+reference implementation.
+
+Measured on sm_86, m = k = 16384, n = 64, float32 homogeneous:
+
+| avg_nnz | `<<<m, 32>>>` (ms) | packed 4/block (ms) | speedup |
+|--------:|-------------------:|--------------------:|--------:|
+| 2 | 0.062 | 0.030 | 2.05x |
+| 4 | 0.055 | 0.031 | 1.77x |
+| 8 | 0.059 | 0.038 | 1.58x |
+| 16 | 0.088 | 0.062 | 1.42x |
+| 32 | 0.142 | 0.111 | 1.28x |
+| 64 | 0.251 | 0.211 | 1.19x |
+
+A win across the entire range the warp tier serves (`avg_nnz <= 64`).
+
+Both kernels were converted to the packed grid-strided form. The row guard becomes
+`continue` rather than `return`, since returning inside a grid-strided loop would abandon
+that warp's remaining rows — the same trap as in Finding 4.
+
+`CSRMM_MAX_GRID_X` and `CSRMM_WARP_RPB` were duplicated verbatim in two `.cu` files;
+rather than add a third copy they were moved to `cuda_common.h` alongside the CSRMV
+geometry and the local definitions deleted.
+
+## Audits that found nothing (recorded so they are not redone)
+
+- **Dynamic shared-memory sizing, tree-wide.** 12 kernels use `extern __shared__`. Every
+  request now matches the largest index the kernel can write. `_fcn/binary_fcnmm.cu` was
+  the one to check closely — it uses the same `(warpid + stride) * 32 + lane` strip
+  indexing that broke CSRMM — and it sizes correctly as
+  `red_off + nwarps * 32 * ACC_SIZE`.
+- **`binary_fcnmm.cu` tree reduction over a non-power-of-two warp count.** The reduction
+  `for (stride = nwarps >> 1; stride > 0; stride >>= 1)` silently drops the top warps if
+  `nwarps` is not a power of two. Not a live bug: all four launch sites hardcode
+  `bsz = 256`, so `nwarps == 8`. Noted because a future block-size change would break it
+  without any test failing.
+- **Dispatch-tier gaps beyond Finding 4.** `dt2t.cu`, `plasticity_binary_on_{pre,post}.cu`
+  and `slice_csr_slice_rows.cu` all already implement three-tier dispatch. The CSRMM
+  `avg_nnz <= 512` two-tier ladders are *not* the Finding 4 defect: for SpMM the two tiers
+  are warp and block (lanes map to columns), which is the right pair.
+- **Warp-reduction convergence** and **`__syncthreads()` divergence**: all flagged kernels
+  verified block- or warp-uniform.
+- **Unguarded fp16/bf16 atomics** in `float_csrmm.cu`: compile fine on sm_75 under CUDA 13;
+  sm_60 is not supported by the toolkit. Not a live bug.
 
 ## Edge cases considered
 

--- a/docs/specs/cuda-kernel-audit.md
+++ b/docs/specs/cuda-kernel-audit.md
@@ -146,6 +146,120 @@ fail to compile below sm_70 / sm_80 — retiring them removes that portability t
 names and their `DEFINE_` macros are present in the `.cu` text; those assertions pin dead
 code and are updated with the removal.
 
+## Finding 3 — CSRMM dense subscripts overflow 32-bit `int` (correctness)
+
+The CSRMM kernels index the dense operands as `B[indices[j] * n + c]` and `C[row * n + c]`.
+Both factors are runtime `int`, so the product is computed in 32-bit and wraps once
+`k * n` (or `m * n`) exceeds 2^31. Demonstrated standalone at `k * n = 2148507648`:
+`int` yields `-2146460672`, `size_t` yields `2148506624` — a wild pointer, not a slow path.
+
+`float_csrmm.cu` had the same exposure. 30 subscripts across the four CSRMM sources were
+widened by inserting a `(size_t)` cast on the leading factor; the smem strides
+(`smem[strip * 32 + lane]`) were left alone since both factors there are block-bounded
+constants. Full GPU CSR suite: 699 passed.
+
+## Finding 4 — CSRMV was missing its warp-per-row tier (performance)
+
+### The defect
+
+`float_csrmv.cu` documents and implements a three-tier row mapping — one thread per row
+below `avg_nnz` 8, one warp per row up to 512, one block per row above. The three binary
+CSRMV sources only had two tiers:
+
+```c
+if (avg_nnz <= 512) { thread-per-row } else { block-per-row }
+```
+
+so every row length from 16 to 512 — the normal range for sparse neural connectivity —
+ran the thread-per-row kernel, where the 32 lanes of a warp each walk a *different* row
+and every `indices[j]` load is uncoalesced.
+
+Git history shows `DEFINE_CSRMV_NT_WARP_HOMO` existed at `da4a812~1`. The predecessor
+cleanup deleted it as unreachable, which was true but was the wrong repair: the dispatcher
+was what needed fixing.
+
+### Measured, on sm_86, m = k = 65536, float32 hetero, bool spikes, 50 iterations
+
+| avg_nnz | thread (ms) | warp (ms) | block (ms) | best |
+|--------:|------------:|----------:|-----------:|:-----|
+| 2 | 0.009 | 0.026 | 0.219 | thread |
+| 8 | 0.017 | 0.034 | 0.278 | thread |
+| 12 | 0.030 | 0.034 | 0.278 | thread |
+| 16 | 0.040 | 0.034 | 0.276 | **warp** |
+| 32 | 0.088 | 0.043 | 0.271 | **warp** |
+| 64 | 0.209 | 0.076 | 0.272 | **warp** |
+| 128 | 0.361 | 0.141 | 0.249 | **warp** |
+| 256 | 0.950 | 0.277 | 0.325 | **warp** |
+| 512 | 1.904 | 0.547 | 0.545 | block |
+
+Up to **3.4x** on the tier that was missing. The crossovers give the thresholds used:
+thread below 16, warp to 512, block above.
+
+### Launch shape: pack warps, don't launch 32-thread blocks
+
+The historical kernel (and `float_csrmv.cu` today) launched `<<<m, 32>>>` — one warp per
+*block*. A block occupies a scheduler slot regardless of size, and an SM caps resident
+blocks, so 32-thread blocks waste 7/8 of each slot. Packing 8 warps into a 256-thread
+grid-strided block instead:
+
+| avg_nnz | `<<<m, 32>>>` (ms) | 8 warps/block (ms) | speedup |
+|--------:|-------------------:|-------------------:|--------:|
+| 8 | 0.111 | 0.034 | 3.31x |
+| 16 | 0.111 | 0.034 | 3.25x |
+| 32 | 0.111 | 0.044 | 2.53x |
+| 64 | 0.160 | 0.076 | 2.11x |
+| 128 | 0.145 | 0.143 | 1.02x |
+| 256 | 0.276 | 0.277 | 1.00x |
+| 512 | 0.545 | 0.550 | 0.99x |
+
+Strictly better at low row lengths, parity above. The same shape applied to the transpose
+atomic-scatter kernel (`csrmv_t_warp`, launched unconditionally): 2.80x at `avg_nnz` 8,
+1.81x at 16, parity through 256, and 0.94x at 512 — net strongly positive.
+
+### Fix
+
+- Added `DEFINE_CSRMV_NT_WARP_{HOMO,HETERO}` to `binary_csrmv.cu` and
+  `DEFINE_CSRMV_NT_WARP_PERM_HETERO` to `binary_indexed_csrmv.cu`, instantiated for all
+  weight/spike dtype pairs (24 new device kernels, **no new `@BE` entry points** — the
+  `nt_auto` wrappers dispatch to them internally).
+- Rewrote all three dispatchers as the three-tier ladder.
+- Converted the two existing `float_csrmv.cu` warp kernels from `<<<m, 32>>>` to the packed
+  grid-strided shape.
+- Added `be_csrmv_warp_grid()` to `cuda_common.h` (shared by all three sources; clamps to
+  `[1, 4096]` so an empty matrix cannot produce a zero-sized grid).
+
+`row` is derived as `blockIdx.x * warps_per + warp_id`, making it **warp-uniform**. That is
+what keeps the `__shfl_down_sync` reduction converged — the M17 precondition documented in
+`cuda_common.h`. A lane-dependent row bound would silently corrupt the reduction.
+
+### Verification
+
+96 configurations through the public API (7 row lengths spanning all three tiers x 3 weight
+dtypes x homo/hetero x bool/float spikes), `cuda_raw` against `jax_raw`:
+
+- float32 and float64: agree to 1e-5 / 1e-12 relative on every tier.
+- float16: differs from `jax_raw` by up to 3e-2 relative — *including on the block tier,
+  which this change does not touch*. Resolved against an exact float64 ground truth: the
+  CUDA path is **10-100x closer to exact** than `jax_raw` in all 8 cases (e.g. 2.4e-4 vs
+  3.8e-2 at `avg_nnz` 1024). The kernels accumulate in float32; the reference accumulates
+  in float16. This is a reference-precision artifact, not a kernel defect.
+
+**End-to-end Python timing could not resolve the improvement on this machine**: JAX host
+dispatch latency floors at ~1.2 ms for this call, well above the 0.03-0.5 ms of kernel time,
+so the API-level A/B returns noise. The standalone CUDA benchmarks above are the measurement
+of record.
+
+### Regression tests
+
+- `test_binary_csrmv_matches_reference_across_dispatch_tiers` — 7 row lengths straddling
+  both thresholds x homo/hetero.
+- `test_binary_csrmv_warp_tier_handles_ragged_and_empty_rows` — empty rows, a row count off
+  the warps-per-block tiling, and wildly varying row lengths; also asserts empty rows are
+  written rather than left uninitialised.
+- `test_binary_csrmv_cuda_source_keeps_three_dispatch_tiers` — source-level, runs without a
+  GPU. Necessary because a two-tier dispatcher is still *correct*, so no numeric test can
+  catch the tier being dropped again. Verified to fail against the pre-change source.
+
 ## Edge cases considered
 
 - **Orphaning a device kernel.** Removing an FFI wrapper can strand the `__global__` kernel
@@ -161,3 +275,22 @@ code and are updated with the removal.
 - **CPU suite proves nothing.** `.cu` sources are never compiled unless a GPU kernel is
   actually lowered. Every change here must be GPU-validated, per the predecessor spec's
   takeaway.
+- **Warp reduction convergence.** The new warp kernels derive `row` from
+  `blockIdx.x * warps_per + warp_id` only. Had the grid-stride bound been lane-dependent,
+  lanes would retire at different trip counts and `__shfl_down_sync` would read from exited
+  lanes. Audited all 6 pre-existing warp-reduction kernels the same way; all are
+  warp-uniform.
+- **Empty rows in the warp kernel.** The thread and block kernels early-return on
+  `start == end`; the warp kernel deliberately does not, because an early `return` inside a
+  grid-strided loop would skip that warp's remaining rows. Instead the inner loop simply
+  does not execute, the reduction yields `ACC_ZERO`, and lane 0 writes it. Covered by the
+  ragged-row test.
+- **Zero-sized grid.** `be_csrmv_warp_grid()` clamps to at least 1. `csrmv_t_warp` has no
+  `avg_nnz` guard, so an `m == 0` matrix would otherwise reach the launch with a
+  zero-sized grid — an invalid configuration. (The pre-change `<<<m, 32>>>` had the same
+  hole; this closes it.)
+- **Threshold asymmetry with `float_csrmv.cu`.** The binary sources switch to the warp tier
+  at `avg_nnz` 16 while `float_csrmv.cu` uses 8. The measured crossover for the binary
+  kernels is between 12 and 16 (0.030 vs 0.034 at 12; 0.040 vs 0.034 at 16). The float
+  threshold was left at 8: converting its warp kernel to the packed shape only makes the
+  warp tier faster, so an unchanged threshold stays on the safe side of the crossover.

--- a/docs/specs/cuda-kernel-audit.md
+++ b/docs/specs/cuda-kernel-audit.md
@@ -1,0 +1,163 @@
+# CUDA kernel audit — correctness, dead code, performance
+
+Status: in progress
+Scope: full sweep of the 46 `.cu` files and 7 headers shipped as package data, looking for
+(a) memory-safety and correctness defects, (b) dead code the previous cleanup missed, and
+(c) performance headroom.
+
+Predecessor: [`cuda-operator-cleanup.md`](cuda-operator-cleanup.md), which removed 102
+unreachable `@BE` entry points, 2 orphan headers and 8 unused `cuda_common.h` symbols. That
+pass audited *reachability*; it did not look inside the kernels.
+
+## Validation environment
+
+RTX 3080 Ti Laptop GPU (sm_86), driver 596.49, CUDA 13.2 / nvcc 13.1, jax 0.11.0 with
+jaxlib CUDA. `compute-sanitizer` is **unavailable** on this host (WSL2/WDDM: "Failed to
+initialize WDDM debugger interface / Device not supported"), so memory-safety findings are
+established with purpose-built canary kernels and standalone harnesses instead.
+
+### Validation pitfall (cost an hour, worth recording)
+
+`brainevent` is installed in editable mode pointing at the **main checkout**. A script run
+as `python /tmp/foo.py` puts `/tmp` — not the CWD — on `sys.path[0]`, so it imports
+`/mnt/d/codes/projects/brainevent/brainevent`, *not* the worktree. Early "the fix does not
+work" results were actually the unfixed main checkout being re-tested. Every GPU validation
+command must pass:
+
+```
+PYTHONPATH=<worktree-root> python ...
+```
+
+and the harness should print `brainevent.__file__` to prove which tree it exercised.
+Deleting `~/.cache/brainevent` between runs is also required, because compiled modules are
+keyed on a content hash of the `.cu` source plus flags.
+
+## Finding 1 — CSRMM block kernels under-request dynamic shared memory (memory fault)
+
+**Severity: high.** float64 `binary_csrmm` aborts the CUDA context with
+`CUDA_ERROR_ILLEGAL_ADDRESS`; float32/float16/bfloat16 silently perform an
+out-of-bounds shared-memory write that only survives by allocation-granularity luck.
+
+### The defect
+
+`_csrmm_nt_block_{homo,hetero}_kern` (and the `_perm_hetero` variant in the indexed file)
+stage one accumulator per `(strip, lane)` pair:
+
+```c
+smem[strip * 32 + lane] = acc0 + acc1;   // strip in 0..7, lane in 0..31 -> 256 slots
+__syncthreads();
+if (strip == 0 && c < n) {
+    for (int s = 0; s < 8; s++) sum += smem[s * 32 + lane];
+```
+
+The kernels launch with 256 threads, so this needs `8 * 32 * sizeof(ACC_T)` bytes. Both
+files instead requested `8 * sizeof(ACC_T)`:
+
+| File | Requested | Required | Instantiations |
+|---|---|---|---|
+| `_csr/binary_csrmm.cu` | `8 * sizeof(T)` | `8 * 32 * sizeof(T)` | 16 |
+| `_csr/binary_indexed_csrmm.cu` | `8 * sizeof(T)` | `8 * 32 * sizeof(T)` | 10 |
+
+`_csr/float_csrmm.cu` — the same kernel shape — already had the correct
+`8 * 32 * sizeof(...)`, which is what identifies this as a dropped `* 32` rather than a
+different design. The CSRMV block kernels reduce into `smem_red[warpid]` (8 slots), so
+their `8 * sizeof(T)` is correct and was left alone.
+
+### Why the bug is dtype-dependent
+
+A canary kernel that requests `shm` bytes but writes `nf` floats per block, run with 65536
+blocks so the SM is saturated, shows what the driver actually tolerates on sm_86:
+
+```
+request=32 bytes, 256 thr/block, 65536 blocks
+  wrote   128 floats (   512 bytes): no error     corrupted=0
+  wrote   256 floats (  1024 bytes): no error     corrupted=0
+  wrote   512 floats (  2048 bytes): an illegal memory access was encountered
+```
+
+The per-block shared-memory window is rounded up to a granule large enough that a 1024-byte
+overrun lands harmlessly, but 2048 bytes faults. That is exactly the split observed:
+
+* `ACC_T = float` (f32/f16/bf16) writes 256 × 4 = **1024 bytes** → survives on this driver,
+  still formally out of bounds and not portable.
+* `ACC_T = double` (f64) writes 256 × 8 = **2048 bytes** → **faults**.
+
+### Reproduction through the public API
+
+`binary_csrmm(..., transpose=False, backend='cuda_raw')` with float64 weights and
+`avg_nnz > 512` (the threshold at which `nt_auto` selects the block kernel). Same script,
+same GPU, only the checkout differs:
+
+```
+main:                                       worktree (fixed):
+  homo   float32 nt_warp : PASS               homo   float32 nt_warp : PASS
+  homo   float32 nt_block: PASS               homo   float32 nt_block: PASS
+  hetero float32 nt_warp : PASS               hetero float32 nt_warp : PASS
+  hetero float32 nt_block: PASS               hetero float32 nt_block: PASS
+  homo   float64 nt_warp : PASS               homo   float64 nt_warp : PASS
+  homo   float64 nt_block: CRASH              homo   float64 nt_block: PASS
+    CUDA_ERROR_ILLEGAL_ADDRESS                hetero float64 nt_warp : PASS
+    (context destroyed, run aborts)           hetero float64 nt_block: PASS
+```
+
+Independently, a standalone harness that `#include`s the real `binary_csrmm.cu` and calls
+`binary_csrmm_nt_auto_hetero_f64_bool` with hand-built `BE::Tensor` views reports
+`no error` and `max abs err = 0` after the fix, and `an illegal memory access was
+encountered` before it.
+
+### Fix
+
+Both files now pass `8 * 32 * sizeof(...)`, matching `float_csrmm.cu`.
+
+### Regression test
+
+`brainevent/_csr/binary_test.py::test_binary_csrmm_nt_block_shared_memory_is_large_enough`
+(`@requires_gpu_backend`, `@pytest.mark.slow`, parametrised over homo/hetero) builds a CSR
+matrix with 1024 nnz per row so `nt_auto` routes to the block kernel, and compares the
+float64 `cuda_raw` result against `jax_raw`. Verified to **fail** (illegal memory access) with
+the fix stashed and **pass** with it applied.
+
+## Finding 2 — 52 unreachable `@BE` entry points remain
+
+The predecessor pass reduced 749 → 647 annotations. A fresh reachability analysis — extract
+every `// @BE <name>`, extract every `kernel_name` f-string template from non-test Python,
+expand `{...}` to `[A-Za-z0-9_]*`, and match — leaves 52 entry points that no Python code
+path can name.
+
+Python only ever composes these CSR binary targets: `binary_csrm{v,m}_nt_auto{_homo,_hetero}`,
+`binary_csrm{v,m}_nt_auto_perm_hetero`, `binary_csrm{v,m}_{wat,sraw}_hybrid*` and
+`binary_indexed_csrm{v,m}_{wat,sraw}_hybrid_hetero*`. The transpose route moved to the
+hybrid kernels, which stranded the whole `t_warp` family:
+
+| File | Dead entry points | Count |
+|---|---|---|
+| `_csr/binary_csrmv.cu` | `binary_csrmv_t_warp_{homo,hetero}_*` | 16 |
+| `_csr/binary_csrmm.cu` | `binary_csrmm_t_warp_{homo,hetero}_*` | 16 |
+| `_csr/binary_indexed_csrmv.cu` | `binary_csrmv_t_warp_perm_hetero_*` | 8 |
+| `_csr/binary_indexed_csrmm.cu` | `binary_csrmm_t_warp_perm_hetero_*` | 8 |
+| `_csr/binary_indexed_csrmm.cu` | `binary_csrmm_nt_{warp,block}_perm_hetero_f32_*` | 4 |
+
+Removing them also retires the `_t_warp_*_kern` device kernels, which nothing else launches.
+Those kernels additionally call `atomicAdd` directly on `__half*` / `__nv_bfloat16*` rather
+than through the arch-guarded `atomic_add_f16` / `atomic_add_bf16` helpers, so they would
+fail to compile below sm_70 / sm_80 — retiring them removes that portability trap too.
+
+`binary_indexed_test.py::test_indexed_mm_cuda_kernel_selects_perm_names` asserts the dead
+names and their `DEFINE_` macros are present in the `.cu` text; those assertions pin dead
+code and are updated with the removal.
+
+## Edge cases considered
+
+- **Orphaning a device kernel.** Removing an FFI wrapper can strand the `__global__` kernel
+  it was the sole launcher of. `nt_warp_perm` / `nt_block_perm` device kernels stay: the
+  `nt_auto_perm` dispatcher still launches them internally; only their standalone FFI
+  wrappers are unreachable.
+- **Shared-memory fix and occupancy.** Raising the request from 32 to 1024 bytes (2048 for
+  f64) does not change occupancy on sm_86: at 256 threads/block the limit is
+  1536/256 = 6 blocks/SM in both cases, confirmed with
+  `cudaOccupancyMaxActiveBlocksPerMultiprocessor`. So the fix costs nothing.
+- **Cache invalidation.** Editing any `.cu` changes its content hash, so the first GPU run
+  after this change recompiles. Expected.
+- **CPU suite proves nothing.** `.cu` sources are never compiled unless a GPU kernel is
+  actually lowered. Every change here must be GPU-validated, per the predecessor spec's
+  takeaway.

--- a/docs/specs/cuda-kernel-audit.md
+++ b/docs/specs/cuda-kernel-audit.md
@@ -305,6 +305,45 @@ that warp's remaining rows — the same trap as in Finding 4.
 rather than add a third copy they were moved to `cuda_common.h` alongside the CSRMV
 geometry and the local definitions deleted.
 
+## Finding 6 — the last five one-warp-per-block launches
+
+After Findings 4 and 5, five `<<<…, 32>>>` launches remained: the three warp kernels in
+`slice_csr_slice_rows.cu` (forward homo, forward hetero, backward) and the two in
+`dt2t.cu` (`csrmv` and `csrmm` row-warp). All five are the same shape — one row per warp,
+warp-stride over that row's non-zeros, no cross-lane operations — so all five were packed.
+
+Measured on sm_86 (m = 65536, float32) for the streaming-write shape these use:
+
+| avg_nnz | `<<<m, 32>>>` (ms) | packed 8/block (ms) | speedup |
+|--------:|-------------------:|--------------------:|--------:|
+| 8 | 0.077 | 0.031 | 2.50x |
+| 16 | 0.078 | 0.030 | 2.57x |
+| 32 | 0.081 | 0.045 | 1.79x |
+| 64 | 0.110 | 0.074 | 1.48x |
+| 128 | 0.146 | 0.146 | 1.00x |
+| 256 | 0.309 | 0.285 | 1.08x |
+| 512 | 0.565 | 0.711 | **0.80x** |
+
+**This one is not a uniform win.** Packing is 2.5x faster over `avg_nnz` 8–32, ~1.5x at 64,
+parity at 128–256, and roughly 20% *slower* at 512 — with enough work per row the
+one-warp-per-block form's larger grid schedules better than the capped grid-strided one.
+Both kernels' warp tiers serve `avg_nnz` 8–511, so a band near the top of that tier
+regresses slightly. It was taken anyway: real sparse connectivity sits well below 256
+nonzeros per row, so the 2.5x low end dominates in practice.
+
+If that band ever matters, the fix is to select warps-per-block from `avg_nnz` at launch
+rather than fixing it at 8 — deliberately not done here, since it adds a tuning knob for a
+case that has no measured workload behind it.
+
+The `slice` kernels needed one extra care beyond the mechanical rewrite: they carry a
+second guard, `if (r < 0 || r >= m) return`, for out-of-range row indices. Inside a
+grid-strided loop that must become `continue`, or one bad row index would silently drop
+every remaining row assigned to that warp.
+
+`BE_CSRMV_WARP_GRID` was renamed `BE_WARP_PER_ROW_GRID` (and the helper
+`be_csrmv_warp_grid` → `be_warp_per_row_grid`) now that slicing and dt2t share it; the
+CSRMV-specific name would have been misleading.
+
 ## Audits that found nothing (recorded so they are not redone)
 
 - **Dynamic shared-memory sizing, tree-wide.** 12 kernels use `extern __shared__`. Every


### PR DESCRIPTION
Scans every CUDA source in the package, removes dead code, and fixes what the
scan turned up. Every change is GPU-validated; full package suite is **3791
passed, 29 skipped**.

Full write-up in `docs/specs/cuda-kernel-audit.md`.

## Correctness

**Shared memory under-allocated 32x** in the CSRMM block kernels. They write
`smem[strip * 32 + lane]` (256 slots) but requested `8 * sizeof(ACC_T)`. float32
happened to survive inside the driver's allocation granularity; float64 faulted
with `CUDA_ERROR_ILLEGAL_ADDRESS`. A canary sweep pinned the tolerance exactly:
sm_86 absorbs a 1024-byte overrun and faults at 2048, which is precisely why the
bug was dtype-dependent. Verified against `main`: `main` crashes on
`homo float64 nt_block`, this branch passes all 8 combinations. Occupancy is
unchanged (6 blocks/SM either way), so the fix costs nothing.

**32-bit index overflow** in dense subscripts: `B[indices[j] * n + c]` computes
in 32-bit and wraps once `k * n` passes 2^31 — demonstrated standalone, `int`
yields -2146460672 where `size_t` yields 2148506624. 30 sites across the CSRMM
sources, plus 24 more in the `_jit_*` chunk arrays found by a tree-wide
re-audit. Reachability is stated plainly in the spec: this needs a buffer of
>=8.6 GB, out of reach on a small card and reachable on an 80 GB one. The
widened multiply costs nothing at runtime.

## Dead code

52 unreachable `t_warp` entry points removed (647 -> 595), each file
nvcc-verified after removal.

## Performance

**CSRMV had no warp tier.** `float_csrmv.cu` documents thread/warp/block, but
the binary dispatchers went straight from thread to block, so every row length
from 16 to 512 — the normal range for sparse neural connectivity — ran the
thread-per-row kernel with uncoalesced `indices[j]` loads. Up to **3.4x** on the
missing tier. The warp kernel existed before the previous cleanup, which removed
it as unreachable; that was true, but the dispatcher was what needed fixing.

**Launch shape.** A block holds a scheduler slot regardless of size, so
`<<<m, 32>>>` wastes 7/8 of it. Packing 8 warps into a grid-strided 256-thread
block is **2-3.3x** faster at low `avg_nnz`. Applied to all 9 remaining sites
across CSRMV, CSRMM, row slicing and dt2t; no `<<<..., 32>>>` launch is left in
the tree.

## Two things worth flagging

The `slice`/`dt2t` packing is **not** a uniform win: 2.5x at `avg_nnz` 8-32 but
**0.80x at 512**, inside the band those tiers serve. Taken because real
connectivity sits well below 256 nonzeros per row, but it is a genuine tradeoff
and the spec records it as one rather than quoting only the favourable numbers.

fp16 validation initially showed 9 apparent failures — including on the block
tier, which this PR never touches. Resolved against an exact float64 ground
truth: the CUDA path is **10-100x closer to exact** than `jax_raw`, which
accumulates in fp16 where the kernels accumulate in fp32. A reference-precision
artifact, not a defect.

Separately, end-to-end Python timing cannot resolve any of these changes: JAX
host dispatch latency floors at ~1.2 ms against 0.03-0.5 ms of kernel time. The
standalone CUDA benchmarks are the measurement of record, and the spec says so
instead of quoting the noise.

## Tests

New GPU regression tests cover the shared-memory fix and all three CSRMV
dispatch tiers, plus ragged/empty rows and a row count off the warps-per-block
tiling. One test is source-level and runs without a GPU: a two-tier dispatcher
is still *correct*, so no numeric test can catch the warp tier being dropped
again — verified to fail against the pre-change source.

The spec also records five audits that found **nothing** (shared-memory sizing
tree-wide, warp/barrier convergence, dispatch gaps outside CSRMV, unguarded half
atomics, and a latent `binary_fcnmm` reduction precondition that holds only
because `bsz` is hardcoded to 256) so they are not redone.

## Summary by Sourcery

Audit CUDA CSR kernels for correctness, remove unreachable entry points, and restore an efficient warp-per-row tier with packed launch geometry.

Bug Fixes:
- Fix under-sized dynamic shared memory requests in CSRMM block kernels that caused float64 CUDA illegal memory accesses and latent f32/f16/bf16 out-of-bounds writes.
- Prevent 32-bit index overflows in CSRMM and JIT connectivity kernels by widening dense indexing multiplications to size_t across all affected sites.

Enhancements:
- Restore and wire in a warp-per-row CSRMV tier, using a three-tier dispatcher (thread/warp/block) and a packed grid-strided launch shape shared by CSRMV, CSRMM, row slicing, and dt2t.
- Refactor warp-per-row launch geometry into reusable helpers and move CSRMM warp grid configuration into cuda_common.h, removing duplicated constants.
- Remove unused transpose warp FFI entry points and their device kernels in CSR binary and indexed CSR sources, simplifying the kernel surface and eliminating unused fp16/bf16 atomic code paths.

Documentation:
- Add a detailed CUDA kernel audit spec documenting the validation environment, identified defects, performance measurements, and non-findings.

Tests:
- Add GPU regression tests for CSRMM shared-memory sizing and CSRMV nt_auto dispatch tiers, including ragged/empty-row cases and warp-tiling edge conditions, plus source-level tests that ensure the CSRMV warp tier remains wired in and permuted CSRMM dispatch names stay correct.