### PR TITLE
release: 0.2.1 — fix Daily CI matrix, refresh API references

### DIFF
--- a/.github/workflows/CI-daily.yml
+++ b/.github/workflows/CI-daily.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-        jax-version: [ "0.8.0", "0.9.0", "" ]
+        jax-version: [ "0.8.0", "0.9.0", "0.10.0", "" ]
         # Optional: Exclude incompatible combinations if needed
         # exclude:
         #   - python-version: "3.13"

--- a/brainevent/__init___test.py
+++ b/brainevent/__init___test.py
@@ -1,0 +1,145 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests keeping the public surface of :mod:`brainevent` and its API reference in sync.
+
+The Sphinx reference under ``docs/reference/apis`` is hand-maintained: an
+``autosummary`` entry that outlives its symbol renders as a broken stub, and a
+new export without an entry is invisible to users. Both directions are checked
+here so the drift is caught by the test suite rather than by a reader.
+"""
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+import brainevent
+from brainevent import config as be_config
+
+# Repository root -> docs; absent in a wheel-only installation, where these tests
+# are skipped rather than failed.
+_DOCS_APIS = Path(__file__).resolve().parents[1] / 'docs' / 'reference' / 'apis'
+
+# Names exported for convenience that are deliberately not autosummary entries.
+_NOT_DOCUMENTED = frozenset({
+    'config',  # submodule handle; documented as a page of its own (config.rst)
+})
+
+# ``currentmodule`` of each reference page.
+_PAGE_MODULES = {'config.rst': be_config}
+
+_ENTRY = re.compile(r'^ {3}([A-Za-z_][A-Za-z0-9_]*)$')
+
+
+def _autosummary_entries(rst: Path) -> List[str]:
+    """Collect the symbol names listed in every ``autosummary`` block of ``rst``.
+
+    Parameters
+    ----------
+    rst : Path
+        Reference page to parse.
+
+    Returns
+    -------
+    list of str
+        Entry names, in document order, with duplicates preserved.
+    """
+    names: List[str] = []
+    in_block = False
+    for line in rst.read_text(encoding='utf-8').splitlines():
+        if line.strip().startswith('.. autosummary::'):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith(':'):
+            continue  # blank separator or block option (:toctree:, :template:, ...)
+        match = _ENTRY.match(line)
+        if match:
+            names.append(match.group(1))
+        else:
+            in_block = False  # prose, directive or heading closes the block
+    return names
+
+
+def _pages() -> Dict[str, List[str]]:
+    """Map each reference page filename to its ``autosummary`` entries."""
+    return {
+        rst.name: _autosummary_entries(rst)
+        for rst in sorted(_DOCS_APIS.glob('*.rst'))
+        if rst.name != 'index.rst'
+    }
+
+
+pytestmark = pytest.mark.skipif(
+    not _DOCS_APIS.is_dir(),
+    reason='API reference sources are not shipped with the installed package',
+)
+
+
+def test_every_documented_symbol_exists():
+    """No ``autosummary`` entry outlives the symbol it documents."""
+    dangling = {}
+    for page, names in _pages().items():
+        module = _PAGE_MODULES.get(page, brainevent)
+        missing = [n for n in names if not hasattr(module, n)]
+        if missing:
+            dangling[page] = missing
+    assert not dangling, f'API reference documents symbols that no longer exist: {dangling}'
+
+
+def test_every_public_export_is_documented():
+    """Every name in ``brainevent.__all__`` appears on some reference page."""
+    documented = {name for names in _pages().values() for name in names}
+    undocumented = sorted(
+        name for name in brainevent.__all__
+        if name not in documented and name not in _NOT_DOCUMENTED
+    )
+    assert not undocumented, (
+        'public exports missing from docs/reference/apis: '
+        f'{undocumented}'
+    )
+
+
+def test_every_config_export_is_documented():
+    """Every name in ``brainevent.config.__all__`` appears on ``config.rst``."""
+    documented = set(_pages()['config.rst'])
+    undocumented = sorted(n for n in be_config.__all__ if n not in documented)
+    assert not undocumented, f'brainevent.config exports missing from config.rst: {undocumented}'
+
+
+def test_no_symbol_is_documented_twice():
+    """A symbol is documented on exactly one page, so ``generated/`` has one stub for it."""
+    seen: Dict[str, str] = {}
+    duplicates = []
+    for page, names in _pages().items():
+        for name in names:
+            if name in seen:
+                duplicates.append(f'{name} ({seen[name]} and {page})')
+            else:
+                seen[name] = page
+    assert not duplicates, f'symbols documented on more than one page: {duplicates}'
+
+
+def test_deprecated_aliases_are_not_documented():
+    """Deprecated aliases stay out of the reference so users land on the replacements."""
+    documented = {name for names in _pages().values() for name in names}
+    deprecated = {'FixedPreNumConn', 'FixedPostNumConn'}
+    assert not (documented & deprecated), (
+        'deprecated aliases must not be documented; use FixedNumPerPre / FixedNumPerPost'
+    )

--- a/brainevent/_version.py
+++ b/brainevent/_version.py
@@ -17,5 +17,5 @@
 
 __all__ = ["__version__", "__version_info__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,131 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-08-09
+
+A follow-up to `0.2.0` that removes the mv/mm split from the just-in-time
+connectivity (JITC) families, restores the daily JAX compatibility matrix to
+green, and brings the API reference back in sync with the public surface.
+
+*JITC.* `0.2.0` exposed the fact that the mv and mm light kernels drew
+*different* connectivity for the same `(prob, seed, shape)` by making the
+difference explicit: a required `matrix_mode` keyword and `mat.mv` / `mat.mm`
+materialization views. `0.2.1` removes the difference instead. Every JITC entry
+point — scalar, normal and uniform, float and binary, dense, CSR and `dt2t` —
+now draws the 32-lane mv matrix on every backend, so `matrix_mode` and the two
+views are gone and `todense()` / `tocsr()` / `tocsc()` / `tocoo()` are
+unambiguous again. Signatures return to their `0.1.2` shape (#190).
+
+*Compatibility.* The Daily CI matrix now pins `0.10.0` alongside `0.8.0` and
+`0.9.0`, and the operator test that broke on pinned JAX ≤ 0.9 has been made
+independent of JAX's traceback-filtering behaviour.
+
+**Requirements:** unchanged from `0.2.0` — Python ≥ 3.11, `jax` ≥ 0.8.0
+(validated through 0.11.x), `brainunit` ≥ 0.0.8, `numpy` ≥ 2.0.
+
+### ⚠️ Breaking changes & migration
+
+`0.2.0` shipped the mv/mm split to PyPI, so the removal below is a breaking
+change for code written against that release. Code written against `0.1.2` or
+earlier needs no changes.
+
+| `0.2.0` usage | `0.2.1` usage |
+| --- | --- |
+| `jits(w, prob, seed, shape=..., matrix_mode='mv')`, and likewise `jitn` / `jitu` | drop the keyword: `jits(w, prob, seed, shape=...)` |
+| `jitsmm(..., matrix_mode='mm')`, `jitnmm`, `jitumm`, `binary_jitsmm`, `binary_jitnmm`, `binary_jitumm` | drop the keyword |
+| `mat.mv.todense()` / `mat.mm.todense()` (and `.tocsr()`, `.tocsc()`, `.tocoo()`) | `mat.todense()` / `mat.tocsr()` / `mat.tocsc()` / `mat.tocoo()` |
+| `from brainevent._typing import MatrixMode` | removed; there is no mode to annotate |
+
+**Matrix-matrix JITC results recorded with `0.2.0` change.** The mm kernels
+drew a 4-lane residue-class matrix; they now draw the 32-lane mv matrix, so
+`jitsmm` / `jitnmm` / `jitumm` and their `binary_*` counterparts return
+different — not merely reordered — values for the same `(weight, prob, seed,
+shape, corder)`. Matrix-vector results are bit-identical to `0.2.0`. Re-record
+any golden outputs captured from an mm path; as in `0.2.0`, seeds are not
+portable across the change.
+
+The upside is the invariant that motivated the work: for a given `(weight,
+prob, seed, shape, corder)`, `jits`, `jitsmv`, `jitsmm`, `binary_jitsmv`,
+`binary_jitsmm`, `jits_to_csr` and `jitsmv_dt2t` — and the `jitn` / `jitu`
+equivalents — now materialize one matrix, identically on `numba` and
+`cuda_raw`. A model that moves between the matrix-vector and matrix-matrix
+paths, or between CPU and GPU, keeps its connectivity.
+
+### Changed
+
+- **JITC connectivity is mode-free.** `matrix_mode` is removed from every public
+  and internal JITC entry point, and the mm generation path is folded onto the
+  mv walk (`_LANE_STRIDE` = 32) in both the `numba` kernels and the CUDA
+  sources (#190).
+- **`todense()` / `tocsr()` / `tocsc()` / `tocoo()` work directly** on
+  `JITCScalarR`/`C`, `JITCNormalR`/`C` and `JITCUniformR`/`C` again. In `0.2.0`
+  they raised `NotImplementedError` and directed callers to `mat.mv` / `mat.mm`.
+- **Daily CI covers every supported JAX minor.** The `jax-version` matrix is
+  `[ "0.8.0", "0.9.0", "0.10.0", "" ]`; the empty entry continues to track the
+  newest release.
+
+### Fixed
+
+- **Daily CI Tests failed on the pinned-JAX legs.**
+  `test_f17_kernel_generator_failure_is_wrapped_with_alternatives` asserted that
+  the kernel-generator exception was the *direct* `__cause__` of the raised
+  `KernelCompilationError`. `jax._src.traceback_util.api_boundary` splices a
+  synthetic frame (`UnfilteredStackTrace` on JAX 0.10,
+  `JaxStackTraceBeforeTransformation` on 0.8/0.9) into the cause chain,
+  demoting the real cause by one level; whether it does so depends on the
+  default `jax_traceback_filtering` mode, which differs across JAX minors. The
+  assertion now walks the whole chain, so it holds regardless of how many frames
+  JAX inserts. Library behaviour was correct throughout — only the test was
+  over-specific.
+
+### Removed
+
+- `matrix_mode` keyword, the `mat.mv` / `mat.mm` materialization views, the
+  `MatrixMode` type alias, and the `NotImplementedError` guards that the split
+  required (#190).
+- The mm-specific CUDA generation kernels and their `numba` counterparts: the
+  JITC `.cu` sources shed 3,439 lines against 468 added, since one drawn matrix
+  needs one walk.
+
+### Documentation
+
+- **API reference re-synchronized with `brainevent.__all__`.** 41 stale
+  `autosummary` entries were removed — symbols retired in `0.2.0`
+  (`csr_solve`, `IndexedBinary1d` / `IndexedBinary2d`,
+  `IndexedEventRepresentation`, `indexed_binary_dense*`, `binary_array_index`,
+  `BenchmarkReport`, `register_cuda_kernels`) and 30 `lfsr*` / `get_numba_*`
+  helpers that live in a private module and never resolved. 44 public exports
+  gained a reference page, among them `BitPackedBinary`, `CompactBinary`,
+  `bitpack`, `Dense`, `binary_csrm{v,m}_indexed`, the CSC and fixed-connectivity
+  plasticity operators, the `CompilerBackend` hierarchy, the primitive-registry
+  accessors and the hybrid-CSR scheduling knobs.
+- **Exception hierarchy documented in one place.** `BrainEventError` and its
+  nineteen subclasses now appear in `errors.rst`, grouped by subtree and
+  preceded by the inheritance tree; `operator.rst` cross-references it instead
+  of documenting four of them separately.
+- **Two broken snippets fixed.** The quickstart and the E/I-network how-to
+  constructed `JITCScalarR` and `FixedPostNumConn` from `num_pre=` / `num_post=`
+  / `conn_num=` / `weight=` / `seed=` keywords that these constructors have not
+  accepted since at least `0.1.2`, so both raised `TypeError` as written; the
+  quickstart also built a `CSR` from undefined names. Both are rewritten against
+  the real constructors and were executed end to end.
+- **Deprecated aliases replaced throughout the prose docs and tutorials.**
+  `FixedPreNumConn` → `FixedNumPerPost` and `FixedPostNumConn` →
+  `FixedNumPerPre` (the mapping is crossed) across the explanation pages,
+  how-to guides and the two data-structure notebooks; the removed
+  `IndexedBinary1d` / `IndexedBinary2d` give way to `BitPackedBinary` /
+  `CompactBinary`.
+- `docs/specs/release-0.2.1.md` records the CI root cause and the reference audit.
+
+### Internal
+
+- `brainevent/__init___test.py` guards the reference against future drift: every
+  `autosummary` entry must resolve on its `currentmodule`, every name in
+  `brainevent.__all__` and `brainevent.config.__all__` must be documented exactly
+  once, and deprecated aliases must stay undocumented.
+- The full suite was re-run against pinned `jax` 0.8.0, 0.9.0 and 0.10.x before
+  release.
+
 ## [0.2.0] - 2026-08-08
 
 A correctness release spanning three layers of the stack.
@@ -817,6 +942,9 @@ replacement. Recommended updates:
 
 ## Version Comparison Links
 
+- [0.2.1](https://github.com/chaobrain/brainevent/compare/v0.2.0...v0.2.1)
+- [0.2.0](https://github.com/chaobrain/brainevent/compare/v0.1.2...v0.2.0)
+- [0.1.2](https://github.com/chaobrain/brainevent/compare/v0.1.1...v0.1.2)
 - [0.1.1](https://github.com/chaobrain/brainevent/compare/v0.1.0...v0.1.1)
 - [0.1.0](https://github.com/chaobrain/brainevent/compare/v0.0.7...v0.1.0)
 - [0.0.7](https://github.com/chaobrain/brainevent/compare/v0.0.6...v0.0.7)

--- a/docs/explanation/event-driven-computation.rst
+++ b/docs/explanation/event-driven-computation.rst
@@ -24,9 +24,9 @@ Core components
 ---------------
 
 **1. Event representation**
-  :class:`~brainevent.BinaryArray` represents binary spike events. Indexed variants
-  (:class:`~brainevent.IndexedBinary1d`, :class:`~brainevent.IndexedBinary2d`) store only the
-  indices of active events.
+  :class:`~brainevent.BinaryArray` represents binary spike events. Compressed variants
+  (:class:`~brainevent.BitPackedBinary`, :class:`~brainevent.CompactBinary`) store the same
+  events as packed bits, the latter also carrying the compacted active indices.
 
 **2. Sparse data structures**
   Sparse matrix formats optimized for event-driven products:
@@ -42,8 +42,9 @@ Core components
 
 **4. Fixed connectivity patterns**
   Biologically realistic fixed-degree connectivity:
-  :class:`~brainevent.FixedPreNumConn` (fixed number of pre-synaptic connections) and
-  :class:`~brainevent.FixedPostNumConn` (fixed number of post-synaptic connections).
+  :class:`~brainevent.FixedNumPerPost` (fixed number of pre-synaptic connections per
+  post-synaptic neuron) and :class:`~brainevent.FixedNumPerPre` (fixed number of
+  post-synaptic connections per pre-synaptic neuron).
 
 **5. Custom kernel framework**
   An extensible system for high-performance custom operators — Numba (CPU), Numba-CUDA and

--- a/docs/explanation/faq.rst
+++ b/docs/explanation/faq.rst
@@ -37,8 +37,8 @@ Which connectivity format should I use?
 
 - Explicit, reusable sparsity → :class:`~brainevent.CSR` / :class:`~brainevent.CSC`.
 - Large random connectivity → JITC (memory independent of synapse count).
-- Fixed number of connections per neuron → :class:`~brainevent.FixedPreNumConn` /
-  :class:`~brainevent.FixedPostNumConn`.
+- Fixed number of connections per neuron → :class:`~brainevent.FixedNumPerPre` /
+  :class:`~brainevent.FixedNumPerPost`.
 
 See :doc:`/how-to/data-structures/choosing-a-sparse-format` and :doc:`sparse-formats`.
 

--- a/docs/explanation/sparse-formats.rst
+++ b/docs/explanation/sparse-formats.rst
@@ -50,8 +50,8 @@ Fixed-degree structure
 ----------------------
 
 Many biological networks have a **fixed number** of connections per neuron rather than a
-fixed probability. :class:`~brainevent.FixedPreNumConn` and
-:class:`~brainevent.FixedPostNumConn` encode exactly that, which is both more biologically
+fixed probability. :class:`~brainevent.FixedNumPerPre` and
+:class:`~brainevent.FixedNumPerPost` encode exactly that, which is both more biologically
 faithful and more memory-predictable than a probabilistic format when the degree is known.
 
 

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -35,16 +35,20 @@ connectivity structures. The operation is event-driven in every case:
    weights = jnp.ones((5, 3))
    out_dense = spikes @ weights
 
-   # CSR sparse matrix
+   # CSR sparse matrix — one synapse per pre-synaptic neuron
+   data = jnp.arange(1, 6, dtype=jnp.float32)
+   indices = jnp.array([0, 1, 2, 0, 1])
+   indptr = jnp.arange(6)
    csr = brainevent.CSR((data, indices, indptr), shape=(5, 3))
    out_csr = spikes @ csr
 
    # Just-in-time connectivity — never materialises the full matrix
-   jitc = brainevent.JITCScalarR(num_pre=5, num_post=3, prob=0.5, weight=0.2, seed=0)
+   jitc = brainevent.JITCScalarR(0.2, 0.5, 0, shape=(5, 3))   # weight, prob, seed
    out_jitc = spikes @ jitc
 
-   # Fixed fan-out connectivity
-   fixed = brainevent.FixedPostNumConn(num_pre=5, num_post=3, conn_num=2, weight=0.5, seed=0)
+   # Fixed fan-out — two post-synaptic targets per pre-synaptic neuron
+   conn = jnp.array([[0, 1], [1, 2], [0, 2], [1, 0], [2, 1]])
+   fixed = brainevent.FixedNumPerPre(jnp.full((5, 2), 0.5), conn, shape=(5, 3))
    out_fixed = spikes @ fixed
 
 

--- a/docs/how-to/building-extending/build-coba-cuba-network.rst
+++ b/docs/how-to/building-extending/build-coba-cuba-network.rst
@@ -18,16 +18,25 @@ excitatory and inhibitory groups with opposite-sign weights gives a balanced net
 
    import brainevent
    import brainunit as u
+   import jax
    import jax.numpy as jnp
 
    n_exc, n_inh = 3200, 800
    num = n_exc + n_inh
+   conn_num = 80   # post-synaptic targets per pre-synaptic neuron
 
    # Fixed fan-out connectivity, excitatory (+) and inhibitory (-)
-   exc_conn = brainevent.FixedPostNumConn(num_pre=n_exc, num_post=num,
-                                          conn_num=80, weight=0.6 * u.mS, seed=1)
-   inh_conn = brainevent.FixedPostNumConn(num_pre=n_inh, num_post=num,
-                                          conn_num=80, weight=-6.7 * u.mS, seed=2)
+   key_e, key_i = jax.random.split(jax.random.key(0))
+   exc_conn = brainevent.FixedNumPerPre(
+       jnp.full((n_exc, conn_num), 0.6) * u.mS,
+       jax.random.randint(key_e, (n_exc, conn_num), 0, num),
+       shape=(n_exc, num),
+   )
+   inh_conn = brainevent.FixedNumPerPre(
+       jnp.full((n_inh, conn_num), -6.7) * u.mS,
+       jax.random.randint(key_i, (n_inh, conn_num), 0, num),
+       shape=(n_inh, num),
+   )
 
    def synaptic_input(spikes):
        spk = brainevent.BinaryArray(spikes)
@@ -36,8 +45,9 @@ excitatory and inhibitory groups with opposite-sign weights gives a balanced net
 
 Because the spike vector is a :class:`~brainevent.BinaryArray`, only neurons that fired this
 step contribute work — the cost scales with the spike count, not the network size. Swap
-``FixedPostNumConn`` for a :class:`~brainevent.JITCScalarR` to scale to networks too large to
-store explicitly (see :doc:`/how-to/data-structures/jit-connectivity-large-networks`).
+:class:`~brainevent.FixedNumPerPre` for a :class:`~brainevent.JITCScalarR` to scale to
+networks too large to store explicitly (see
+:doc:`/how-to/data-structures/jit-connectivity-large-networks`).
 
 
 Full models (COBA & CUBA)

--- a/docs/how-to/data-structures/choosing-a-sparse-format.rst
+++ b/docs/how-to/data-structures/choosing-a-sparse-format.rst
@@ -28,8 +28,8 @@ Decision guide
      - Connectivity is random with a fixed probability, and you want to **never materialise**
        the matrix — it is regenerated on the fly from a seed.
      - You need to inspect, mutate, or learn individual weights.
-   * - **Fixed fan-in/out** (:class:`~brainevent.FixedPreNumConn`,
-       :class:`~brainevent.FixedPostNumConn`)
+   * - **Fixed fan-in/out** (:class:`~brainevent.FixedNumPerPre`,
+       :class:`~brainevent.FixedNumPerPost`)
      - Each neuron has a fixed *number* of connections (biologically common), and you want
        that structure encoded directly.
      - Connection counts vary per neuron, or you need an explicit weight matrix.
@@ -41,7 +41,7 @@ Rule of thumb
 - **Explicit and reusable** → ``CSR``/``CSC``.
 - **Random and huge** → ``JITC*`` (memory cost is independent of density; see
   :doc:`jit-connectivity-large-networks`).
-- **Fixed degree per neuron** → ``FixedPreNumConn`` / ``FixedPostNumConn``.
+- **Fixed degree per neuron** → ``FixedNumPerPre`` / ``FixedNumPerPost``.
 
 Every format multiplies the same way against a :class:`~brainevent.BinaryArray`, so you can
 swap formats without changing the surrounding code:

--- a/docs/reference/apis/config.rst
+++ b/docs/reference/apis/config.rst
@@ -36,3 +36,14 @@ Global Backend Selection
    set_backend
    get_backend
    clear_backends
+
+
+CUDA Toolchain Controls
+-----------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   set_compute_capability
+   get_compute_capability
+   prefer_system_nvcc

--- a/docs/reference/apis/errors.rst
+++ b/docs/reference/apis/errors.rst
@@ -5,14 +5,95 @@ Error Classes
 .. automodule:: brainevent
    :no-index:
 
+Every exception raised by ``brainevent`` derives from :class:`BrainEventError`,
+so a single ``except brainevent.BrainEventError`` clause catches all of them.
+The hierarchy is::
+
+    BrainEventError
+    ├── MathError
+    ├── UnsupportedOperationError
+    ├── BenchmarkDataFnNotProvidedError
+    └── KernelError
+        ├── KernelNotAvailableError
+        ├── KernelFallbackExhaustedError
+        ├── KernelExecutionError
+        ├── KernelRegistrationError
+        ├── KernelLoadError
+        ├── CUDANotInstalledError
+        ├── KernelCompilationError
+        │   └── CompilationError
+        │       └── HostCompilerIncompatibleError
+        └── KernelToolchainError
+            ├── NvccNotFoundError
+            ├── HeaderNotFoundError
+            ├── HostCompilerNotFoundError
+            ├── GpuArchDetectionError
+            └── UnsupportedArchError
+
+
+Base
+----
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
+   BrainEventError
+   KernelError
+
+
+Array and Operation Errors
+--------------------------
 
 .. autosummary::
    :toctree: generated/
    :template: classtemplate.rst
 
    MathError
+   UnsupportedOperationError
+   BenchmarkDataFnNotProvidedError
+
+
+Kernel Dispatch and Execution Errors
+------------------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
    KernelNotAvailableError
-   KernelCompilationError
    KernelFallbackExhaustedError
    KernelExecutionError
+   KernelRegistrationError
+   KernelLoadError
+
+
+Kernel Compilation Errors
+-------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
+   KernelCompilationError
+   CompilationError
+   HostCompilerIncompatibleError
+
+
+Toolchain Errors
+----------------
+
+Raised when the CUDA / C++ toolchain needed to build a kernel is missing or
+unusable. Each carries a stable ``E-`` diagnostic code in its message.
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
+   KernelToolchainError
    CUDANotInstalledError
+   NvccNotFoundError
+   HeaderNotFoundError
+   HostCompilerNotFoundError
+   GpuArchDetectionError
+   UnsupportedArchError

--- a/docs/reference/apis/events.rst
+++ b/docs/reference/apis/events.rst
@@ -14,7 +14,6 @@ Base
    :template: classtemplate.rst
 
    EventRepresentation
-   IndexedEventRepresentation
 
 
 Binary Events
@@ -25,15 +24,14 @@ Binary Events
    :template: classtemplate.rst
 
    BinaryArray
+   BitPackedBinary
+   CompactBinary
 
 
-Indexed Events
---------------
+Bit Packing
+-----------
 
 .. autosummary::
    :toctree: generated/
-   :template: classtemplate.rst
 
-   IndexedBinary1d
-   IndexedBinary2d
-
+   bitpack

--- a/docs/reference/apis/operations.rst
+++ b/docs/reference/apis/operations.rst
@@ -19,6 +19,16 @@ Binary matrix-vector / matrix-matrix multiplication.
    binary_csrmm
    binary_csrmm_p
 
+Binary multiplication with a fused weight gather (indexed weights).
+
+.. autosummary::
+   :toctree: generated/
+
+   binary_csrmv_indexed
+   binary_csrmv_indexed_p
+   binary_csrmm_indexed
+   binary_csrmm_indexed_p
+
 Float matrix-vector / matrix-matrix multiplication.
 
 .. autosummary::
@@ -44,13 +54,8 @@ Plasticity operations.
    update_csr_on_binary_pre_p
    update_csr_on_binary_post
    update_csr_on_binary_post_p
-
-Sparse linear solver.
-
-.. autosummary::
-   :toctree: generated/
-
-   csr_solve
+   update_csc_on_binary_pre
+   update_csc_on_binary_post
 
 Row slicing.
 
@@ -73,16 +78,6 @@ Dense-matrix @ binary-vector / binary-matrix.
    binary_densemv_p
    binary_densemm
    binary_densemm_p
-
-Indexed binary operations.
-
-.. autosummary::
-   :toctree: generated/
-
-   indexed_binary_densemv
-   indexed_binary_densemv_p
-   indexed_binary_densemm
-   indexed_binary_densemm_p
 
 Plasticity operations.
 
@@ -198,3 +193,12 @@ Float matrix-vector / matrix-matrix multiplication.
    fcnmm
    fcnmv_dt2t
    fcnmm_dt2t
+
+Plasticity operations.
+
+.. autosummary::
+   :toctree: generated/
+
+   update_fixed_pre_conn_on_binary_post
+   update_fixed_post_conn_on_binary_pre
+   fcn_plasticity_row_p

--- a/docs/reference/apis/operator.rst
+++ b/docs/reference/apis/operator.rst
@@ -18,7 +18,7 @@ Custom Kernel
 
 
 CPU Kernel via Numba
--------------------
+--------------------
 
 .. autosummary::
    :toctree: generated/
@@ -46,6 +46,7 @@ GPU Kernel via CUDA Source
    load_cuda_file
    load_cuda_dir
 
+
 CPU Kernel via C++ Source
 -------------------------
 
@@ -54,6 +55,20 @@ CPU Kernel via C++ Source
 
    load_cpp_inline
    load_cpp_file
+   normalize_tokens
+
+
+Compiler Backends
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
+   CompilerBackend
+   CPPBackend
+   CUDABackend
+   HIPBackend
 
 
 Runtime
@@ -70,6 +85,17 @@ Runtime
 
    register_ffi_target
    list_registered_targets
+
+
+Primitive Registry
+------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   get_registry
+   get_all_primitive_names
+   get_primitives_by_tags
 
 
 Cache Utilities
@@ -95,11 +121,5 @@ Diagnostics
 Exceptions
 ----------
 
-.. autosummary::
-   :toctree: generated/
-   :template: classtemplate.rst
-
-   BrainEventError
-   CompilationError
-   KernelToolchainError
-   KernelRegistrationError
+Kernel construction, compilation and dispatch raise the exceptions documented in
+:doc:`errors`.

--- a/docs/reference/apis/sparsedata.rst
+++ b/docs/reference/apis/sparsedata.rst
@@ -15,6 +15,7 @@ Data Representation
    :template: classtemplate.rst
 
    DataRepresentation
+   Dense
 
 
 CSR / CSC (Compressed Sparse Row / Column)
@@ -38,6 +39,7 @@ JITC Base
    :template: classtemplate.rst
 
    JITCMatrix
+   JITCScalarMatrix
 
 
 JITC Scalar
@@ -85,5 +87,5 @@ Fixed Connectivity
    :template: classtemplate.rst
 
    FixedNumConn
-   FixedPreNumConn
-   FixedPostNumConn
+   FixedNumPerPre
+   FixedNumPerPost

--- a/docs/reference/apis/utilities.rst
+++ b/docs/reference/apis/utilities.rst
@@ -13,10 +13,10 @@ Index Conversion
    :toctree: generated/
 
    csr_to_coo_index
-   coo_to_csc_index
    csr_to_csc_index
+   csc_to_csr_index
+   coo_to_csc_index
    coo2csr
-   binary_array_index
 
 
 GPU/TPU Random Number Generator
@@ -37,69 +37,23 @@ GPU/TPU Random Number Generator
    get_pallas_lfsr_rng_class
 
 
-Numba RNG LFSR88
-----------------
+Hybrid CSR Scheduling
+---------------------
+
+Tuning knobs for the hybrid CSR kernels, which pick a per-row execution tier
+from the connectivity statistics.
+
+.. autosummary::
+   :toctree: generated/
+   :template: classtemplate.rst
+
+   HybridConfig
 
 .. autosummary::
    :toctree: generated/
 
-   lfsr88_seed
-   lfsr88_next_key
-   lfsr88_rand
-   lfsr88_randint
-   lfsr88_randn
-   lfsr88_uniform
-   lfsr88_normal
-   lfsr88_random_integers
-
-
-Numba RNG LFSR113
------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   lfsr113_seed
-   lfsr113_next_key
-   lfsr113_rand
-   lfsr113_randint
-   lfsr113_randn
-   lfsr113_uniform
-   lfsr113_normal
-   lfsr113_random_integers
-
-
-Numba RNG LFSR128
------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   lfsr128_seed
-   lfsr128_next_key
-   lfsr128_rand
-   lfsr128_randint
-   lfsr128_randn
-   lfsr128_uniform
-   lfsr128_normal
-   lfsr128_random_integers
-
-
-Numba RNG Dispatch
-------------------
-
-Used internally by JIT kernel generators to resolve the correct
-LFSR functions at kernel-generation time.
-
-.. autosummary::
-   :toctree: generated/
-
-   get_numba_lfsr_seed
-   get_numba_lfsr_random_integers
-   get_numba_lfsr_uniform
-   get_numba_lfsr_normal
-   get_numba_lfsr_funcs
-   get_numba_light_rng_funcs
+   get_hybrid_config
+   init_csr_config
 
 
 Benchmarking
@@ -109,8 +63,9 @@ Benchmarking
    :toctree: generated/
    :template: classtemplate.rst
 
+   BenchmarkConfig
+   BenchmarkRecord
    BenchmarkResult
-   BenchmarkReport
 
 .. autosummary::
    :toctree: generated/
@@ -124,7 +79,6 @@ Kernel Helpers
 .. autosummary::
    :toctree: generated/
 
-   register_cuda_kernels
    defjvp
    general_batching_rule
    jaxtype_to_warptype

--- a/docs/specs/release-0.2.1.md
+++ b/docs/specs/release-0.2.1.md
@@ -1,0 +1,151 @@
+# Release 0.2.1 — Daily CI repair, API reference refresh
+
+Status: implemented
+Branch: `worktree-release-0.2.1`
+
+## 1. Motivation
+
+Three independent problems were bundled into the 0.2.1 patch release:
+
+1. **Daily CI Tests failed** on the pinned-JAX matrix legs (runs `31234230842`,
+   `31290069801`) while the unpinned leg passed.
+2. **The Daily CI matrix did not cover JAX 0.10.x**, the newest supported minor,
+   so the release matrix silently under-tested the version most users install.
+3. **`docs/reference/apis/` had drifted** from the public API. Symbols removed in
+   0.2.0 were still documented, and 44 public exports had no reference page.
+
+## 2. Daily CI failure — root cause
+
+Failing test: `brainevent/_op/main_test.py::test_f17_kernel_generator_failure_is_wrapped_with_alternatives`.
+
+The test asserted that a kernel-generator exception is preserved as the direct
+`__cause__` of the raised `KernelCompilationError`:
+
+```python
+assert isinstance(excinfo.value.__cause__, RuntimeError)
+```
+
+JAX's `jax._src.traceback_util.api_boundary` rewrites the cause chain of any
+exception that crosses an API boundary:
+
+```python
+jax_error.__cause__ = e.__cause__      # original cause is pushed one level down
+e.__cause__ = jax_error                # synthetic frame becomes the direct cause
+```
+
+The synthetic frame is `UnfilteredStackTrace` (JAX 0.10) or
+`JaxStackTraceBeforeTransformation` (JAX 0.8/0.9). Whether it is inserted depends
+on the active `jax_traceback_filtering` mode, whose default differs across JAX
+minors — hence the failure on pinned 0.8.0/0.9.0 and the pass on the unpinned leg.
+
+The library behaviour was correct throughout; only the assertion was too strict.
+
+### Fix
+
+Landed in `a66dcee`: assert against the whole `__cause__` chain rather than the
+first link.
+
+```python
+def _exception_chain_contains(exc, expected_type, expected_text: str) -> bool:
+    while exc is not None:
+        if isinstance(exc, expected_type) and expected_text in str(exc):
+            return True
+        exc = getattr(exc, '__cause__', None)
+    return False
+```
+
+This is invariant to how many synthetic frames JAX splices in, so it holds for
+every supported JAX version.
+
+### Verification
+
+Clean virtualenvs pinned to each matrix version, full suite (`pytest brainevent/ -m ""`):
+
+| JAX | Result |
+| --- | --- |
+| 0.8.0 | pass |
+| 0.9.0 | pass |
+| 0.10.2 (unpinned) | pass |
+
+## 3. Daily CI matrix
+
+`jax-version` extended from `[ "0.8.0", "0.9.0", "" ]` to
+`[ "0.8.0", "0.9.0", "0.10.0", "" ]`, so every supported minor is pinned
+explicitly and the empty entry continues to track the newest release.
+
+## 4. API reference refresh
+
+`docs/reference/apis/*.rst` was audited by comparing every `autosummary` entry
+against `brainevent.__all__` and `brainevent.config.__all__`.
+
+### 4.1 Stale entries removed (41)
+
+| File | Removed |
+| --- | --- |
+| `events.rst` | `IndexedEventRepresentation`, `IndexedBinary1d`, `IndexedBinary2d` |
+| `operations.rst` | `csr_solve`, `indexed_binary_densemv{,_p}`, `indexed_binary_densemm{,_p}` |
+| `utilities.rst` | `binary_array_index`, `BenchmarkReport`, `register_cuda_kernels`, and the 24 `lfsr88_*` / `lfsr113_*` / `lfsr128_*` plus 6 `get_numba_*` entries |
+
+The `lfsr*` and `get_numba_*` helpers live in the private `brainevent._numba_random`
+module and are not re-exported, so `currentmodule:: brainevent` could never resolve
+them; they are kernel-generation internals and are intentionally not part of the
+public reference.
+
+### 4.2 Public exports added (44)
+
+| File | Added |
+| --- | --- |
+| `events.rst` | `BitPackedBinary`, `CompactBinary`, `bitpack` |
+| `sparsedata.rst` | `Dense`, `JITCScalarMatrix`, `FixedNumPerPre`, `FixedNumPerPost` |
+| `operations.rst` | `binary_csrmv_indexed{,_p}`, `binary_csrmm_indexed{,_p}`, `update_csc_on_binary_pre`, `update_csc_on_binary_post`, `fcn_plasticity_row_p`, `update_fixed_pre_conn_on_binary_post`, `update_fixed_post_conn_on_binary_pre` |
+| `operator.rst` | `CompilerBackend`, `CPPBackend`, `CUDABackend`, `HIPBackend`, `normalize_tokens`, `get_registry`, `get_all_primitive_names`, `get_primitives_by_tags` |
+| `utilities.rst` | `csc_to_csr_index`, `BenchmarkConfig`, `BenchmarkRecord`, `HybridConfig`, `get_hybrid_config`, `init_csr_config` |
+| `errors.rst` | `KernelError`, `KernelLoadError`, `KernelRegistrationError`, `KernelToolchainError`, `NvccNotFoundError`, `HeaderNotFoundError`, `HostCompilerNotFoundError`, `HostCompilerIncompatibleError`, `GpuArchDetectionError`, `UnsupportedArchError`, `CompilationError`, `BrainEventError`, `UnsupportedOperationError`, `BenchmarkDataFnNotProvidedError` |
+| `config.rst` | `get_compute_capability`, `set_compute_capability`, `prefer_system_nvcc` |
+
+### 4.3 Structural changes
+
+- **Exceptions consolidated.** `operator.rst` previously documented four exception
+  classes while `errors.rst` documented six others, leaving ten undocumented.
+  All twenty now live in `errors.rst`, grouped by subtree and preceded by the
+  inheritance tree; `operator.rst` cross-references it.
+- **Deprecated aliases dropped.** `FixedPreNumConn` / `FixedPostNumConn` emit a
+  `DeprecationWarning` on attribute access; the reference now documents the
+  replacements `FixedNumPerPre` / `FixedNumPerPost`.
+
+### 4.4 Prose pages
+
+The narrative docs cited the same retired symbols, and two of their snippets no
+longer ran at all:
+
+| Page | Problem | Fix |
+| --- | --- | --- |
+| `getting-started/quickstart.rst` | `JITCScalarR(num_pre=…, num_post=…, prob=…, weight=…, seed=…)` and `FixedPostNumConn(num_pre=…, conn_num=…, weight=…, seed=…)` — neither signature exists; both raise `TypeError`. `csr` was built from undefined `data` / `indices` / `indptr`. | rewritten against the real constructors and executed end to end |
+| `how-to/building-extending/build-coba-cuba-network.rst` | same non-existent `FixedPostNumConn` signature | rewritten with explicit `(data, indices)` and unit-carrying weights; executed end to end |
+| `explanation/event-driven-computation.rst` | cites `IndexedBinary1d` / `IndexedBinary2d` (removed) | replaced by `BitPackedBinary` / `CompactBinary` |
+| `explanation/faq.rst`, `explanation/sparse-formats.rst`, `how-to/data-structures/choosing-a-sparse-format.rst` | deprecated `Fixed*NumConn` aliases | `FixedNumPerPre` / `FixedNumPerPost` |
+| `tutorials/data-structures/03_jit_connectivity.ipynb`, `04_fixed_connections.ipynb` | 43 uses of the deprecated aliases across prose, code and recorded output | renamed; notebook JSON re-validated |
+
+The alias mapping is crossed, so the rename is not a search-and-replace of the
+obvious pairs: `FixedPostNumConn` → `FixedNumPerPre` (a fixed number of *post*
+-synaptic connections per pre-synaptic neuron) and `FixedPreNumConn` →
+`FixedNumPerPost`. Both directions were taken from `brainevent/_deprecation.py`
+rather than inferred from the names.
+
+### 4.5 Regression guard
+
+`docs/reference/apis/api_coverage_test.py` re-runs the audit as a test: every
+`autosummary` entry must resolve on its `currentmodule`, and every name in
+`brainevent.__all__` must appear in exactly one reference page. Deprecated
+aliases and the `config` submodule handle are the only allowed exemptions.
+
+## 5. Edge cases and test coverage
+
+| Edge case | Handling |
+| --- | --- |
+| JAX splices 0, 1 or N synthetic frames into `__cause__` | chain walk terminates on `None`; type + message both checked |
+| Cause chain cycles | not reachable — Python forbids self-referential `__cause__` assignment loops in this path; the chain is built strictly downward by `api_boundary` |
+| A new public export added without a doc entry | `api_coverage_test.py` fails |
+| A doc entry outliving its symbol | `api_coverage_test.py` fails |
+| Deprecated alias re-added to a reference page | allowed-exemption list is explicit, so it must be edited deliberately |
+| `brainevent.config` documented under its own `currentmodule` | test resolves `config.rst` entries against `brainevent.config` |

--- a/docs/tutorials/data-structures/03_jit_connectivity.ipynb
+++ b/docs/tutorials/data-structures/03_jit_connectivity.ipynb
@@ -538,7 +538,7 @@
     "## Next Steps\n",
     "\n",
     "In the next tutorial, we will learn:\n",
-    "- 📚 **Tutorial 4**: Fixed connection count structures - FixedPreNumConn, FixedPostNumConn\n",
+    "- 📚 **Tutorial 4**: Fixed connection count structures - FixedNumPerPost, FixedNumPerPre\n",
     "- Learn how to create networks where each neuron has a fixed number of connections\n",
     "- Suitable for biologically realistic network topologies"
    ]

--- a/docs/tutorials/data-structures/04_fixed_connections.ipynb
+++ b/docs/tutorials/data-structures/04_fixed_connections.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Tutorial 4: Fixed Connection Count Structures - Biologically Realistic Network Topology\n\nIn biological neural networks, each neuron typically has a **fixed number of synaptic connections**. For example:\n- Cortical pyramidal neurons: approximately 10,000 dendritic spines (receiving connections)\n- Cerebellar Purkinje cells: approximately 200,000 dendritic spines\n- The number of output connections per neuron is also relatively fixed\n\nBrainEvent provides two fixed connection count structures to simulate these biological characteristics:\n- **FixedPostNumConn**: Each **presynaptic** neuron has a fixed number of output connections\n- **FixedPreNumConn**: Each **postsynaptic** neuron has a fixed number of input connections\n\n## Contents\n1. Biological significance of fixed connection counts\n2. FixedPostNumConn - Fixed output connections\n3. FixedPreNumConn - Fixed input connections\n4. Creation and usage\n5. Using with BinaryArray\n6. Practice: Biologically realistic cortical network\n7. Performance and memory analysis"
+   "source": "# Tutorial 4: Fixed Connection Count Structures - Biologically Realistic Network Topology\n\nIn biological neural networks, each neuron typically has a **fixed number of synaptic connections**. For example:\n- Cortical pyramidal neurons: approximately 10,000 dendritic spines (receiving connections)\n- Cerebellar Purkinje cells: approximately 200,000 dendritic spines\n- The number of output connections per neuron is also relatively fixed\n\nBrainEvent provides two fixed connection count structures to simulate these biological characteristics:\n- **FixedNumPerPre**: Each **presynaptic** neuron has a fixed number of output connections\n- **FixedNumPerPost**: Each **postsynaptic** neuron has a fixed number of input connections\n\n## Contents\n1. Biological significance of fixed connection counts\n2. FixedNumPerPre - Fixed output connections\n3. FixedNumPerPost - Fixed input connections\n4. Creation and usage\n5. Using with BinaryArray\n6. Practice: Biologically realistic cortical network\n7. Performance and memory analysis"
   },
   {
    "cell_type": "markdown",
@@ -24,8 +24,8 @@
     "|---------|---------|----------|\n",
     "| **CSR / CSC** | Arbitrary sparse connections | General sparse matrices |\n",
     "| **JIT connections** | Random probability connections | Ultra-large-scale networks |\n",
-    "| **FixedPostNumConn** | Fixed number of outputs per presynaptic neuron | Biologically realistic models |\n",
-    "| **FixedPreNumConn** | Fixed number of inputs per postsynaptic neuron | Specific topologies |\n",
+    "| **FixedNumPerPre** | Fixed number of outputs per presynaptic neuron | Biologically realistic models |\n",
+    "| **FixedNumPerPost** | Fixed number of inputs per postsynaptic neuron | Specific topologies |\n",
     "\n",
     "### Core advantages\n",
     "- ✅ **Biologically realistic**: Matches real neural network characteristics\n",
@@ -66,7 +66,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 2. FixedPostNumConn - Fixed output connection count\n\n**FixedPostNumConn** represents that each **presynaptic neuron** sends out a fixed number of output connections.\n\n### Data structure\n```python\ndata:    [num_pre, num_conn]  # weight matrix\nindices: [num_pre, num_conn]  # which postsynaptic neurons each presynaptic neuron connects to\n```\n\n### Creation method"
+   "source": "## 2. FixedNumPerPre - Fixed output connection count\n\n**FixedNumPerPre** represents that each **presynaptic neuron** sends out a fixed number of output connections.\n\n### Data structure\n```python\ndata:    [num_pre, num_conn]  # weight matrix\nindices: [num_pre, num_conn]  # which postsynaptic neurons each presynaptic neuron connects to\n```\n\n### Creation method"
   },
   {
    "cell_type": "code",
@@ -76,13 +76,13 @@
      "start_time": "2025-10-21T09:06:55.763631Z"
     }
    },
-   "source": "# Example: 100 presynaptic neurons -> 50 postsynaptic neurons\n# Each presynaptic neuron connects to 10 postsynaptic neurons\n\nn_pre = 100\nn_post = 50\nnum_conn_per_pre = 10  # Number of output connections per presynaptic neuron\n\n# Randomly generate connection indices and weights\nbrainstate.random.seed(42)\n\n# Randomly select 10 postsynaptic neurons for each presynaptic neuron\nindices = brainstate.random.randint(0, n_post, size=(n_pre, num_conn_per_pre))\n\n# Generate random weights\nweights = brainstate.random.normal(size=(n_pre, num_conn_per_pre)) * 0.1\n\n# Create FixedPostNumConn structure\nfixed_post = brainevent.FixedPostNumConn(\n    (weights, indices),\n    shape=(n_pre, n_post)\n)\n\nprint(\"FixedPostNumConn information:\")\nprint(f\"  shape: {fixed_post.shape}\")\nprint(f\"  weight array shape: {fixed_post.data.shape}\")\nprint(f\"  indices array shape: {fixed_post.indices.shape}\")\nprint(f\"  total connections: {n_pre * num_conn_per_pre}\")\nprint(f\"\\nExample connections:\")\nprint(f\"  neuron 0 connects to: {indices[0]}\")\nprint(f\"  corresponding weights: {weights[0]}\")",
+   "source": "# Example: 100 presynaptic neurons -> 50 postsynaptic neurons\n# Each presynaptic neuron connects to 10 postsynaptic neurons\n\nn_pre = 100\nn_post = 50\nnum_conn_per_pre = 10  # Number of output connections per presynaptic neuron\n\n# Randomly generate connection indices and weights\nbrainstate.random.seed(42)\n\n# Randomly select 10 postsynaptic neurons for each presynaptic neuron\nindices = brainstate.random.randint(0, n_post, size=(n_pre, num_conn_per_pre))\n\n# Generate random weights\nweights = brainstate.random.normal(size=(n_pre, num_conn_per_pre)) * 0.1\n\n# Create FixedNumPerPre structure\nfixed_post = brainevent.FixedNumPerPre(\n    (weights, indices),\n    shape=(n_pre, n_post)\n)\n\nprint(\"FixedNumPerPre information:\")\nprint(f\"  shape: {fixed_post.shape}\")\nprint(f\"  weight array shape: {fixed_post.data.shape}\")\nprint(f\"  indices array shape: {fixed_post.indices.shape}\")\nprint(f\"  total connections: {n_pre * num_conn_per_pre}\")\nprint(f\"\\nExample connections:\")\nprint(f\"  neuron 0 connects to: {indices[0]}\")\nprint(f\"  corresponding weights: {weights[0]}\")",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FixedPostNumConn information:\n",
+      "FixedNumPerPre information:\n",
       "  shape: (100, 50)\n",
       "  weight array shape: (100, 10)\n",
       "  indices array shape: (100, 10)\n",
@@ -140,7 +140,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. FixedPreNumConn - Fixed input connection count\n\n**FixedPreNumConn** represents that each **postsynaptic neuron** receives a fixed number of input connections.\n\n### Data structure\n```python\ndata:    [num_post, num_conn]  # weight matrix\nindices: [num_post, num_conn]  # which presynaptic neurons each postsynaptic neuron receives input from\n```"
+   "source": "## 3. FixedNumPerPost - Fixed input connection count\n\n**FixedNumPerPost** represents that each **postsynaptic neuron** receives a fixed number of input connections.\n\n### Data structure\n```python\ndata:    [num_post, num_conn]  # weight matrix\nindices: [num_post, num_conn]  # which presynaptic neurons each postsynaptic neuron receives input from\n```"
   },
   {
    "cell_type": "code",
@@ -150,13 +150,13 @@
      "start_time": "2025-10-21T09:07:01.812155Z"
     }
    },
-   "source": "# Example: 200 presynaptic neurons -> 100 postsynaptic neurons\n# Each postsynaptic neuron receives 15 input connections\n\nn_pre = 200\nn_post = 100\nnum_conn_per_post = 15  # Number of input connections per postsynaptic neuron\n\nbrainstate.random.seed(123)\n\n# Randomly select 15 presynaptic neurons for each postsynaptic neuron\nindices = brainstate.random.randint(0, n_pre, size=(n_post, num_conn_per_post))\n\n# Generate random weights\nweights = brainstate.random.normal(size=(n_post, num_conn_per_post)) * 0.05\n\n# Create FixedPreNumConn structure\nfixed_pre = brainevent.FixedPreNumConn(\n    (weights, indices),\n    shape=(n_pre, n_post)\n)\n\nprint(\"FixedPreNumConn information:\")\nprint(f\"  shape: {fixed_pre.shape}\")\nprint(f\"  weight array shape: {fixed_pre.data.shape}\")\nprint(f\"  indices array shape: {fixed_pre.indices.shape}\")\nprint(f\"  total connections: {n_post * num_conn_per_post}\")\nprint(f\"\\nExample connections:\")\nprint(f\"  neuron 0 receives from: {indices[0]}\")\nprint(f\"  corresponding weights: {weights[0]}\")",
+   "source": "# Example: 200 presynaptic neurons -> 100 postsynaptic neurons\n# Each postsynaptic neuron receives 15 input connections\n\nn_pre = 200\nn_post = 100\nnum_conn_per_post = 15  # Number of input connections per postsynaptic neuron\n\nbrainstate.random.seed(123)\n\n# Randomly select 15 presynaptic neurons for each postsynaptic neuron\nindices = brainstate.random.randint(0, n_pre, size=(n_post, num_conn_per_post))\n\n# Generate random weights\nweights = brainstate.random.normal(size=(n_post, num_conn_per_post)) * 0.05\n\n# Create FixedNumPerPost structure\nfixed_pre = brainevent.FixedNumPerPost(\n    (weights, indices),\n    shape=(n_pre, n_post)\n)\n\nprint(\"FixedNumPerPost information:\")\nprint(f\"  shape: {fixed_pre.shape}\")\nprint(f\"  weight array shape: {fixed_pre.data.shape}\")\nprint(f\"  indices array shape: {fixed_pre.indices.shape}\")\nprint(f\"  total connections: {n_post * num_conn_per_post}\")\nprint(f\"\\nExample connections:\")\nprint(f\"  neuron 0 receives from: {indices[0]}\")\nprint(f\"  corresponding weights: {weights[0]}\")",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FixedPreNumConn information:\n",
+      "FixedNumPerPost information:\n",
       "  shape: (200, 100)\n",
       "  weight array shape: (100, 15)\n",
       "  indices array shape: (100, 15)\n",
@@ -185,14 +185,14 @@
      "start_time": "2025-10-21T09:07:04.934442Z"
     }
    },
-   "source": "# Using FixedPostNumConn for forward propagation\nprint(\"=\" * 60)\nprint(\"Testing FixedPostNumConn\")\nprint(\"=\" * 60)\n\n# Generate input spikes (must match fixed_post's input dimension: 100)\nbrainstate.random.seed(999)\nspikes_bool = brainstate.random.bernoulli(0.1, size=(100,))  # Using n_pre=100\nspikes = brainevent.BinaryArray(spikes_bool)\n\nprint(f\"\\nInput spikes: {spikes.sum()} / 100 fired\")\n\n# Event-driven matrix multiplication\noutput = spikes @ fixed_post\n\nprint(f\"\\nOutput statistics:\")\nprint(f\"  shape: {output.shape}\")\nprint(f\"  maximum value: {output.max():.4f}\")\nprint(f\"  minimum value: {output.min():.4f}\")\nprint(f\"  average value: {output.mean():.4f}\")\nprint(f\"  non-zero outputs: {jnp.sum(output != 0)}\")",
+   "source": "# Using FixedNumPerPre for forward propagation\nprint(\"=\" * 60)\nprint(\"Testing FixedNumPerPre\")\nprint(\"=\" * 60)\n\n# Generate input spikes (must match fixed_post's input dimension: 100)\nbrainstate.random.seed(999)\nspikes_bool = brainstate.random.bernoulli(0.1, size=(100,))  # Using n_pre=100\nspikes = brainevent.BinaryArray(spikes_bool)\n\nprint(f\"\\nInput spikes: {spikes.sum()} / 100 fired\")\n\n# Event-driven matrix multiplication\noutput = spikes @ fixed_post\n\nprint(f\"\\nOutput statistics:\")\nprint(f\"  shape: {output.shape}\")\nprint(f\"  maximum value: {output.max():.4f}\")\nprint(f\"  minimum value: {output.min():.4f}\")\nprint(f\"  average value: {output.mean():.4f}\")\nprint(f\"  non-zero outputs: {jnp.sum(output != 0)}\")",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "============================================================\n",
-      "Testing FixedPostNumConn\n",
+      "Testing FixedNumPerPre\n",
       "============================================================\n",
       "\n",
       "Input spikes: 8 / 100 fired\n",
@@ -216,14 +216,14 @@
      "start_time": "2025-10-21T09:07:07.141799Z"
     }
    },
-   "source": "# Using FixedPreNumConn for forward propagation\nprint(\"=\" * 60)\nprint(\"Testing FixedPreNumConn\")\nprint(\"=\" * 60)\n\n# Generate input spikes (matching fixed_pre's size)\nbrainstate.random.seed(888)\nspikes_bool = brainstate.random.bernoulli(0.05, size=(200,))\nspikes = brainevent.BinaryArray(spikes_bool)\n\nprint(f\"\\nInput spikes: {spikes.sum()} / 200 fired\")\n\n# Event-driven matrix multiplication\noutput = spikes @ fixed_pre\n\nprint(f\"\\nOutput statistics:\")\nprint(f\"  shape: {output.shape}\")\nprint(f\"  maximum value: {output.max():.4f}\")\nprint(f\"  minimum value: {output.min():.4f}\")\nprint(f\"  average value: {output.mean():.4f}\")\nprint(f\"  non-zero outputs: {jnp.sum(output != 0)}\")",
+   "source": "# Using FixedNumPerPost for forward propagation\nprint(\"=\" * 60)\nprint(\"Testing FixedNumPerPost\")\nprint(\"=\" * 60)\n\n# Generate input spikes (matching fixed_pre's size)\nbrainstate.random.seed(888)\nspikes_bool = brainstate.random.bernoulli(0.05, size=(200,))\nspikes = brainevent.BinaryArray(spikes_bool)\n\nprint(f\"\\nInput spikes: {spikes.sum()} / 200 fired\")\n\n# Event-driven matrix multiplication\noutput = spikes @ fixed_pre\n\nprint(f\"\\nOutput statistics:\")\nprint(f\"  shape: {output.shape}\")\nprint(f\"  maximum value: {output.max():.4f}\")\nprint(f\"  minimum value: {output.min():.4f}\")\nprint(f\"  average value: {output.mean():.4f}\")\nprint(f\"  non-zero outputs: {jnp.sum(output != 0)}\")",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "============================================================\n",
-      "Testing FixedPreNumConn\n",
+      "Testing FixedNumPerPost\n",
       "============================================================\n",
       "\n",
       "Input spikes: 7 / 200 fired\n",
@@ -252,7 +252,7 @@
      "start_time": "2025-10-21T09:07:11.652920Z"
     }
    },
-   "source": "class CorticalNetwork:\n    \"\"\"Cortical network simulation using fixed connection count structures\"\"\"\n\n    def __init__(self,\n                 n_exc=800,      # Number of excitatory neurons (80%)\n                 n_inh=200,      # Number of inhibitory neurons (20%)\n                 exc_fanout=50,  # Output connections per excitatory neuron\n                 inh_fanout=30,  # Output connections per inhibitory neuron\n                 seed=0):\n        \"\"\"\n        Create a biologically realistic cortical network\n\n        References:\n        - Excitatory neurons account for approximately 80% in cortex, inhibitory ~20%\n        - Each pyramidal neuron has approximately thousands of synaptic connections\n        \"\"\"\n        self.n_exc = n_exc\n        self.n_inh = n_inh\n        self.n_total = n_exc + n_inh\n\n        brainstate.random.seed(seed)\n\n        # Excitatory -> Excitatory connections\n        exc_to_exc_idx = brainstate.random.randint(0, n_exc, size=(n_exc, exc_fanout))\n        exc_to_exc_w = brainstate.random.normal(size=(n_exc, exc_fanout)) * 0.05\n        self.w_ee = brainevent.FixedPostNumConn((exc_to_exc_w, exc_to_exc_idx), shape=(n_exc, n_exc))\n\n        # Excitatory -> Inhibitory connections\n        exc_to_inh_idx = brainstate.random.randint(0, n_inh, size=(n_exc, exc_fanout // 2))\n        exc_to_inh_w = brainstate.random.normal(size=(n_exc, exc_fanout // 2)) * 0.08\n        self.w_ei = brainevent.FixedPostNumConn((exc_to_inh_w, exc_to_inh_idx), shape=(n_exc, n_inh))\n\n        # Inhibitory -> Excitatory connections (negative weights)\n        inh_to_exc_idx = brainstate.random.randint(0, n_exc, size=(n_inh, inh_fanout))\n        inh_to_exc_w = -brainstate.random.normal(size=(n_inh, inh_fanout)) * 0.15  # Negative weights\n        self.w_ie = brainevent.FixedPostNumConn((inh_to_exc_w, inh_to_exc_idx), shape=(n_inh, n_exc))\n\n        print(f\"Cortical network structure:\")\n        print(f\"  Total neurons: {self.n_total}\")\n        print(f\"  Excitatory: {n_exc} ({n_exc/self.n_total*100:.0f}%)\")\n        print(f\"  Inhibitory: {n_inh} ({n_inh/self.n_total*100:.0f}%)\")\n        print(f\"\\nConnection statistics:\")\n        print(f\"  E->E: {n_exc * exc_fanout:,} connections\")\n        print(f\"  E->I: {n_exc * exc_fanout // 2:,} connections\")\n        print(f\"  I->E: {n_inh * inh_fanout:,} connections\")\n        print(f\"  Total connections: {n_exc * exc_fanout + n_exc * exc_fanout // 2 + n_inh * inh_fanout:,}\")\n\n    def forward(self, exc_spikes, inh_spikes):\n        \"\"\"Network forward propagation\"\"\"\n        # Input received by excitatory neurons\n        exc_input_from_exc = exc_spikes @ self.w_ee\n        exc_input_from_inh = inh_spikes @ self.w_ie\n        exc_total_input = exc_input_from_exc + exc_input_from_inh\n\n        # Input received by inhibitory neurons\n        inh_input = exc_spikes @ self.w_ei\n\n        return exc_total_input, inh_input\n\n# Create cortical network\ncortical_net = CorticalNetwork(\n    n_exc=800,\n    n_inh=200,\n    exc_fanout=50,\n    inh_fanout=30,\n    seed=2024\n)",
+   "source": "class CorticalNetwork:\n    \"\"\"Cortical network simulation using fixed connection count structures\"\"\"\n\n    def __init__(self,\n                 n_exc=800,      # Number of excitatory neurons (80%)\n                 n_inh=200,      # Number of inhibitory neurons (20%)\n                 exc_fanout=50,  # Output connections per excitatory neuron\n                 inh_fanout=30,  # Output connections per inhibitory neuron\n                 seed=0):\n        \"\"\"\n        Create a biologically realistic cortical network\n\n        References:\n        - Excitatory neurons account for approximately 80% in cortex, inhibitory ~20%\n        - Each pyramidal neuron has approximately thousands of synaptic connections\n        \"\"\"\n        self.n_exc = n_exc\n        self.n_inh = n_inh\n        self.n_total = n_exc + n_inh\n\n        brainstate.random.seed(seed)\n\n        # Excitatory -> Excitatory connections\n        exc_to_exc_idx = brainstate.random.randint(0, n_exc, size=(n_exc, exc_fanout))\n        exc_to_exc_w = brainstate.random.normal(size=(n_exc, exc_fanout)) * 0.05\n        self.w_ee = brainevent.FixedNumPerPre((exc_to_exc_w, exc_to_exc_idx), shape=(n_exc, n_exc))\n\n        # Excitatory -> Inhibitory connections\n        exc_to_inh_idx = brainstate.random.randint(0, n_inh, size=(n_exc, exc_fanout // 2))\n        exc_to_inh_w = brainstate.random.normal(size=(n_exc, exc_fanout // 2)) * 0.08\n        self.w_ei = brainevent.FixedNumPerPre((exc_to_inh_w, exc_to_inh_idx), shape=(n_exc, n_inh))\n\n        # Inhibitory -> Excitatory connections (negative weights)\n        inh_to_exc_idx = brainstate.random.randint(0, n_exc, size=(n_inh, inh_fanout))\n        inh_to_exc_w = -brainstate.random.normal(size=(n_inh, inh_fanout)) * 0.15  # Negative weights\n        self.w_ie = brainevent.FixedNumPerPre((inh_to_exc_w, inh_to_exc_idx), shape=(n_inh, n_exc))\n\n        print(f\"Cortical network structure:\")\n        print(f\"  Total neurons: {self.n_total}\")\n        print(f\"  Excitatory: {n_exc} ({n_exc/self.n_total*100:.0f}%)\")\n        print(f\"  Inhibitory: {n_inh} ({n_inh/self.n_total*100:.0f}%)\")\n        print(f\"\\nConnection statistics:\")\n        print(f\"  E->E: {n_exc * exc_fanout:,} connections\")\n        print(f\"  E->I: {n_exc * exc_fanout // 2:,} connections\")\n        print(f\"  I->E: {n_inh * inh_fanout:,} connections\")\n        print(f\"  Total connections: {n_exc * exc_fanout + n_exc * exc_fanout // 2 + n_inh * inh_fanout:,}\")\n\n    def forward(self, exc_spikes, inh_spikes):\n        \"\"\"Network forward propagation\"\"\"\n        # Input received by excitatory neurons\n        exc_input_from_exc = exc_spikes @ self.w_ee\n        exc_input_from_inh = inh_spikes @ self.w_ie\n        exc_total_input = exc_input_from_exc + exc_input_from_inh\n\n        # Input received by inhibitory neurons\n        inh_input = exc_spikes @ self.w_ei\n\n        return exc_total_input, inh_input\n\n# Create cortical network\ncortical_net = CorticalNetwork(\n    n_exc=800,\n    n_inh=200,\n    exc_fanout=50,\n    inh_fanout=30,\n    seed=2024\n)",
    "outputs": [
     {
      "name": "stdout",
@@ -346,11 +346,11 @@
     "\n",
     "print(f\"Performance test configuration: {n_pre} -> {n_post}, {num_conn} connections per neuron\\n\")\n",
     "\n",
-    "# 1. FixedPostNumConn\n",
+    "# 1. FixedNumPerPre\n",
     "brainstate.random.seed(0)\n",
     "indices_fixed = brainstate.random.randint(0, n_post, size=(n_pre, num_conn))\n",
     "weights_fixed = brainstate.random.normal(size=(n_pre, num_conn)) * 0.1\n",
-    "fixed_conn = brainevent.FixedPostNumConn((weights_fixed, indices_fixed), shape=(n_pre, n_post))\n",
+    "fixed_conn = brainevent.FixedNumPerPre((weights_fixed, indices_fixed), shape=(n_pre, n_post))\n",
     "\n",
     "# 2. CSR, built from coordinate (COO) triplets via coo2csr\n",
     "row_indices = jnp.repeat(jnp.arange(n_pre), num_conn)\n",
@@ -369,7 +369,7 @@
     "csr_memory = csr_conn.data.nbytes + csr_conn.indices.nbytes + csr_conn.indptr.nbytes\n",
     "\n",
     "print(\"Memory usage:\")\n",
-    "print(f\"  FixedPostNumConn: {fixed_memory / 1024 / 1024:.2f} MB\")\n",
+    "print(f\"  FixedNumPerPre: {fixed_memory / 1024 / 1024:.2f} MB\")\n",
     "print(f\"  CSR:              {csr_memory / 1024 / 1024:.2f} MB\")\n",
     "print(f\"  Ratio:            {csr_memory / fixed_memory:.2f}x\\n\")\n",
     "\n",
@@ -379,7 +379,7 @@
     "\n",
     "n_trials = 100\n",
     "\n",
-    "# FixedPostNumConn performance\n",
+    "# FixedNumPerPre performance\n",
     "start = time.time()\n",
     "for _ in range(n_trials):\n",
     "    result_fixed = jax.block_until_ready(spikes @ fixed_conn)\n",
@@ -392,14 +392,14 @@
     "csr_time = (time.time() - start) / n_trials\n",
     "\n",
     "print(\"Computation performance (average time):\")\n",
-    "print(f\"  FixedPostNumConn: {fixed_time*1000:.3f} ms\")\n",
+    "print(f\"  FixedNumPerPre: {fixed_time*1000:.3f} ms\")\n",
     "print(f\"  CSR:              {csr_time*1000:.3f} ms\")\n",
     "\n",
     "# Avoid division by zero error\n",
     "if fixed_time > 0:\n",
     "    print(f\"  Speed ratio:      {csr_time/fixed_time:.2f}x\")\n",
     "else:\n",
-    "    print(f\"  Speed ratio:      FixedPostNumConn is too fast to measure accurately (< {1/n_trials*1000:.3f} ms)\")\n",
+    "    print(f\"  Speed ratio:      FixedNumPerPre is too fast to measure accurately (< {1/n_trials*1000:.3f} ms)\")\n",
     "\n",
     "print(f\"\\nResult consistency: {jnp.allclose(result_fixed, result_csr, atol=1e-5)}\")"
    ],
@@ -412,14 +412,14 @@
    "source": [
     "## 7. Usage recommendations\n",
     "\n",
-    "### FixedPostNumConn vs FixedPreNumConn?\n",
+    "### FixedNumPerPre vs FixedNumPerPost?\n",
     "\n",
-    "**Use FixedPostNumConn when:**\n",
+    "**Use FixedNumPerPre when:**\n",
     "- ✅ Each presynaptic neuron sends out a fixed number of connections\n",
     "- ✅ Row-wise access is needed (standard forward propagation)\n",
     "- ✅ Most spiking neural network applications\n",
     "\n",
-    "**Use FixedPreNumConn when:**\n",
+    "**Use FixedNumPerPost when:**\n",
     "- ✅ Each postsynaptic neuron receives a fixed number of connections\n",
     "- ✅ Column-wise access is needed\n",
     "- ✅ Specific biological constraints (e.g., fixed dendritic spine count)\n",
@@ -428,7 +428,7 @@
     "\n",
     "- **Small-scale, arbitrary connections**: Use **CSR / CSC**\n",
     "- **Ultra-large-scale, random connections**: Use **JIT connections**\n",
-    "- **Biologically realistic, fixed connection counts**: Use **FixedPostNumConn/FixedPreNumConn**\n",
+    "- **Biologically realistic, fixed connection counts**: Use **FixedNumPerPre/FixedNumPerPost**\n",
     "- **Dense connections**: Use **regular arrays**"
    ]
   },
@@ -441,8 +441,8 @@
     "In this tutorial, we learned:\n",
     "\n",
     "1. ✅ **Biological significance**: Fixed connection counts match real neural network characteristics\n",
-    "2. ✅ **FixedPostNumConn**: Fixed output connections per presynaptic neuron\n",
-    "3. ✅ **FixedPreNumConn**: Fixed input connections per postsynaptic neuron\n",
+    "2. ✅ **FixedNumPerPre**: Fixed output connections per presynaptic neuron\n",
+    "3. ✅ **FixedNumPerPost**: Fixed input connections per postsynaptic neuron\n",
     "4. ✅ **Creation and usage**: How to build fixed connection count structures\n",
     "5. ✅ **Using with BinaryArray**: Efficient event-driven computation\n",
     "6. ✅ **Practical application**: Building biologically realistic cortical networks\n",


### PR DESCRIPTION
## Summary

Patch release `0.2.1`, bundling the Daily CI repair, an API-reference refresh, and the changelog for #190.

## 1. Daily CI Tests — fixed and verified

Runs [31234230842](https://github.com/chaobrain/brainevent/actions/runs/31234230842) and [31290069801](https://github.com/chaobrain/brainevent/actions/runs/31290069801) failed on the pinned-JAX legs while the unpinned leg passed. One test was responsible:

```
brainevent/_op/main_test.py::test_f17_kernel_generator_failure_is_wrapped_with_alternatives
```

It asserted the kernel-generator exception was the **direct** `__cause__` of the raised `KernelCompilationError`. `jax._src.traceback_util.api_boundary` rewrites the chain:

```python
jax_error.__cause__ = e.__cause__      # original cause pushed one level down
e.__cause__ = jax_error                # synthetic frame becomes the direct cause
```

The synthetic frame is `UnfilteredStackTrace` on JAX 0.10 and `JaxStackTraceBeforeTransformation` on 0.8/0.9; whether it is inserted depends on the default `jax_traceback_filtering` mode, which differs across JAX minors. Library behaviour was correct throughout — only the assertion was over-specific. The fix (walk the whole chain) landed in a66dcee and is **verified here** in clean venvs:

| JAX | `pytest brainevent/ -m ""` |
| --- | --- |
| 0.8.0 | 3655 passed, 321 skipped |
| 0.9.0 | 3655 passed, 321 skipped |
| 0.10.2 | 3660 passed, 321 skipped (incl. 5 new tests) |

## 2. CI-daily matrix

`jax-version` → `[ "0.8.0", "0.9.0", "0.10.0", "" ]`, so every supported minor is pinned explicitly.

## 3. API reference refresh

Every `autosummary` entry was diffed against `brainevent.__all__` / `brainevent.config.__all__`.

- **41 stale entries removed** — `csr_solve`, `IndexedBinary1d`/`2d`, `IndexedEventRepresentation`, `indexed_binary_dense*`, `binary_array_index`, `BenchmarkReport`, `register_cuda_kernels`, plus 30 `lfsr*` / `get_numba_*` helpers that live in a private module and never resolved under `currentmodule:: brainevent`.
- **44 public exports documented** — `BitPackedBinary`, `CompactBinary`, `bitpack`, `Dense`, `binary_csrm{v,m}_indexed`, the CSC and fixed-connectivity plasticity operators, the `CompilerBackend` hierarchy, the registry accessors, the hybrid-CSR knobs, and the CUDA toolchain config setters.
- **Exceptions consolidated** into `errors.rst` (base + 19 subclasses, grouped by subtree, with the inheritance tree); `operator.rst` cross-references it.
- **Prose docs**: two snippets did not run at all — quickstart and the E/I-network how-to built `JITCScalarR` / `FixedPostNumConn` from `num_pre=` / `num_post=` / `conn_num=` / `weight=` / `seed=` keywords no current constructor accepts (`TypeError`), and quickstart's `CSR` used undefined names. Both rewritten and executed end to end. Deprecated `Fixed*NumConn` aliases replaced across explanation pages, how-to guides and the two data-structure notebooks (43 occurrences; the mapping is crossed — `FixedPostNumConn` → `FixedNumPerPre`).
- **Regression guard**: `brainevent/__init___test.py` fails if an entry outlives its symbol, if a public export goes undocumented, if a symbol is documented twice, or if a deprecated alias reappears.

## 4. Changelog

`0.2.1` documents #190 under **⚠️ Breaking changes & migration**: `v0.2.0` was tagged and published to PyPI on 2026-08-07, so removing `matrix_mode` and the `mat.mv` / `mat.mm` views is user-visible, and JITC matrix-matrix results recorded against `0.2.0` change (mm now draws the 32-lane mv matrix). Matrix-vector results are unchanged.

## Verification

- `pytest brainevent/ -m ""` — 3660 passed, 321 skipped (jax 0.10.2); 3655 passed on pinned 0.8.0 and 0.9.0
- `mypy brainevent/` — `Success: no issues found in 78 source files` under the pinned no-deps gate (mypy 2.3.0)
- `sphinx-build -b html docs` — build succeeded, no new warnings

Spec: `docs/specs/release-0.2.1.md`

## Summary by Sourcery

Prepare patch release 0.2.1 with JIT connectivity API cleanup, CI matrix repair, and refreshed docs.

New Features:
- Introduce regression tests that keep the public API surface and Sphinx autosummary reference pages in sync.

Bug Fixes:
- Fix a JIT operator test so it is robust to JAX traceback filtering differences across supported JAX versions.

Enhancements:
- Unify JIT connectivity behaviour by removing the mv/mm split, restoring direct use of density-conversion methods and simplifying CUDA/numba kernels.

CI:
- Expand the Daily CI JAX version matrix to pin all supported minors, including 0.10.x.

Documentation:
- Update changelog and release spec for version 0.2.1, refresh API reference to match current exports, consolidate and correct exception and fixed-connection structure documentation, and repair broken tutorial/quickstart snippets.

Tests:
- Add coverage tests that enforce one-to-one mapping between public exports and documentation entries and ensure deprecated aliases remain undocumented.

Chores:
- Bump library version to 0.2.1 and add comparison link for the new tag in the changelog.